### PR TITLE
[Feat] #51 - UIView extension popup 애니메이션 구현

### DIFF
--- a/Offroad-iOS/Offroad-iOS/Global/Extensions/UIView+.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Extensions/UIView+.swift
@@ -15,7 +15,6 @@ extension UIView {
         views.forEach { self.addSubview($0) }
     }
     
-    
     /// view의 코너를 둥글게 설정
     /// - Parameters:
     ///   - cornerRadius: 코너의 곡률 반경
@@ -29,6 +28,19 @@ extension UIView {
         }
     }
     
+    func excutePresentPopupAnimation() {
+        transform = CGAffineTransform(scaleX: 0.5, y: 0.5)
+        
+        UIView.animate(withDuration: 0.5, delay: 0, usingSpringWithDamping: 1, initialSpringVelocity: 1, options: .curveEaseInOut, animations: {
+            self.transform = CGAffineTransform.identity
+            self.alpha = 1
+        }, completion: nil)
+    }
     
-    
+    func excuteDismissPopupAnimation() {
+        UIView.animate(withDuration: 0.5, delay: 0, usingSpringWithDamping: 1, initialSpringVelocity: 1, options: .curveEaseInOut, animations: {
+            self.transform = CGAffineTransform(scaleX: 0.1, y: 0.1)
+            self.alpha = 0
+        }, completion: nil)
+    }
 }

--- a/Offroad-iOS/Offroad-iOS/Global/Extensions/UIView+.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Extensions/UIView+.swift
@@ -28,6 +28,9 @@ extension UIView {
         }
     }
     
+    /// view의 pop up 효과가 나타나는 animation 설정
+    /// - 해당 함수를 불러오기 전에 popupView(or 적용할 View).alpha = 0 으로 설정해줘야 동작함
+    /// > 사용 예시 : `popupView.excutePresentPopupAnimation()`
     func excutePresentPopupAnimation() {
         transform = CGAffineTransform(scaleX: 0.5, y: 0.5)
         
@@ -37,6 +40,8 @@ extension UIView {
         }, completion: nil)
     }
     
+    /// view의 pop up 효과가 사라지는 animation 설정
+    /// > 사용 예시 : `popupView.excuteDismissPopupAnimation()`
     func excuteDismissPopupAnimation() {
         UIView.animate(withDuration: 0.5, delay: 0, usingSpringWithDamping: 1, initialSpringVelocity: 1, options: .curveEaseInOut, animations: {
             self.transform = CGAffineTransform(scaleX: 0.1, y: 0.1)

--- a/Offroad-iOS/Offroad-iOS/Presentation/Home/TitlePopup/View/TitlePopupView.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Home/TitlePopup/View/TitlePopupView.swift
@@ -53,6 +53,7 @@ extension TitlePopupView {
         popupView.do {
             $0.backgroundColor = .main(.main3)
             $0.roundCorners(cornerRadius: 15)
+            $0.alpha = 0
         }
         
         myTitleLabel.do {
@@ -132,6 +133,15 @@ extension TitlePopupView {
     
     func getTitleCollectionViewWidth() -> CGFloat {
         return titleCollectionView.frame.size.width
+    }
+    
+    func presentPopupView() {
+        popupView.excutePresentPopupAnimation()
+    }
+    
+    func dismissPopupView() {
+        backgroundColor = .clear
+        popupView.excuteDismissPopupAnimation()
     }
     
     //MARK: - targetView Method

--- a/Offroad-iOS/Offroad-iOS/Presentation/Home/TitlePopup/ViewController/TitlePopupViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Home/TitlePopup/ViewController/TitlePopupViewController.swift
@@ -33,6 +33,10 @@ final class TitlePopupViewController: UIViewController {
         
         setupTarget()
     }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        rootView.presentPopupView()
+    }
 }
 
 extension TitlePopupViewController {
@@ -48,13 +52,19 @@ extension TitlePopupViewController {
         print("changeTitleButtonTapped")
         
         delegate?.fetchTitleString(titleString: selectedTitleString)
-        self.dismiss(animated: false)
+        rootView.dismissPopupView()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.4){
+            self.dismiss(animated: false)
+        }
     }
     
     private func closeButtonTapped() {
         print("closeButtonTapped")
         
-        self.dismiss(animated: false)
+        rootView.dismissPopupView()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.4){
+            self.dismiss(animated: false)
+        }
     }
 }
 


### PR DESCRIPTION
### 🌴 작업한 브랜치
- #51


### ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->
UIView의 popup이 나타나고 사라지는 extension 함수를 구현하였습니다.

디자이너 분들과 상의 후 지속 속도를 `withDuration: 0.5` 으로 설정해두었습니다! 추후 변경이 필요하다면 파라미터로 빼두어 수정하하겠습니당

  ```
  func presentPopupAnimation() {
      transform = CGAffineTransform(scaleX: 0.5, y: 0.5)
      
      UIView.animate(withDuration: 0.5, delay: 0, usingSpringWithDamping: 1, initialSpringVelocity: 1, options: .curveEaseInOut, animations: {
          self.transform = CGAffineTransform.identity
          self.alpha = 1
      }, completion: nil)
  }
  ```
`presentPopupAnimation()`의 경우 기존 View의 알파값을 0으로 지정해주어야 점차 alpha 값이 진해지면서 나타나는 구조로 작성했기 때문에, 함수를 불러오기 전에 꼭 애니메이션을 적용할 View의 alpha 값을 0으로 지정해야합니다!!
(alpha값을 해당 함수에서 0으로 설정한 뒤 애니메이션을 적용시키게 되면 기존에 투명하지 않았던 뷰가 먼저 보인뒤 애니메이션이 나타나는 형태가 보이기도 해서 위와 같이 구현하였는데.. 더 좋은 방법이 있다면 알려주십시오 ㅠ)

### ❗️PR Point
<!-- 부족했던 점 혹은 개선하고 싶은 방향이 있다면 얘기해주세요 -->
  ```
  private func changeTitleButtonTapped() {
      print("changeTitleButtonTapped")
      
      delegate?.fetchTitleString(titleString: selectedTitleString)
      rootView.dismissPopupView()
      DispatchQueue.main.asyncAfter(deadline: .now() + 0.4){
          self.dismiss(animated: false)
      }
  }
    
  private func closeButtonTapped() {
      print("closeButtonTapped")
      
      rootView.dismissPopupView()
      DispatchQueue.main.asyncAfter(deadline: .now() + 0.4){
          self.dismiss(animated: false)
      }
  }
  ```
- 팝업을 dismiss 하는 경우, 소멸되는 애니메이션이 먼저 보인 후 팝업이 사라져야 하기 때문에 `DispatchQueue.main.asyncAfter`를 통해 딜레이를 준 뒤 `self.dismiss(animated: false)`를 실행하였습니다.

### 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->

|iPhone 15 Pro|iPhone SE|
|:------:|:------:|
|<img src="https://github.com/user-attachments/assets/3bba6f73-0346-4c36-96aa-87b271fe3115" width="393px"/>|<img src="https://github.com/user-attachments/assets/5255fad3-f722-476c-bcf3-7c978d577ef1" width="393px"/>|

- Resolved: #51
