### PR TITLE
[Feat] #62 - HomeView API 통신

### DIFF
--- a/Offroad-iOS/Offroad-iOS/Network/Adventure/AdventureAPI.swift
+++ b/Offroad-iOS/Offroad-iOS/Network/Adventure/AdventureAPI.swift
@@ -20,8 +20,7 @@ extension AdventureAPI: BaseTargetType {
     var parameter: [String : Any]? {
         switch self {
         case .getAdventureInfo:
-            return ["category": "NONE",
-                    "characterId": 1]
+            return ["category": "NONE"]
         }
     }
     

--- a/Offroad-iOS/Offroad-iOS/Network/Adventure/DTO/Response/AdventureInfoResponseDTO.swift
+++ b/Offroad-iOS/Offroad-iOS/Network/Adventure/DTO/Response/AdventureInfoResponseDTO.swift
@@ -14,7 +14,7 @@ struct AdventureInfoResponseDTO: Codable {
 
 struct AdventureInfoData: Codable {
     let nickname: String
-    let characterImageUrl: String
+    let characterImgUrl: String
     let characterName: String
     let emblemName: String
 }

--- a/Offroad-iOS/Offroad-iOS/Network/Auth/AuthAPI.swift
+++ b/Offroad-iOS/Offroad-iOS/Network/Auth/AuthAPI.swift
@@ -28,7 +28,7 @@ extension AuthAPI: BaseTargetType {
     var path: String {
         switch self {
         case .postSocialLogin:
-            return "/oauth/login/apple"
+            return "/oauth/login"
         case .postRefreshToken:
             return "/auth/refresh"
         }

--- a/Offroad-iOS/Offroad-iOS/Network/Base/BaseService.swift
+++ b/Offroad-iOS/Offroad-iOS/Network/Base/BaseService.swift
@@ -29,7 +29,7 @@ class BaseService {
     /// 200 받았을 때 decoding 할 데이터가 없는 경우 (대부분의 PATCH, PUT, DELETE)
     func fetchNetworkResult(statusCode: Int, data: Data) -> NetworkResult<Any> {
         switch statusCode {
-        case 200: return .success(nil)
+        case 200, 201: return .success(nil)
         case 400: return .requestErr
         case 401: return .unAuthentication
         case 403: return .unAuthorization

--- a/Offroad-iOS/Offroad-iOS/Network/Base/BaseTargetType.swift
+++ b/Offroad-iOS/Offroad-iOS/Network/Base/BaseTargetType.swift
@@ -37,13 +37,13 @@ extension BaseTargetType {
         case .accessTokenHeaderForGet:
             guard let accessToken = UserDefaults.standard.string(forKey: "AccessToken") else { return [:] }
             
-            var header = ["Authorization": "Bearer \(accessToken)"]
+            let header = ["Authorization": "Bearer \(accessToken)"]
             
             return header
         case .accessTokenHeaderForGeneral:
             guard let accessToken = UserDefaults.standard.string(forKey: "AccessToken") else { return [:] }
             
-            var header = ["Content-Type": "application/json",
+            let header = ["Content-Type": "application/json",
                           "Authorization": "Bearer \(accessToken)"]
             return header
         }

--- a/Offroad-iOS/Offroad-iOS/Network/Base/NetworkService.swift
+++ b/Offroad-iOS/Offroad-iOS/Network/Base/NetworkService.swift
@@ -15,4 +15,5 @@ final class NetworkService {
     
     let authService: AuthServiceProtocol = AuthService()
     let adventureService: AdventureServiceProtocol = AdventureService()
+    let questService: QuestServiceProtocol = QuestService()
 }

--- a/Offroad-iOS/Offroad-iOS/Network/Base/NetworkService.swift
+++ b/Offroad-iOS/Offroad-iOS/Network/Base/NetworkService.swift
@@ -16,4 +16,5 @@ final class NetworkService {
     let authService: AuthServiceProtocol = AuthService()
     let adventureService: AdventureServiceProtocol = AdventureService()
     let questService: QuestServiceProtocol = QuestService()
+    let emblemService: EmblemServiceProtocol = EmblemService()
 }

--- a/Offroad-iOS/Offroad-iOS/Network/Emblem/DTO/Response/ChangeEmblemResponseDTO.swift
+++ b/Offroad-iOS/Offroad-iOS/Network/Emblem/DTO/Response/ChangeEmblemResponseDTO.swift
@@ -9,4 +9,5 @@ import Foundation
 
 struct ChangeEmblemResponseDTO: Codable {
     let message: String
+    var data: Data? = nil
 }

--- a/Offroad-iOS/Offroad-iOS/Network/Emblem/EmblemAPI.swift
+++ b/Offroad-iOS/Offroad-iOS/Network/Emblem/EmblemAPI.swift
@@ -6,3 +6,47 @@
 //
 
 import Foundation
+
+import Moya
+
+enum EmblemAPI {
+    case getEmblemInfo
+    case patchUserEmblem(emBlemCode: String)
+}
+
+extension EmblemAPI: BaseTargetType {
+
+    var headerType: HeaderType { return .accessTokenHeaderForGet }
+    
+    var parameter: [String : Any]? {
+        switch self {
+        case .getEmblemInfo:
+            return .none
+        case .patchUserEmblem(let emblemCode):
+            return ["emblemCode" : emblemCode]
+        }
+    }
+    
+    var path: String {
+        switch self {
+        case .getEmblemInfo, .patchUserEmblem:
+            return "/users/emblems"
+        }
+    }
+    
+    var method: Moya.Method {
+        switch self {
+        case .getEmblemInfo:
+            return .get
+        case .patchUserEmblem:
+            return .patch
+        }
+    }
+    
+    var task: Moya.Task {
+        switch self {
+        case .getEmblemInfo, .patchUserEmblem:
+            return .requestParameters(parameters: parameter ?? [:], encoding: URLEncoding.queryString)
+        }
+    }
+}

--- a/Offroad-iOS/Offroad-iOS/Network/Emblem/EmblemService.swift
+++ b/Offroad-iOS/Offroad-iOS/Network/Emblem/EmblemService.swift
@@ -6,3 +6,44 @@
 //
 
 import Foundation
+
+import Moya
+
+protocol EmblemServiceProtocol {
+    func getEmblemInfo(completion: @escaping (NetworkResult<EmblemInfoResponseDTO>) -> ())
+    func patchUserEmblem(parameter: String, completion: @escaping (NetworkResult<ChangeEmblemResponseDTO>) -> ())
+}
+
+final class EmblemService: BaseService, EmblemServiceProtocol {
+    let provider = MoyaProvider<EmblemAPI>(plugins: [MoyaPlugin()])
+
+    func getEmblemInfo(completion: @escaping (NetworkResult<EmblemInfoResponseDTO>) -> ()) {
+        provider.request(.getEmblemInfo) { result in
+            switch result {
+            case .success(let response):
+                let networkResult: NetworkResult<EmblemInfoResponseDTO> = self.fetchNetworkResult(
+                    statusCode: response.statusCode,
+                    data: response.data
+                )
+                completion(networkResult)
+            case .failure(let err):
+                print(err)
+            }
+        }
+    }
+    
+    func patchUserEmblem(parameter: String, completion: @escaping (NetworkResult<ChangeEmblemResponseDTO>) -> ()) {
+        provider.request(.patchUserEmblem(emBlemCode: parameter)) { result in
+            switch result {
+            case .success(let response):
+                let networkResult: NetworkResult<ChangeEmblemResponseDTO> = self.fetchNetworkResult(
+                    statusCode: response.statusCode,
+                    data: response.data
+                )
+                completion(networkResult)
+            case .failure(let err):
+                print(err)
+            }
+        }
+    }
+}

--- a/Offroad-iOS/Offroad-iOS/Network/Quest/QuestAPI.swift
+++ b/Offroad-iOS/Offroad-iOS/Network/Quest/QuestAPI.swift
@@ -6,3 +6,43 @@
 //
 
 import Foundation
+
+import Moya
+
+enum QuestAPI {
+    case getQuestInfo
+}
+
+extension QuestAPI: BaseTargetType {
+
+    var headerType: HeaderType { return .accessTokenHeaderForGet }
+    
+    var parameter: [String : Any]? {
+        switch self {
+        case .getQuestInfo:
+            return .none
+        }
+    }
+    
+    var path: String {
+        switch self {
+        case .getQuestInfo:
+            return "/users/quests"
+        }
+    }
+    
+    var method: Moya.Method {
+        switch self {
+        case .getQuestInfo:
+            return .get
+        }
+    }
+    
+    var task: Moya.Task {
+        switch self {
+        case .getQuestInfo:
+            return .requestPlain
+        }
+    }
+}
+

--- a/Offroad-iOS/Offroad-iOS/Network/Quest/QuestService.swift
+++ b/Offroad-iOS/Offroad-iOS/Network/Quest/QuestService.swift
@@ -6,3 +6,28 @@
 //
 
 import Foundation
+
+import Moya
+
+protocol QuestServiceProtocol {
+    func getQuestInfo(completion: @escaping (NetworkResult<QuestInfoResponseDTO>) -> ())
+}
+
+final class QuestService: BaseService, QuestServiceProtocol {
+    let provider = MoyaProvider<QuestAPI>(plugins: [MoyaPlugin()])
+
+    func getQuestInfo(completion: @escaping (NetworkResult<QuestInfoResponseDTO>) -> ()) {
+        provider.request(.getQuestInfo) { result in
+            switch result {
+            case .success(let response):
+                let networkResult: NetworkResult<QuestInfoResponseDTO> = self.fetchNetworkResult(
+                    statusCode: response.statusCode,
+                    data: response.data
+                )
+                completion(networkResult)
+            case .failure(let err):
+                print(err)
+            }
+        }
+    }
+}

--- a/Offroad-iOS/Offroad-iOS/Presentation/Home/Component/CustomAlmostDoneProgressView.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Home/Component/CustomAlmostDoneProgressView.swift
@@ -31,9 +31,9 @@ final class CustomAlmostDoneProgressView: UIView {
 
 extension CustomAlmostDoneProgressView {
     
-    //MARK: - Method
+    //MARK: - Private Func
     
-    func createLinePath(rect: CGRect) {
+    private func createLinePath(rect: CGRect) {
         let linePath = UIBezierPath()
         linePath.move(to: CGPoint(x: rect.minX, y: rect.midY))
         linePath.addLine(to: CGPoint(x: rect.maxX, y: rect.midY))
@@ -44,15 +44,20 @@ extension CustomAlmostDoneProgressView {
         lineLayer.strokeColor = UIColor.blackOpacity(.black25).cgColor
         layer.addSublayer(lineLayer)
         
-        let endPointX = rect.maxX - rect.width / 8.0
-        let progressPath = UIBezierPath()
-        progressPath.move(to: CGPoint(x: rect.minX, y: rect.midY))
-        progressPath.addLine(to: CGPoint(x: endPointX, y: rect.midY))
-        
-        progressLayer.path = progressPath.cgPath
         progressLayer.lineCap = .round
         progressLayer.lineWidth = 9
         progressLayer.strokeColor = UIColor.sub(.sub4).cgColor
         layer.addSublayer(progressLayer)
+    }
+    
+    //MARK: - Func
+    
+    func setProgressView(progressValue: CGFloat) {
+        let endPointX = bounds.width * progressValue
+        let progressPath = UIBezierPath()
+        progressPath.move(to: CGPoint(x: bounds.minX, y: bounds.midY))
+        progressPath.addLine(to: CGPoint(x: endPointX, y: bounds.midY))
+        
+        progressLayer.path = progressPath.cgPath
     }
 }

--- a/Offroad-iOS/Offroad-iOS/Presentation/Home/Component/CustomQuestView.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Home/Component/CustomQuestView.swift
@@ -92,12 +92,15 @@ extension CustomQuestView {
     
     //MARK: - Method
     
-    func configureCustomView(mainColor: UIColor, questString: String, textColor: UIColor, image: UIImage, detailString: String) {
+    func configureCustomView(mainColor: UIColor, questString: String, textColor: UIColor, image: UIImage) {
         backgroundColor = mainColor
         questLabel.text = questString
         questLabel.textColor = textColor
         questLabelImageView.image = image
-        detailLabel.text = detailString
         detailLabel.textColor = textColor
+    }
+    
+    func setupDetailString(detailString: String) {
+        detailLabel.text = detailString
     }
 }

--- a/Offroad-iOS/Offroad-iOS/Presentation/Home/Component/CustomRecentProgressView.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Home/Component/CustomRecentProgressView.swift
@@ -23,26 +23,32 @@ final class CustomRecentProgressView: UIView {
     }
     
     required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+        super.init(coder: coder)
     }
     
-    override func draw(_ rect: CGRect) {
-        createCircularPath(rect: rect)
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        
+        createCircularPath()
     }
 }
 
 extension CustomRecentProgressView {
     
-    //MARK: - Method
+    //MARK: - Private Method
     
-    func createCircularPath(rect: CGRect) {
-        let centerX = rect.width / 2.0
-        let centerY = rect.height / 2.0
+    func createCircularPath() {
+        let centerX = bounds.width / 2.0
+        let centerY = bounds.height / 2.0
         let circularPath = UIBezierPath(arcCenter: .init(x: centerX, y: centerY),
                                         radius: frame.size.height / 2.0,
                                         startAngle: startAngle,
                                         endAngle: endAngle,
                                         clockwise: true)
+        
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        
         circleLayer.path = circularPath.cgPath
         circleLayer.fillColor = UIColor.clear.cgColor
         circleLayer.lineCap = .round
@@ -55,8 +61,18 @@ extension CustomRecentProgressView {
         progressLayer.fillColor = UIColor.clear.cgColor
         progressLayer.lineCap = .round
         progressLayer.lineWidth = 9
-        progressLayer.strokeEnd = 0.75
         progressLayer.strokeColor = UIColor.home(.homeContents1GraphMain).cgColor
         layer.addSublayer(progressLayer)
+        
+        CATransaction.commit()
+    }
+    
+    func setProgressView(progressValue: CGFloat) {
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        
+        progressLayer.strokeEnd = progressValue
+        
+        CATransaction.commit()
     }
 }

--- a/Offroad-iOS/Offroad-iOS/Presentation/Home/TitlePopup/View/Cell/TitleCollectionViewCell.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Home/TitlePopup/View/Cell/TitleCollectionViewCell.swift
@@ -86,7 +86,7 @@ extension TitleCollectionViewCell {
     
     //MARK: - Func
     
-    func configureCell(data: TitleModel) {
-        titleLabel.text = data.titleString
+    func configureCell(data: EmblemList) {
+        titleLabel.text = data.emblemName
     }
 }

--- a/Offroad-iOS/Offroad-iOS/Presentation/Home/TitlePopup/View/TitlePopupView.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Home/TitlePopup/View/TitlePopupView.swift
@@ -162,4 +162,8 @@ extension TitlePopupView {
         titleCollectionView.dataSource = viewController as? UICollectionViewDataSource
         titleCollectionView.delegate = viewController as? UICollectionViewDelegate
     }
+    
+    func reloadCollectionView() {
+        titleCollectionView.reloadData()
+    }
 }

--- a/Offroad-iOS/Offroad-iOS/Presentation/Home/View/HomeView.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Home/View/HomeView.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 
+import Kingfisher
 import SnapKit
 import Then
 
@@ -17,12 +18,6 @@ final class HomeView: UIView {
     typealias ChangeTitleButtonAction = () -> Void
 
     private var changeTitleButtonAction: ChangeTitleButtonAction?
-    
-    private var nicknameString = "비포장도로"
-    private var characterNameString = "오푸"
-    private var titleString = "오프로드 스타터"
-    private var recentQuestString = "홍대입구 한바퀴"
-    private var almostDoneString = "도심 속 공원 탐방"
 
     //MARK: - UI Properties
     
@@ -69,10 +64,8 @@ extension HomeView {
         backgroundColor = .main(.main1)
         
         nicknameLabel.do {
-            $0.text = "모험가 \(nicknameString)님"
             $0.font = .offroad(style: .iosSubtitleReg)
             $0.textAlignment = .center
-            $0.highlightText(targetText: nicknameString, font: .offroad(style: .iosSubtitle2Bold))
             $0.textColor = .main(.main2)
         }
         
@@ -84,7 +77,6 @@ extension HomeView {
         }
         
         characterNameLabel.do {
-            $0.text = characterNameString
             $0.font = .offroad(style: .iosSubtitle2Semibold)
             $0.textAlignment = .center
             $0.textColor = .primary(.white)
@@ -120,7 +112,6 @@ extension HomeView {
         }
         
         titleLabel.do {
-            $0.text = titleString
             $0.font = .offroad(style: .iosSubtitle2Semibold)
             $0.textAlignment = .center
             $0.textColor = .primary(.white)
@@ -266,6 +257,19 @@ extension HomeView {
     func changeMyTitleLabelText(text: String) {
         titleLabel.text = text
     }
+    
+    func updateAdventureInfo(nickname: String, characterImgUrl: String, characterName: String, emblemName: String) {
+        nicknameLabel.text = "모험가 \(nickname)님"
+        nicknameLabel.highlightText(targetText: nickname, font: .offroad(style: .iosSubtitle2Bold))
+        
+        let url = URL(string: characterImgUrl)
+        characterImageView.kf.setImage(with: url)
+        
+        characterNameLabel.text = characterName
+        
+        titleLabel.text = emblemName
+    }
+    
     
     //MARK: - targetView Method
     

--- a/Offroad-iOS/Offroad-iOS/Presentation/Home/View/HomeView.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Home/View/HomeView.swift
@@ -123,8 +123,8 @@ extension HomeView {
             $0.roundCorners(cornerRadius: 9)
         }
         
-        recentQuestView.configureCustomView(mainColor: .home(.homeContents1), questString: "최근 진행한 퀘스트", textColor: .main(.main1), image: .imgCompass, detailString: recentQuestString)
-        almostDoneQuestView.configureCustomView(mainColor: .home(.homeContents2), questString: "완료 임박 퀘스트", textColor: .sub(.sub4), image: .imgFire, detailString: almostDoneString)
+        recentQuestView.configureCustomView(mainColor: .home(.homeContents1), questString: "최근 진행한 퀘스트", textColor: .main(.main1), image: .imgCompass)
+        almostDoneQuestView.configureCustomView(mainColor: .home(.homeContents2), questString: "완료 임박 퀘스트", textColor: .sub(.sub4), image: .imgFire)
         
         questStackView.do {
             $0.axis = .horizontal
@@ -133,18 +133,15 @@ extension HomeView {
         }
         
         recentQuestProgressLabel.do {
-            $0.text = "3/4"
             $0.textColor = .main(.main1)
             $0.textAlignment = .center
             $0.font = .offroad(style: .bothRecentNum)
         }
         
         almostDoneQuestProgressLabel.do {
-            $0.text = "7 / 8"
             $0.textColor = .blackOpacity(.black25)
             $0.textAlignment = .center
             $0.font = .offroad(style: .bothUpcomingSmallNum)
-            $0.highlightText(targetText: "7", font: .offroad(style: .bothUpcomingBigNum), color: .sub(.sub4))
         }
     }
     
@@ -270,6 +267,21 @@ extension HomeView {
         titleLabel.text = emblemName
     }
     
+    func updateQuestInfo(recentQuestName: String, recentProgress: Int, recentCompleteCondition: Int, almostQuestName: String, almostprogress: Int, almostCompleteCondition: Int) {
+        recentQuestView.setupDetailString(detailString: recentQuestName)
+        almostDoneQuestView.setupDetailString(detailString: almostQuestName)
+        
+        recentQuestProgressLabel.text = "\(recentProgress)/\(recentCompleteCondition)"
+        almostDoneQuestProgressLabel.text = "\(almostprogress) / \(almostCompleteCondition)"
+        almostDoneQuestProgressLabel.highlightText(targetText: "\(almostprogress)", font: .offroad(style: .bothUpcomingBigNum), color: .sub(.sub4))
+
+        
+        let recentProgressValue = CGFloat(recentProgress)/CGFloat(recentCompleteCondition)
+        let almostProgressValue = CGFloat(almostprogress)/CGFloat(almostCompleteCondition)
+        
+        recentQuestProgressView.setProgressView(progressValue: recentProgressValue)
+        almostDoneQuestProgressView.setProgressView(progressValue: almostProgressValue)
+    }
     
     //MARK: - targetView Method
     

--- a/Offroad-iOS/Offroad-iOS/Presentation/Home/ViewController/HomeViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Home/ViewController/HomeViewController.swift
@@ -24,6 +24,13 @@ final class HomeViewController: OffroadTabBarViewController {
         
         setupTarget()
     }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        getUserAdventureInfo()
+        getUserQuestInfo()
+    }
 }
 
 extension HomeViewController {
@@ -42,6 +49,41 @@ extension HomeViewController {
         titlePopupViewController.delegate = self
         
         present(titlePopupViewController, animated: false)
+    }
+    
+    private func getUserAdventureInfo() {
+        NetworkService.shared.adventureService.getAdventureInfo { response in
+            switch response {
+            case .success(let data):
+                let nickname = data?.data.nickname ?? ""
+                let characterImgUrl = data?.data.characterImgUrl ?? ""
+                let characterName = data?.data.characterName ?? ""
+                let emblemName = data?.data.emblemName ?? ""
+
+                self.rootView.updateAdventureInfo(nickname: nickname, characterImgUrl: characterImgUrl, characterName: characterName, emblemName: emblemName)
+            default:
+                break
+            }
+        }
+    }
+    
+    private func getUserQuestInfo() {
+        NetworkService.shared.questService.getQuestInfo { response in
+            switch response {
+            case .success(let data):
+                let recentQuestName = data?.data.recent.questName ?? ""
+                let recentProgress = data?.data.recent.progress ?? Int()
+                let recentCompleteCondition = data?.data.recent.completeCondition ?? Int()
+                
+                let almostQuestName = data?.data.almost.questName ?? ""
+                let almostprogress = data?.data.almost.progress ?? Int()
+                let almostCompleteCondition = data?.data.almost.completeCondition ?? Int()
+                
+                self.rootView.updateQuestInfo(recentQuestName: recentQuestName, recentProgress: recentProgress, recentCompleteCondition: recentCompleteCondition, almostQuestName: almostQuestName, almostprogress: almostprogress, almostCompleteCondition: almostCompleteCondition)
+            default:
+                break
+            }
+        }
     }
 }
 

--- a/Offroad-iOS/Offroad-iOS/Presentation/Login/ViewController/LoginViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Login/ViewController/LoginViewController.swift
@@ -49,15 +49,23 @@ extension LoginViewController {
         AppleAuthManager.shared.loginSuccess = { user, identifyToken in
             print("login success!")
             
-            let userName = user.name ?? ""
-            let userEmail = user.email ?? ""
+            var userName = user.name ?? ""
+            var userEmail = user.email ?? ""
             let userIdentifyToken = identifyToken ?? ""
-
-            print("userName: \(userName)")
-            print("userEmail: \(userEmail)")
-            print("userIdentifyToken: \(userIdentifyToken)")
             
-            self.postTokenForAppleLogin(request: SocialLoginRequestDTO(socialPlatform: "APPLE", name: "조혜린", code: userIdentifyToken))
+            if let userDefaultName = UserDefaults.standard.string(forKey: "UserName") {
+                userName = userDefaultName
+            } else {
+                UserDefaults.standard.set(userName, forKey: "UserName")
+            }
+            
+            if let userDefaultEmail = UserDefaults.standard.string(forKey: "UserEmail") {
+                userEmail = userDefaultEmail
+            } else {
+                UserDefaults.standard.set(userEmail, forKey: "UserEmail")
+            }
+            
+            self.postTokenForAppleLogin(request: SocialLoginRequestDTO(socialPlatform: "APPLE", name: userName, code: userIdentifyToken))
         }
         
         AppleAuthManager.shared.loginFailure = { error in
@@ -70,8 +78,10 @@ extension LoginViewController {
             switch response {
             case .success(let data):
                 let accessToken = data?.data.accessToken ?? ""
+                let refreshToken = data?.data.refreshToken ?? ""
                 
                 UserDefaults.standard.set(accessToken, forKey: "AccessToken")
+                UserDefaults.standard.set(refreshToken, forKey: "RefreshToken")
             default:
                 break
             }

--- a/Offroad-iOS/Offroad-iOS/Presentation/TabBar/ViewControllers/OffroadTabBarController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/TabBar/ViewControllers/OffroadTabBarController.swift
@@ -101,7 +101,7 @@ extension OffroadTabBarController {
         ]
         
         setViewControllers(viewControllersArray, animated: false)
-        selectedIndex = 1
+        selectedIndex = 0
     }
     
     private func setTabBarButtons() {


### PR DESCRIPTION
### 🌴 작업한 브랜치
- #62

### ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->
HomeView 및 TitlePopupView에서 작동하는 모든 API를 연결하였습니다.

- 초기 홈 화면 로드 시 탐험 정보 불러오는 API
- 초기 홈 화면 로드 시 퀘스트 정보 불러오는 API
- 칭호 바꾸기 버튼 클릭 시 칭호 조회 API 
- 칭호 선택 후 "바꾸기" 버튼 클릭 시 변경된 칭호 서버에 전송하는 API

### ❗️PR Point
<!-- 부족했던 점 혹은 개선하고 싶은 방향이 있다면 얘기해주세요 -->

<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->

|칭호 바꾸기까지 전체적인 로직 실행 화면|칭호 변경 후 재접속 했을 시에 변경했던 칭호로 초기 로드되는 것 확인|
|:------------:|:--------:|
|https://github.com/user-attachments/assets/f2dd250d-d318-4220-9aac-81064c28d694|![image](https://github.com/user-attachments/assets/7bde351a-87cf-4f88-afde-c9b6958a68cb)|

|탐험 정보 GET 요청|퀘스트 정보 GET 요청|
|:------:|:--------:|
|<img width="199" alt="image" src="https://github.com/user-attachments/assets/2be94bd3-8a32-4306-ac7b-041896c7e57d">|<img width="164" alt="image" src="https://github.com/user-attachments/assets/b69071c7-3e30-454d-b162-454ab23fa3a1">|

|탐험 정보 응답|퀘스트 정보 응답|
|:------:|:------:|
|<img width="245" alt="image" src="https://github.com/user-attachments/assets/2ca5cb5f-d89f-4cab-813c-f59d35c0e6c2">|<img width="255" alt="image" src="https://github.com/user-attachments/assets/1eb690af-887d-4b0f-8412-d7df3ca9354f">|


- Resolved: #62
