### PR TITLE
[Fix/#11] Info.plist에 추가된 폰트 이름에 확장자 추가

### DIFF
--- a/Offroad-iOS/Offroad-iOS.xcworkspace/contents.xcworkspacedata
+++ b/Offroad-iOS/Offroad-iOS.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:Offroad-iOS.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/Offroad-iOS/Offroad-iOS.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Offroad-iOS/Offroad-iOS.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Offroad-iOS/Offroad-iOS.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Offroad-iOS/Offroad-iOS.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,77 @@
+{
+  "pins" : [
+    {
+      "identity" : "alamofire",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Alamofire/Alamofire.git",
+      "state" : {
+        "revision" : "f455c2975872ccd2d9c81594c658af65716e9b9a",
+        "version" : "5.9.1"
+      }
+    },
+    {
+      "identity" : "kakao-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kakao/kakao-ios-sdk.git",
+      "state" : {
+        "revision" : "e9e649d3ba823c3673867d3d09010fc77005a940",
+        "version" : "2.22.3"
+      }
+    },
+    {
+      "identity" : "kingfisher",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/onevcat/Kingfisher.git",
+      "state" : {
+        "revision" : "2ef543ee21d63734e1c004ad6c870255e8716c50",
+        "version" : "7.12.0"
+      }
+    },
+    {
+      "identity" : "moya",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Moya/Moya",
+      "state" : {
+        "revision" : "c263811c1f3dbf002be9bd83107f7cdc38992b26",
+        "version" : "15.0.3"
+      }
+    },
+    {
+      "identity" : "reactiveswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ReactiveCocoa/ReactiveSwift.git",
+      "state" : {
+        "revision" : "c43bae3dac73fdd3cb906bd5a1914686ca71ed3c",
+        "version" : "6.7.0"
+      }
+    },
+    {
+      "identity" : "rxswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ReactiveX/RxSwift.git",
+      "state" : {
+        "revision" : "b06a8c8596e4c3e8e7788e08e720e3248563ce6a",
+        "version" : "6.7.1"
+      }
+    },
+    {
+      "identity" : "snapkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SnapKit/SnapKit",
+      "state" : {
+        "revision" : "2842e6e84e82eb9a8dac0100ca90d9444b0307f4",
+        "version" : "5.7.1"
+      }
+    },
+    {
+      "identity" : "then",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/devxoul/Then",
+      "state" : {
+        "revision" : "d41ef523faef0f911369f79c0b96815d9dbb6d7a",
+        "version" : "3.0.0"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Offroad-iOS/Offroad-iOS/Global/Resources/Info.plist
+++ b/Offroad-iOS/Offroad-iOS/Global/Resources/Info.plist
@@ -4,15 +4,15 @@
 <dict>
 	<key>UIAppFonts</key>
 	<array>
-		<string>Pretendard-Black</string>
-		<string>Pretendard-Bold</string>
-		<string>Pretendard-ExtraBold</string>
-		<string>Pretendard-ExtraLight</string>
-		<string>Pretendard-Light</string>
-		<string>Pretendard-Medium</string>
-		<string>Pretendard-Regular</string>
-		<string>Pretendard-Semibold</string>
-		<string>Pretendard-Thin</string>
+		<string>Pretendard-Black.otf</string>
+		<string>Pretendard-Bold.otf</string>
+		<string>Pretendard-ExtraBold.otf</string>
+		<string>Pretendard-ExtraLight.otf</string>
+		<string>Pretendard-Light.otf</string>
+		<string>Pretendard-Medium.otf</string>
+		<string>Pretendard-Regular.otf</string>
+		<string>Pretendard-Semibold.otf</string>
+		<string>Pretendard-Thin.otf</string>
 	</array>
 	<key>UIApplicationSceneManifest</key>
 	<dict>


### PR DESCRIPTION
### 🌴 작업한 브랜치
- #11 


### ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->
FontLitera을 사용하기 위해 lable.font = UIFont.offroad(style: .title) 과 같이 사용할 수 있어야 하는데, 에러가 나는 버그 해결
-> Info.plist에 폰트를 추가할 때, 폰트 확장자까지 추가했어야 하는데, 확장자가 누락되었음. 확장자 추가함으로써 해결
<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


- Resolved: #11 
