### PR TITLE
[Feat] #39 - SplashView LoginView 화면 전환 애니메이션 구현

### DIFF
--- a/Offroad-iOS/Offroad-iOS/Presentation/Splash/View/SplashView.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Splash/View/SplashView.swift
@@ -48,4 +48,12 @@ extension SplashView {
             $0.center.equalToSuperview()
         }
     }
+    
+    //MARK: - Private Func
+    
+    func dismissOffroadLogiView() {
+        UIView.animate(withDuration: 0.5, animations: {
+            self.offroadLogoImageView.alpha = 0
+        })
+    }
 }

--- a/Offroad-iOS/Offroad-iOS/Presentation/Splash/View/SplashView.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Splash/View/SplashView.swift
@@ -51,9 +51,11 @@ extension SplashView {
     
     //MARK: - Private Func
     
-    func dismissOffroadLogiView() {
-        UIView.animate(withDuration: 0.5, animations: {
+    func dismissOffroadLogiView(completion: @escaping () -> Void) {
+        UIView.animate(withDuration: 0.4, animations: {
             self.offroadLogoImageView.alpha = 0
+        }, completion: { _ in
+            completion()
         })
     }
 }

--- a/Offroad-iOS/Offroad-iOS/Presentation/Splash/ViewController/SplashViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Splash/ViewController/SplashViewController.swift
@@ -22,11 +22,15 @@ final class SplashViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
-            self.rootView.dismissOffroadLogiView()
-        }
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
-            self.presentLoginViewController()
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
+            self.rootView.dismissOffroadLogiView {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
+                    self.presentLoginViewController()
+                }
+            }
         }
     }
 }
@@ -37,9 +41,14 @@ extension SplashViewController {
     
     private func presentLoginViewController() {
         let loginViewController = LoginViewController()
-        loginViewController.modalTransitionStyle = .crossDissolve
         loginViewController.modalPresentationStyle = .fullScreen
         
-        present(loginViewController, animated: true, completion: nil)
+        let transition = CATransition()
+        transition.duration = 0.6
+        transition.type = .fade
+        transition.subtype = .fromRight
+        view.window?.layer.add(transition, forKey: kCATransition)
+        
+        present(loginViewController, animated: false, completion: nil)
     }
 }

--- a/Offroad-iOS/Offroad-iOS/Presentation/Splash/ViewController/SplashViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Splash/ViewController/SplashViewController.swift
@@ -22,5 +22,24 @@ final class SplashViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+            self.rootView.dismissOffroadLogiView()
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+            self.presentLoginViewController()
+        }
+    }
+}
+
+extension SplashViewController {
+    
+    //MARK: - Private Func
+    
+    private func presentLoginViewController() {
+        let loginViewController = LoginViewController()
+        loginViewController.modalTransitionStyle = .crossDissolve
+        loginViewController.modalPresentationStyle = .fullScreen
+        
+        present(loginViewController, animated: true, completion: nil)
     }
 }


### PR DESCRIPTION
### 🌴 작업한 브랜치
- #39


### ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->
SplashView에서 LoginView 전환하는 애니메이션을 구현했습니다.

- present시 Dissolve 효과를 CATransition을 활용하여 구현하였습니다.
```
    private func presentLoginViewController() {
        let loginViewController = LoginViewController()
        loginViewController.modalPresentationStyle = .fullScreen
        
        let transition = CATransition()
        transition.duration = 0.6
        transition.type = .fade
        transition.subtype = .fromRight
        view.window?.layer.add(transition, forKey: kCATransition)
        
        present(loginViewController, animated: false, completion: nil)
    }
```

### ❗️PR Point
<!-- 부족했던 점 혹은 개선하고 싶은 방향이 있다면 얘기해주세요 -->

피그마 기준으로 로고 유지시간 = 0.6초, 로고 Fade out 시간 = 0.4초, 로고 사라진 후 유지시간 = 0.4초, dissolve 시간 = 0.6초를 다음과 같이 작성했는데 뭔가.. 효율적인지 잘 모르겠어서.. 의견 주세요!!  ㅠㅠ

```
    override func viewDidAppear(_ animated: Bool) {
        DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
            self.rootView.dismissOffroadLogiView {
                DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
                    self.presentLoginViewController()
                }
            }
        }
    }
```
```
    func dismissOffroadLogiView(completion: @escaping () -> Void) {
        UIView.animate(withDuration: 0.4, animations: {
            self.offroadLogoImageView.alpha = 0
        }, completion: { _ in
            completion()
        })
    }
```


### 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->

|SplashView|
|:------:|
|![Simulator Screen Recording - iPhone 15 Pro - 2024-07-13 at 15 27 33](https://github.com/user-attachments/assets/cacc3647-2c5c-46b5-ba4b-9ad52b371610)| 


- Resolved: #39
