### PR TITLE
[Feat] #25 - GenderViewController UI 구현

### DIFF
--- a/Offroad-iOS/Offroad-iOS.xcodeproj/project.pbxproj
+++ b/Offroad-iOS/Offroad-iOS.xcodeproj/project.pbxproj
@@ -46,6 +46,8 @@
 		8792CFFC2C3D8240002051AC /* Secrets.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 8792CFFB2C3D823F002051AC /* Secrets.xcconfig */; };
 		8792CFFE2C3D85BE002051AC /* NicknameViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8792CFFD2C3D85BE002051AC /* NicknameViewController.swift */; };
 		8792D0112C3DA1C9002051AC /* BirthView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8792D0102C3DA1C9002051AC /* BirthView.swift */; };
+		8792D0152C3E581E002051AC /* GenderViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8792D0142C3E581E002051AC /* GenderViewController.swift */; };
+		8792D0172C3E5828002051AC /* GenderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8792D0162C3E5828002051AC /* GenderView.swift */; };
 		87E046942C3D2B38002D12C2 /* BirthViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87E046932C3D2B38002D12C2 /* BirthViewController.swift */; };
 		87E046982C3D5E3D002D12C2 /* NicknameView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87E046972C3D5E3D002D12C2 /* NicknameView.swift */; };
 		AFD0294A332A568516A1C70E /* Pods_Offroad_iOSTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1C748B13438908AFF5CFFFA4 /* Pods_Offroad_iOSTests.framework */; };
@@ -114,6 +116,8 @@
 		8792CFFB2C3D823F002051AC /* Secrets.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Secrets.xcconfig; sourceTree = "<group>"; };
 		8792CFFD2C3D85BE002051AC /* NicknameViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NicknameViewController.swift; sourceTree = "<group>"; };
 		8792D0102C3DA1C9002051AC /* BirthView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BirthView.swift; sourceTree = "<group>"; };
+		8792D0142C3E581E002051AC /* GenderViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenderViewController.swift; sourceTree = "<group>"; };
+		8792D0162C3E5828002051AC /* GenderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenderView.swift; sourceTree = "<group>"; };
 		87E046932C3D2B38002D12C2 /* BirthViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BirthViewController.swift; sourceTree = "<group>"; };
 		87E046972C3D5E3D002D12C2 /* NicknameView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NicknameView.swift; sourceTree = "<group>"; };
 		C9C00FCF31F1DF74855DC482 /* Pods_Offroad_iOS_Offroad_iOSUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Offroad_iOS_Offroad_iOSUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -569,6 +573,7 @@
 			children = (
 				87E046972C3D5E3D002D12C2 /* NicknameView.swift */,
 				8792D0102C3DA1C9002051AC /* BirthView.swift */,
+				8792D0162C3E5828002051AC /* GenderView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -578,6 +583,7 @@
 			children = (
 				8792CFFD2C3D85BE002051AC /* NicknameViewController.swift */,
 				87E046932C3D2B38002D12C2 /* BirthViewController.swift */,
+				8792D0142C3E581E002051AC /* GenderViewController.swift */,
 			);
 			path = ViewController;
 			sourceTree = "<group>";
@@ -896,7 +902,9 @@
 				4E0394DB2C2ABE9D007F0517 /* UIStackView+.swift in Sources */,
 				4E0394E62C2AC16A007F0517 /* UIScreen+.swift in Sources */,
 				4EDC3D4B2C312850006A1493 /* FontLiterals.swift in Sources */,
+				8792D0172C3E5828002051AC /* GenderView.swift in Sources */,
 				4E0394D92C2ABCCC007F0517 /* UIView+.swift in Sources */,
+				8792D0152C3E581E002051AC /* GenderViewController.swift in Sources */,
 				4E1E94112C39870700A7B08A /* ColorLiterals.swift in Sources */,
 				4E0394312C2A9DCE007F0517 /* ViewController.swift in Sources */,
 				D0EAF21F2C3B02B700566543 /* SplashView.swift in Sources */,

--- a/Offroad-iOS/Offroad-iOS/Presentation/Nickname/View/GenderView.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Nickname/View/GenderView.swift
@@ -28,38 +28,54 @@ final class GenderView: UIView {
         $0.font = UIFont.offroad(style: .iosSubtitleReg)
     }
     
-    private let maleButton = UIButton().then {
+    let maleButton = UIButton().then {
         $0.setTitle("남성", for: .normal)
         $0.titleLabel?.textAlignment = .center
         $0.titleLabel?.font = UIFont.offroad(style: .iosTextRegular)
         $0.setTitleColor(UIColor.grayscale(.gray300), for: .normal)
         $0.setTitleColor(UIColor.main(.main2), for: .selected)
         $0.backgroundColor = UIColor.main(.main3)
+        $0.setBackgroundColor(UIColor.neutral(.nametagInactive), for: .selected)
+        $0.layer.borderWidth = 1.0
         $0.layer.borderColor = UIColor.grayscale(.gray100).cgColor
         $0.layer.cornerRadius = 5
     }
     
-    private let femaleButton = UIButton().then {
+    let femaleButton = UIButton().then {
         $0.setTitle("여성", for: .normal)
         $0.titleLabel?.textAlignment = .center
         $0.titleLabel?.font = UIFont.offroad(style: .iosTextRegular)
         $0.setTitleColor(UIColor.grayscale(.gray300), for: .normal)
         $0.setTitleColor(UIColor.main(.main2), for: .selected)
         $0.backgroundColor = UIColor.main(.main3)
+        $0.setBackgroundColor(UIColor.neutral(.nametagInactive), for: .selected)
+        $0.layer.borderWidth = 1.0
         $0.layer.borderColor = UIColor.grayscale(.gray100).cgColor
         $0.layer.cornerRadius = 5
     }
     
-    private let etcButton = UIButton().then {
+    let etcButton = UIButton().then {
         $0.setTitle("기타", for: .normal)
         $0.titleLabel?.textAlignment = .center
         $0.titleLabel?.font = UIFont.offroad(style: .iosTextRegular)
         $0.setTitleColor(UIColor.grayscale(.gray300), for: .normal)
         $0.setTitleColor(UIColor.main(.main2), for: .selected)
         $0.backgroundColor = UIColor.main(.main3)
+        $0.setBackgroundColor(UIColor.neutral(.nametagInactive), for: .selected)
+        $0.layer.borderWidth = 1.0
         $0.layer.borderColor = UIColor.grayscale(.gray100).cgColor
         $0.layer.cornerRadius = 5
     }
+    
+    private let nextButton = UIButton().then {
+        $0.setTitle("다음", for: .normal)
+        $0.titleLabel?.textAlignment = .center
+        $0.titleLabel?.font = UIFont.offroad(style: .iosTextRegular)
+        $0.setTitleColor(UIColor.main(.main1), for: .normal)
+        $0.backgroundColor = UIColor.main(.main2)
+        $0.layer.cornerRadius = 5
+    }
+    
     // MARK: - Life Cycle
     
     override init(frame: CGRect) {
@@ -85,7 +101,8 @@ extension GenderView {
             subLabel,
             maleButton,
             femaleButton,
-            etcButton
+            etcButton,
+            nextButton
         )
     }
     
@@ -112,15 +129,21 @@ extension GenderView {
         }
         
         femaleButton.snp.makeConstraints { make in
-            make.top.equalTo(maleButton.snp.bottom).offset(64)
+            make.top.equalTo(maleButton.snp.bottom).offset(12)
             make.leading.trailing.equalToSuperview().inset(24)
             make.height.equalTo(60)
         }
         
         etcButton.snp.makeConstraints { make in
-            make.top.equalTo(femaleButton.snp.bottom).offset(64)
+            make.top.equalTo(femaleButton.snp.bottom).offset(12)
             make.leading.trailing.equalToSuperview().inset(24)
             make.height.equalTo(60)
+        }
+        
+        nextButton.snp.makeConstraints { make in
+            make.bottom.equalTo(safeAreaLayoutGuide).inset(24)
+            make.leading.trailing.equalToSuperview().inset(24)
+            make.height.equalTo(54)
         }
     }
 }

--- a/Offroad-iOS/Offroad-iOS/Presentation/Nickname/View/GenderView.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Nickname/View/GenderView.swift
@@ -1,0 +1,126 @@
+//
+//  GenderView.swift
+//  Offroad-iOS
+//
+//  Created by  정지원 on 7/10/24.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class GenderView: UIView {
+    
+    //MARK: - Properties
+    
+    private let mainLabel = UILabel().then {
+        $0.text = "모험가 프로필 작성"
+        $0.textAlignment = .center
+        $0.textColor = UIColor.main(.main2)
+        $0.font = UIFont.offroad(style: .iosProfileTitle)
+    }
+    
+    private let subLabel = UILabel().then {
+        $0.text = "성별을 선택해 주세요."
+        $0.textAlignment = .center
+        $0.textColor = UIColor.main(.main2)
+        $0.font = UIFont.offroad(style: .iosSubtitleReg)
+    }
+    
+    private let maleButton = UIButton().then {
+        $0.setTitle("남성", for: .normal)
+        $0.titleLabel?.textAlignment = .center
+        $0.titleLabel?.font = UIFont.offroad(style: .iosTextRegular)
+        $0.setTitleColor(UIColor.grayscale(.gray300), for: .normal)
+        $0.backgroundColor = UIColor.main(.main3)
+        $0.layer.borderColor = UIColor.grayscale(.gray100).cgColor
+        $0.layer.cornerRadius = 5
+    }
+    
+    private let femaleButton = UIButton().then {
+        $0.setTitle("여성", for: .normal)
+        $0.titleLabel?.textAlignment = .center
+        $0.titleLabel?.font = UIFont.offroad(style: .iosTextRegular)
+        $0.setTitleColor(UIColor.grayscale(.gray300), for: .normal)
+        $0.backgroundColor = UIColor.main(.main3)
+        $0.layer.borderColor = UIColor.grayscale(.gray100).cgColor
+        $0.layer.cornerRadius = 5
+    }
+    
+    private let etcButton = UIButton().then {
+        $0.setTitle("기타", for: .normal)
+        $0.titleLabel?.textAlignment = .center
+        $0.titleLabel?.font = UIFont.offroad(style: .iosTextRegular)
+        $0.setTitleColor(UIColor.grayscale(.gray300), for: .normal)
+        $0.backgroundColor = UIColor.main(.main3)
+        $0.layer.borderColor = UIColor.grayscale(.gray100).cgColor
+        $0.layer.cornerRadius = 5
+    }
+    // MARK: - Life Cycle
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setupHierarchy()
+        setupStyle()
+        setupLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+extension GenderView {
+    
+    // MARK: - Private Func
+    
+    private func setupHierarchy() {
+        addSubviews(
+            mainLabel,
+            subLabel,
+            maleButton,
+            femaleButton,
+            etcButton
+        )
+    }
+    
+    private func setupStyle() {
+        backgroundColor = UIColor.main(.main1)
+    }
+    
+    private func setupLayout() {
+        
+        mainLabel.snp.makeConstraints{ make in
+            make.top.equalTo(safeAreaLayoutGuide).inset(97)
+            make.leading.trailing.equalToSuperview().inset(63)
+        }
+        
+        subLabel.snp.makeConstraints{ make in
+            make.top.equalTo(mainLabel.snp.bottom).offset(12)
+            make.leading.trailing.equalToSuperview().inset(63)
+        }
+        
+        maleButton.snp.makeConstraints { make in
+            make.top.equalTo(subLabel.snp.bottom).offset(64)
+            make.leading.trailing.equalToSuperview().inset(24)
+            make.height.equalTo(60)
+        }
+        
+        femaleButton.snp.makeConstraints { make in
+            make.top.equalTo(maleButton.snp.bottom).offset(64)
+            make.leading.trailing.equalToSuperview().inset(24)
+            make.height.equalTo(60)
+        }
+        
+        etcButton.snp.makeConstraints { make in
+            make.top.equalTo(femaleButton.snp.bottom).offset(64)
+            make.leading.trailing.equalToSuperview().inset(24)
+            make.height.equalTo(60)
+        }
+    }
+}
+
+
+

--- a/Offroad-iOS/Offroad-iOS/Presentation/Nickname/ViewController/GenderViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Nickname/ViewController/GenderViewController.swift
@@ -1,0 +1,15 @@
+//
+//  GenderViewController.swift
+//  Offroad-iOS
+//
+//  Created by  정지원 on 7/10/24.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class GenderViewController: UIViewController {
+    
+}

--- a/Offroad-iOS/Offroad-iOS/Presentation/Nickname/ViewController/GenderViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Nickname/ViewController/GenderViewController.swift
@@ -43,14 +43,15 @@ extension GenderViewController {
     @objc func buttonTapped(_ sender: UIButton) {
         
         [genderView.maleButton, genderView.femaleButton, genderView.etcButton].forEach { button in
-            button.isSelected = false
-            button.layer.borderColor = UIColor.grayscale(.gray100).cgColor
+            if button == sender {
+                button.isSelected.toggle()
+                button.layer.borderColor = button.isSelected ? UIColor.sub(.sub).cgColor : UIColor.grayscale(.gray100).cgColor
+            } else {
+                button.isSelected = false
+                button.layer.borderColor = UIColor.grayscale(.gray100).cgColor
+            }
         }
-
-        sender.isSelected = true
-        sender.layer.borderColor = UIColor.sub(.sub).cgColor
     }
 }
-
 
 

--- a/Offroad-iOS/Offroad-iOS/Presentation/Nickname/ViewController/GenderViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Nickname/ViewController/GenderViewController.swift
@@ -12,4 +12,45 @@ import Then
 
 final class GenderViewController: UIViewController {
     
+    //MARK: - Properties
+    
+    private let genderView = GenderView()
+    
+    //MARK: - Life Cycle
+    
+    override func loadView() {
+        view = genderView
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        setupAddTarget()
+    }
+    
+    //MARK: - Private Method
+    
+    private func setupAddTarget() {
+        genderView.maleButton.addTarget(self, action: #selector(buttonTapped(_:)), for: .touchUpInside)
+        genderView.femaleButton.addTarget(self, action: #selector(buttonTapped(_:)), for: .touchUpInside)
+        genderView.etcButton.addTarget(self, action: #selector(buttonTapped(_:)), for: .touchUpInside)
+    }
 }
+
+extension GenderViewController {
+    
+    //MARK: - @objc Method
+    @objc func buttonTapped(_ sender: UIButton) {
+        
+        [genderView.maleButton, genderView.femaleButton, genderView.etcButton].forEach { button in
+            button.isSelected = false
+            button.layer.borderColor = UIColor.grayscale(.gray100).cgColor
+        }
+
+        sender.isSelected = true
+        sender.layer.borderColor = UIColor.sub(.sub).cgColor
+    }
+}
+
+
+


### PR DESCRIPTION
### 🌴 작업한 브랜치
- #25 


### ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->
3개의 버튼 중 하나만 선택할 수 있고, 버튼이 선택되면 textColor, backgroundColor, borderColor가 변경되도록 구현했다.
View와 Controller의 책임 분리를 하고, 마크주석도 추가했다.
<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### ❗️PR Point
<!-- 부족했던 점 혹은 개선하고 싶은 방향이 있다면 얘기해주세요 -->
1.
 isEnabled는 버튼이 눌릴 수 있는 지의 “가능여부”이고, isSelected는 버튼의 “선택여부”이다.
```swift
 @objc func buttonTapped(_ sender: UIButton) {
       
        [genderView.maleButton, genderView.femaleButton, genderView.etcButton].forEach { button in
            if button == sender {
                button.isSelected.toggle()
                button.layer.borderColor = button.isSelected ? UIColor.sub(.sub).cgColor : UIColor.grayscale(.gray100).cgColor
            } else {
                button.isSelected = false
                button.layer.borderColor = UIColor.grayscale(.gray100).cgColor
            }
        }
    }
```

2. ➕왜 함수 앞에 @objc를 붙이지?

Objective-C에서 `@selector`를 사용하여 메서드를 호출하는 경우, 해당 메서드는 `@objc` 속성으로 선언되어야 함.

`@objc`를 사용하지 않으면 Objective-C 런타임에서 해당 메서드를 찾을 수 없기 때문에 에러가 발생


### 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->
![Simulator Screen Recording - iPhone 15 Pro - 2024-07-10 at 17 21 24](https://github.com/Team-Offroad/Offroad-iOS/assets/121231822/8490b70c-1145-40f4-9434-14987633cc0c)

|뷰|설명|
|:------:|:---:|
|  GenderViewController   | 프로필 설정에서 유저가 성별을 선택하는 뷰이다. |


- Resolved: #25 
