### PR TITLE
[Feat] #92 - 백버튼 눌렀을 때 다음 버튼 비활성화

### DIFF
--- a/Offroad-iOS/Offroad-iOS/Presentation/Nickname/ViewController/NicknameViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Nickname/ViewController/NicknameViewController.swift
@@ -35,6 +35,11 @@ final class NicknameViewController: UIViewController {
         self.modalPresentationStyle = .fullScreen
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        nicknameView.nextButton.changeState(forState: .isDisabled)
+    }
 }
 
 extension NicknameViewController {


### PR DESCRIPTION
### 🌴 작업한 브랜치
- #92 


### ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->
뒤로가기를 눌렀을 때 다음 버튼이 계속 활성화되는 이슈 발생
viewWillApppear에 버튼 isDisabled 코드를 넣으면 VC로 이동할 때마다 버튼이 비활성화되고,
중복확인을 해야지만 버튼이 활성화된다.
<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### ❗️PR Point
<!-- 부족했던 점 혹은 개선하고 싶은 방향이 있다면 얘기해주세요 -->

<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->

|뷰|설명|
|:------:|:---:|
|        |     |


- Resolved: #92 
