### PR TITLE
[Fix] #112 - 생년월일 자동이동 및 자동변환

### DIFF
--- a/Offroad-iOS/Offroad-iOS/Presentation/Nickname/ViewController/BirthViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Nickname/ViewController/BirthViewController.swift
@@ -42,7 +42,7 @@ final class BirthViewController: UIViewController {
         
         setupDelegate()
         setupAddTarget()
-
+        
         self.hideKeyboardWhenTappedAround()
     }
     
@@ -94,6 +94,29 @@ extension BirthViewController {
         if let text = textField.text, text.count > maxLength {
             textField.text = String(text.prefix(maxLength))
         }
+        //텍스트필드 자동 이동 구현
+        if textField == birthView.yearTextField {
+            if let yearText = birthView.yearTextField.text, yearText.count == 4, let year = Int(yearText), year >= 1920 {
+                birthView.monthTextField.becomeFirstResponder()
+            }
+        } else if textField == birthView.monthTextField {
+            if let monthText = birthView.monthTextField.text, monthText.count == 2, let month = Int(monthText), month >= 1 && month <= 12 {
+                birthView.dayTextField.becomeFirstResponder()
+            }
+        }
+    }
+    
+    //1자리수를 2자리수로 자동 변환
+    @objc internal func textFieldDidEndEditing(_ textField: UITextField) {
+        if textField == birthView.monthTextField {
+            if let monthText = birthView.monthTextField.text, monthText.count == 1 {
+                birthView.monthTextField.text = "0\(monthText)"
+            }
+        } else if textField == birthView.dayTextField {
+            if let dayText = birthView.dayTextField.text, dayText.count == 1 {
+                birthView.dayTextField.text = "0\(dayText)"
+            }
+        }
     }
     
     @objc func buttonToGenderVC(sender: UIButton) {
@@ -126,13 +149,13 @@ extension BirthViewController {
     @objc private func executePop() {
         navigationController?.popViewController(animated: true)
     }
-
+    
     
     @objc func skipButtonTapped() {
         let genderViewController = GenderViewController(nickname: nickname, birthYear: nil, birthMonth: nil, birthDay: nil)
         self.navigationController?.pushViewController(genderViewController, animated: true)
     }
-
+    
     
     // 텍스트 필드 글자 수 제한
     func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
@@ -185,7 +208,7 @@ extension BirthViewController {
         
         return true
     }
-
+    
     private func isLeapYear(_ year: Int) -> Bool {
         return (year % 4 == 0 && year % 100 != 0) || year % 400 == 0
     }
@@ -207,14 +230,15 @@ extension BirthViewController: UITextFieldDelegate {
     }
 }
 
-extension UIViewController {
-    func hideKeyboardWhenTappedAround() {
-        let tap = UITapGestureRecognizer(target: self, action: #selector(UIViewController.dismissKeyboard))
-        tap.cancelsTouchesInView = false
-        view.addGestureRecognizer(tap)
-    }
+extension BirthViewController {
     
     @objc func dismissKeyboard() {
         view.endEditing(true)
+    }
+    
+    func hideKeyboardWhenTappedAround() {
+        let tap = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
+        tap.cancelsTouchesInView = false
+        view.addGestureRecognizer(tap)
     }
 }


### PR DESCRIPTION
### 🌴 작업한 브랜치
- #112 


### ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->
"년"이 유효한 4자리수고 "월"이 유효한 2자리수일 때 다음 textfield로 자동 이동하도록 구현했다.
**@objc func textFieldDidEndEditing**를 통해 “월” textfield에서 “1”만 입력하고 다른 곳을 누르면 사용자 화면에 “01”로 바뀌도록 구현했다.

```swift
@objc internal func textFieldDidEndEditing(_ textField: UITextField) {
        if textField == birthView.monthTextField {
            if let monthText = birthView.monthTextField.text, monthText.count == 1 {
                birthView.monthTextField.text = "0\(monthText)"
            }
        } else if textField == birthView.dayTextField {
            if let dayText = birthView.dayTextField.text, dayText.count == 1 {
                birthView.dayTextField.text = "0\(dayText)"
            }
        }
    }
```



### ❗️PR Point
<!-- 부족했던 점 혹은 개선하고 싶은 방향이 있다면 얘기해주세요 -->

<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->

|뷰|설명|
|:------:|:---:|
|        |     |


- Resolved: #112 
