### PR TITLE
[Fix] #108 - 다음 버튼 로직 QA 수정

### DIFF
--- a/Offroad-iOS/Offroad-iOS/Presentation/Nickname/ViewController/BirthViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Nickname/ViewController/BirthViewController.swift
@@ -42,8 +42,14 @@ final class BirthViewController: UIViewController {
         
         setupDelegate()
         setupAddTarget()
-
+        
         self.hideKeyboardWhenTappedAround()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        birthView.nextButton.changeState(forState: .isDisabled)
     }
     
     //MARK: - Private Method
@@ -56,6 +62,7 @@ final class BirthViewController: UIViewController {
         birthView.yearTextField.addTarget(self, action: #selector(textFieldEditingChanged(_:)), for: .editingChanged)
         birthView.monthTextField.addTarget(self, action: #selector(textFieldEditingChanged(_:)), for: .editingChanged)
         birthView.dayTextField.addTarget(self, action: #selector(textFieldEditingChanged(_:)), for: .editingChanged)
+        
         birthView.nextButton.addTarget(self, action: #selector(buttonToGenderVC), for: .touchUpInside)
         birthView.skipButton.addTarget(self, action: #selector(skipButtonTapped), for: .touchUpInside)
         
@@ -81,6 +88,15 @@ extension BirthViewController {
             birthView.yearTextField.layer.borderColor = UIColor.grayscale(.gray100).cgColor
             birthView.monthTextField.layer.borderColor = UIColor.grayscale(.gray100).cgColor
             birthView.dayTextField.layer.borderColor = UIColor.sub(.sub).cgColor
+        }
+        
+        if validateDate() &&
+            !(birthView.yearTextField.text?.isEmpty ?? true) &&
+            !(birthView.monthTextField.text?.isEmpty ?? true) &&
+            !(birthView.dayTextField.text?.isEmpty ?? true) {
+            birthView.nextButton.changeState(forState: .isEnabled)
+        } else {
+            birthView.nextButton.changeState(forState: .isDisabled)
         }
     }
     
@@ -126,13 +142,13 @@ extension BirthViewController {
     @objc private func executePop() {
         navigationController?.popViewController(animated: true)
     }
-
+    
     
     @objc func skipButtonTapped() {
         let genderViewController = GenderViewController(nickname: nickname, birthYear: nil, birthMonth: nil, birthDay: nil)
         self.navigationController?.pushViewController(genderViewController, animated: true)
     }
-
+    
     
     // 텍스트 필드 글자 수 제한
     func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
@@ -185,7 +201,7 @@ extension BirthViewController {
         
         return true
     }
-
+    
     private func isLeapYear(_ year: Int) -> Bool {
         return (year % 4 == 0 && year % 100 != 0) || year % 400 == 0
     }

--- a/Offroad-iOS/Offroad-iOS/Presentation/Nickname/ViewController/GenderViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Nickname/ViewController/GenderViewController.swift
@@ -50,7 +50,7 @@ final class GenderViewController: UIViewController {
         setupAddTarget()
         
         self.modalPresentationStyle = .fullScreen
-
+        
     }
     
     private func presentToNextVC() {
@@ -70,6 +70,11 @@ final class GenderViewController: UIViewController {
         navigationItem.rightBarButtonItem = UIBarButtonItem(customView: genderView.skipButton)
         genderView.skipButton.addTarget(self, action: #selector(nextButtonTapped), for: .touchUpInside)
     }
+    
+    private func updateNextButtonState() {
+        let isGenderSelected = genderView.maleButton.isSelected || genderView.femaleButton.isSelected || genderView.etcButton.isSelected
+        genderView.nextButton.changeState(forState: isGenderSelected ? .isEnabled : .isDisabled)
+    }
 }
 
 extension GenderViewController {
@@ -87,6 +92,7 @@ extension GenderViewController {
                 button.layer.borderColor = UIColor.grayscale(.gray100).cgColor
             }
         }
+        updateNextButtonState()
     }
     
     @objc func nextButtonTapped() {

--- a/Offroad-iOS/Offroad-iOS/Presentation/Nickname/ViewController/NicknameViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Nickname/ViewController/NicknameViewController.swift
@@ -56,6 +56,7 @@ extension NicknameViewController {
         
         if isTextFieldEmpty {
             nicknameView.textField.layer.borderColor = UIColor.grayscale(.gray100).cgColor
+            nicknameView.nextButton.changeState(forState: .isDisabled)
         } else {
             nicknameView.textField.layer.borderColor = UIColor.sub(.sub).cgColor
         }


### PR DESCRIPTION
### 🌴 작업한 브랜치
- #108 


### ✅ 작업한 내용
 중복확인 뷰 다음 버튼 로직 수정
 생년월일 통과 시 다음 버튼 활성화되도록 수정
 성별 버튼 비활성화 시 다음 버튼도 비활성화되도록 수정

```swift
private func updateNextButtonState() {
        let isGenderSelected = genderView.maleButton.isSelected || genderView.femaleButton.isSelected || genderView.etcButton.isSelected
        genderView.nextButton.changeState(forState: isGenderSelected ? .isEnabled : .isDisabled)
    }
```



### ❗️PR Point
<!-- 부족했던 점 혹은 개선하고 싶은 방향이 있다면 얘기해주세요 -->

<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->

|뷰|설명|
|:------:|:---:|
|        |     |


- Resolved: #108 
