### PR TITLE
[Fix] #105 - Keychain을 사용한 로그인 로직 수정

### DIFF
--- a/Offroad-iOS/Offroad-iOS.xcodeproj/project.pbxproj
+++ b/Offroad-iOS/Offroad-iOS.xcodeproj/project.pbxproj
@@ -84,6 +84,7 @@
 		D063E98C2C49328300434A09 /* SVGKImage+.swift in Sources */ = {isa = PBXBuildFile; fileRef = D063E98B2C49328200434A09 /* SVGKImage+.swift */; };
 		D063E98E2C49483000434A09 /* UIImageView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = D063E98D2C49483000434A09 /* UIImageView+.swift */; };
 		D063E9902C496EA500434A09 /* LottieAnimationView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = D063E98F2C496EA500434A09 /* LottieAnimationView+.swift */; };
+		D063E9922C57FE7400434A09 /* KeychainManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D063E9912C57FE7400434A09 /* KeychainManager.swift */; };
 		D06D26B92C3BA91900E79F25 /* Optician-Sans.otf in Resources */ = {isa = PBXBuildFile; fileRef = D06D26B82C3BA91900E79F25 /* Optician-Sans.otf */; };
 		D06D26C12C3D6A2A00E79F25 /* UILabel+.swift in Sources */ = {isa = PBXBuildFile; fileRef = D06D26C02C3D6A2A00E79F25 /* UILabel+.swift */; };
 		D06D26C32C3D835300E79F25 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D06D26C22C3D835300E79F25 /* HomeView.swift */; };
@@ -238,6 +239,7 @@
 		D063E98B2C49328200434A09 /* SVGKImage+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SVGKImage+.swift"; sourceTree = "<group>"; };
 		D063E98D2C49483000434A09 /* UIImageView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImageView+.swift"; sourceTree = "<group>"; };
 		D063E98F2C496EA500434A09 /* LottieAnimationView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LottieAnimationView+.swift"; sourceTree = "<group>"; };
+		D063E9912C57FE7400434A09 /* KeychainManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainManager.swift; sourceTree = "<group>"; };
 		D06D26B82C3BA91900E79F25 /* Optician-Sans.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Optician-Sans.otf"; sourceTree = "<group>"; };
 		D06D26C02C3D6A2A00E79F25 /* UILabel+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+.swift"; sourceTree = "<group>"; };
 		D06D26C22C3D835300E79F25 /* HomeView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
@@ -1042,6 +1044,7 @@
 			isa = PBXGroup;
 			children = (
 				D0E795FB2C447511005B47A5 /* AppleAuthManager.swift */,
+				D063E9912C57FE7400434A09 /* KeychainManager.swift */,
 			);
 			path = AuthManager;
 			sourceTree = "<group>";
@@ -1654,6 +1657,7 @@
 				4E0394E12C2AC059007F0517 /* NSObject+.swift in Sources */,
 				D0E796502C453B47005B47A5 /* AdventureService.swift in Sources */,
 				87E046942C3D2B38002D12C2 /* BirthViewController.swift in Sources */,
+				D063E9922C57FE7400434A09 /* KeychainManager.swift in Sources */,
 				D06D26E22C400C3800E79F25 /* TitleCollectionViewCell.swift in Sources */,
 				D0E796672C455467005B47A5 /* CharacterInfoResponseDTO.swift in Sources */,
 				4E03942D2C2A9DCE007F0517 /* AppDelegate.swift in Sources */,

--- a/Offroad-iOS/Offroad-iOS/Network/Adventure/DTO/Response/AdventureInfoResponseDTO.swift
+++ b/Offroad-iOS/Offroad-iOS/Network/Adventure/DTO/Response/AdventureInfoResponseDTO.swift
@@ -13,9 +13,9 @@ struct AdventureInfoResponseDTO: Codable {
 }
 
 struct AdventureInfoData: Codable {
-    let nickname: String
-    let baseImageUrl: String
+    let nickname: String?
+    let baseImageUrl: String?
     let motionImageUrl: String?
-    let characterName: String
+    let characterName: String?
     let emblemName: String
 }

--- a/Offroad-iOS/Offroad-iOS/Network/Base/BaseTargetType.swift
+++ b/Offroad-iOS/Offroad-iOS/Network/Base/BaseTargetType.swift
@@ -35,13 +35,13 @@ extension BaseTargetType {
         case .noneHeader:
             return .none
         case .accessTokenHeaderForGet:
-            guard let accessToken = UserDefaults.standard.string(forKey: "AccessToken") else { return [:] }
+            guard let accessToken = KeychainManager.shared.loadAccessToken() else { return [:] }
             
             let header = ["Authorization": "Bearer \(accessToken)"]
             
             return header
         case .accessTokenHeaderForGeneral:
-            guard let accessToken = UserDefaults.standard.string(forKey: "AccessToken") else { return [:] }
+            guard let accessToken = KeychainManager.shared.loadAccessToken() else { return [:] }
             
             let header = ["Content-Type": "application/json",
                           "Authorization": "Bearer \(accessToken)"]

--- a/Offroad-iOS/Offroad-iOS/Presentation/Character/ChoosingCharacter/ViewController/ChoosingCharacterPopupViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Character/ChoosingCharacter/ViewController/ChoosingCharacterPopupViewController.swift
@@ -17,7 +17,6 @@ final class ChoosingCharacterPopupViewController: UIViewController {
     private var myCharacterID = Int()
     private var myCharacterImage = String() {
         didSet {
-            UserDefaults.standard.set(true, forKey: "isLoggedIn")
             let completeChoosingCharacterViewController = CompleteChoosingCharacterViewController(characterImage: myCharacterImage)
             completeChoosingCharacterViewController.modalTransitionStyle = .crossDissolve
             completeChoosingCharacterViewController.modalPresentationStyle = .fullScreen

--- a/Offroad-iOS/Offroad-iOS/Presentation/Login/AuthManager/KeychainManager.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Login/AuthManager/KeychainManager.swift
@@ -1,0 +1,125 @@
+//
+//  KeychainManager.swift
+//  Offroad-iOS
+//
+//  Created by 조혜린 on 7/30/24.
+//
+
+import Foundation
+
+import Security
+
+final class KeychainManager {
+    
+    static let shared = KeychainManager()
+    
+    private init() {}
+    
+    func saveAccessToken(token: String) {
+        guard let tokenData = token.data(using: .utf8) else { return }
+        save(key: "accessToken", data: tokenData)
+    }
+
+    func saveRefreshToken(token: String) {
+        guard let tokenData = token.data(using: .utf8) else { return }
+        save(key: "refreshToken", data: tokenData)
+    }
+    
+    func loadAccessToken() -> String? {
+        guard let tokenData = read(key: "accessToken") else { return nil }
+        return String(data: tokenData, encoding: .utf8)
+    }
+
+    func loadRefreshToken() -> String? {
+        guard let tokenData = read(key: "refreshToken") else { return nil }
+        return String(data: tokenData, encoding: .utf8)
+    }
+    
+    func deleteAccessToken() {
+        delete(key: "accessToken")
+    }
+
+    func deleteRefreshToken() {
+        delete(key: "refreshToken")
+    }
+    
+    func saveUserName(name: String) {
+        guard let nameData = name.data(using: .utf8) else { return }
+        save(key: "userName", data: nameData)
+    }
+    
+    func loadUserName() -> String? {
+        guard let nameData = read(key: "userName") else { return nil }
+        return String(data: nameData, encoding: .utf8)
+    }
+    
+    func saveUserEmail(email: String) {
+        guard let emailData = email.data(using: .utf8) else { return }
+        save(key: "userEmail", data: emailData)
+    }
+    
+    func loadUserEmail() -> String? {
+        guard let emailData = read(key: "userEmail") else { return nil }
+        return String(data: emailData, encoding: .utf8)
+    }
+    
+    func saveUserId(id: String) {
+        guard let idData = id.data(using: .utf8) else { return }
+        save(key: "userId", data: idData)
+    }
+    
+    func checkLoginHistory() -> Bool {
+        guard read(key: "userId") != nil else { return false }
+        return true
+    }
+    
+    private func save(key: String, data: Data) {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: key,
+            kSecValueData as String: data
+        ]
+        
+        SecItemDelete(query as CFDictionary)
+        
+        let status = SecItemAdd(query as CFDictionary, nil)
+        
+        guard status == errSecSuccess else {
+            print("Error: \(status)")
+            return
+        }
+    }
+    
+    private func read(key: String) -> Data? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: key,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+        
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        
+        guard status == errSecSuccess else {
+            print("Error: \(status)")
+            return nil
+        }
+        
+        return result as? Data
+    }
+    
+    private func delete(key: String) {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: key
+        ]
+        
+        let status = SecItemDelete(query as CFDictionary)
+        
+        guard status == errSecSuccess else {
+            print("Error: \(status)")
+            return
+        }
+    }
+}

--- a/Offroad-iOS/Offroad-iOS/Presentation/Login/AuthManager/KeychainManager.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Login/AuthManager/KeychainManager.swift
@@ -63,16 +63,6 @@ final class KeychainManager {
         return String(data: emailData, encoding: .utf8)
     }
     
-    func saveUserId(id: String) {
-        guard let idData = id.data(using: .utf8) else { return }
-        save(key: "userId", data: idData)
-    }
-    
-    func checkLoginHistory() -> Bool {
-        guard read(key: "userId") != nil else { return false }
-        return true
-    }
-    
     private func save(key: String, data: Data) {
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,

--- a/Offroad-iOS/Offroad-iOS/Presentation/Login/ViewController/LoginViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Login/ViewController/LoginViewController.swift
@@ -52,11 +52,8 @@ extension LoginViewController {
             
             var userName = user.name ?? ""
             var userEmail = user.email ?? ""
-            let userId = user.userIdentifier
             let userIdentifyToken = identifyToken ?? ""
-            
-            KeychainManager.shared.saveUserId(id: userId)
-            
+                        
             if userName != "" {
                 if let userDefaultName = KeychainManager.shared.loadUserName() {
                     userName = userDefaultName
@@ -86,12 +83,11 @@ extension LoginViewController {
     }
     
     private func postTokenForAppleLogin(request: SocialLoginRequestDTO) {
-        NetworkService.shared.authService.postSocialLogin(body: request) { [weak self] response in
+        NetworkService.shared.authService.postSocialLogin(body: request) { response in
             switch response {
             case .success(let data):
                 let accessToken = data?.data.tokens.accessToken ?? ""
                 let refreshToken = data?.data.tokens.refreshToken ?? ""
-                let isAlreadyExist = data?.data.isAlreadyExist ?? Bool()
                 
                 KeychainManager.shared.saveAccessToken(token: accessToken)
                 KeychainManager.shared.saveRefreshToken(token: refreshToken)

--- a/Offroad-iOS/Offroad-iOS/Presentation/Login/ViewController/LoginViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Login/ViewController/LoginViewController.swift
@@ -92,21 +92,42 @@ extension LoginViewController {
                 KeychainManager.shared.saveAccessToken(token: accessToken)
                 KeychainManager.shared.saveRefreshToken(token: refreshToken)
 
-                if isAlreadyExist {
-                    let offroadTabBarController = OffroadTabBarController()
-                    
-                    offroadTabBarController.modalTransitionStyle = .crossDissolve
-                    offroadTabBarController.modalPresentationStyle = .fullScreen
-                    
-                    self?.present(offroadTabBarController, animated: true)
-                } else {
+                self.checkUserChoosingInfo()
+            default:
+                break
+            }
+        }
+    }
+    
+    private func checkUserChoosingInfo() {
+        NetworkService.shared.adventureService.getAdventureInfo(category: "NONE") { response in
+            switch response {
+            case .success(let data):
+                let userNickname = data?.data.nickname ?? ""
+                let characterName = data?.data.characterName ?? ""
+                                                
+                if userNickname == "" {
                     let nicknameViewController = NicknameViewController()
                     let navigationController = UINavigationController(rootViewController: nicknameViewController)
                     
-                    navigationController.modalTransitionStyle = .crossDissolve
                     navigationController.modalPresentationStyle = .fullScreen
+                    navigationController.modalTransitionStyle = .crossDissolve
                     
-                    self?.present(navigationController, animated: true)
+                    self.present(navigationController, animated: true)
+                } else if characterName == "" {
+                    let choosingCharacterViewController = ChoosingCharacterViewController()
+                    
+                    choosingCharacterViewController.modalPresentationStyle = .fullScreen
+                    choosingCharacterViewController.modalTransitionStyle = .crossDissolve
+                    
+                    self.present(choosingCharacterViewController, animated: true)
+                } else {
+                    let offroadTabBarViewController = OffroadTabBarController()
+                    
+                    offroadTabBarViewController.modalPresentationStyle = .fullScreen
+                    offroadTabBarViewController.modalTransitionStyle = .crossDissolve
+                    
+                    self.present(offroadTabBarViewController, animated: true)
                 }
             default:
                 break

--- a/Offroad-iOS/Offroad-iOS/Presentation/Login/ViewController/LoginViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Login/ViewController/LoginViewController.swift
@@ -51,26 +51,29 @@ extension LoginViewController {
             
             var userName = user.name ?? ""
             var userEmail = user.email ?? ""
+            let userId = user.userIdentifier
             let userIdentifyToken = identifyToken ?? ""
             
+            KeychainManager.shared.saveUserId(id: userId)
+            
             if userName != "" {
-                if let userDefaultName = UserDefaults.standard.string(forKey: "UserName") {
+                if let userDefaultName = KeychainManager.shared.loadUserName() {
                     userName = userDefaultName
                 } else {
-                    UserDefaults.standard.set(userName, forKey: "UserName")
+                    KeychainManager.shared.saveUserName(name: userName)
                 }
             } else {
-                userName = UserDefaults.standard.string(forKey: "UserName") ?? ""
+                userName = KeychainManager.shared.loadUserName() ?? ""
             }
             
             if userEmail != "" {
-                if let userDefaultEmail = UserDefaults.standard.string(forKey: "UserEmail") {
+                if let userDefaultEmail = KeychainManager.shared.loadUserEmail() {
                     userEmail = userDefaultEmail
                 } else {
-                    UserDefaults.standard.set(userEmail, forKey: "UserEmail")
+                    KeychainManager.shared.saveUserEmail(email: userEmail)
                 }
             } else {
-                userEmail = UserDefaults.standard.string(forKey: "UserEmail") ?? ""
+                userEmail = KeychainManager.shared.loadUserEmail() ?? ""
             }
             
             self.postTokenForAppleLogin(request: SocialLoginRequestDTO(socialPlatform: "APPLE", name: userName, code: userIdentifyToken))
@@ -89,9 +92,8 @@ extension LoginViewController {
                 let refreshToken = data?.data.tokens.refreshToken ?? ""
                 let isAlreadyExist = data?.data.isAlreadyExist ?? Bool()
                 
-                UserDefaults.standard.set(accessToken, forKey: "AccessToken")
-                UserDefaults.standard.set(refreshToken, forKey: "RefreshToken")
-                
+                KeychainManager.shared.saveAccessToken(token: accessToken)
+                KeychainManager.shared.saveRefreshToken(token: refreshToken)
 
                 if isAlreadyExist {
                     let offroadTabBarController = OffroadTabBarController()

--- a/Offroad-iOS/Offroad-iOS/Presentation/Login/ViewController/LoginViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Login/ViewController/LoginViewController.swift
@@ -48,6 +48,7 @@ extension LoginViewController {
         
         AppleAuthManager.shared.loginSuccess = { user, identifyToken in
             print("login success!")
+            UserDefaults.standard.set(true, forKey: "isLoggedIn")
             
             var userName = user.name ?? ""
             var userEmail = user.email ?? ""

--- a/Offroad-iOS/Offroad-iOS/Presentation/Splash/ViewController/SplashViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Splash/ViewController/SplashViewController.swift
@@ -27,9 +27,8 @@ final class SplashViewController: UIViewController {
         super.viewDidAppear(animated)
         
         if UserDefaults.standard.bool(forKey: "isLoggedIn") {
-            presentViewController(viewController: OffroadTabBarController())
-        }
-        else {
+            checkUserChoosingInfo()
+        } else {
             presentViewController(viewController: LoginViewController())
         }
     }
@@ -58,4 +57,25 @@ extension SplashViewController {
         }
     }
     
+    private func checkUserChoosingInfo() {
+        NetworkService.shared.adventureService.getAdventureInfo(category: "NONE") { response in
+            switch response {
+            case .success(let data):
+                let userNickname = data?.data.nickname ?? ""
+                let characterName = data?.data.characterName ?? ""
+                                                
+                if userNickname == "" {
+                    let nicknameViewController = NicknameViewController()
+                    let navigationController = UINavigationController(rootViewController: nicknameViewController)
+                    self.presentViewController(viewController: navigationController)
+                } else if characterName == "" {
+                    self.presentViewController(viewController: ChoosingCharacterViewController())
+                } else {
+                    self.presentViewController(viewController: OffroadTabBarViewController())
+                }
+            default:
+                break
+            }
+        }
+    }
 }

--- a/Offroad-iOS/Offroad-iOS/Presentation/Splash/ViewController/SplashViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Splash/ViewController/SplashViewController.swift
@@ -71,7 +71,7 @@ extension SplashViewController {
                 } else if characterName == "" {
                     self.presentViewController(viewController: ChoosingCharacterViewController())
                 } else {
-                    self.presentViewController(viewController: OffroadTabBarViewController())
+                    self.presentViewController(viewController: OffroadTabBarController())
                 }
             default:
                 break


### PR DESCRIPTION
### 🌴 작업한 브랜치
- #105 


### ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->
- 기존에 토큰, 사용자 이름 등을 UserDefault에 저장했던 방식을 Keychain을 사용하는 방식으로 변경하였습니다!
```
    private func postTokenForAppleLogin(request: SocialLoginRequestDTO) {
        NetworkService.shared.authService.postSocialLogin(body: request) { response in
            switch response {
            case .success(let data):
                let accessToken = data?.data.tokens.accessToken ?? ""
                let refreshToken = data?.data.tokens.refreshToken ?? ""
                
                KeychainManager.shared.saveAccessToken(token: accessToken)
                KeychainManager.shared.saveRefreshToken(token: refreshToken)
```
- 로그인 이력도 키체인에 저장하게 되면 앱을 삭제했다 다시 깔아도 자동 로그인이 되기 때문에 한 번의 로그인 과정을 거칠 수 있도록 UserDefault에 저장하였고, 다시 로그인을 하면 로그인 이력이 저장되게 됩니다.
```
        AppleAuthManager.shared.loginSuccess = { user, identifyToken in
            print("login success!")
            UserDefaults.standard.set(true, forKey: "isLoggedIn")
```

### ❗️PR Point
<!-- 부족했던 점 혹은 개선하고 싶은 방향이 있다면 얘기해주세요 -->
- 서버측과 논의하여 같은 API를 서로 다른 부분에 불러와서 활용하고 있는데(getAdventureInfo), 계속 이대로 가도 괜찮을지 의견 주시면 감사하겠습니다! 

- 스플래시와 로그인에서 사용하는 뷰 전환 로직이 같은데 이부분 코드에 대해 좀 더 고민이 필요할 것 같습니당 의견 주시면 감사하겠습니닷



- Resolved: #105 
