### PR TITLE
[Fix]#110 - skipButton에 커스텀 backButton 적용

### DIFF
--- a/Offroad-iOS/Offroad-iOS/Presentation/Nickname/ViewController/BirthViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Nickname/ViewController/BirthViewController.swift
@@ -169,6 +169,21 @@ extension BirthViewController {
     
     @objc func skipButtonTapped() {
         let genderViewController = GenderViewController(nickname: nickname, birthYear: nil, birthMonth: nil, birthDay: nil)
+        
+        let button = UIButton().then { button in
+            button.setImage(.backBarButton, for: .normal)
+            button.addTarget(self, action: #selector(executePop), for: .touchUpInside)
+            button.imageView?.contentMode = .scaleAspectFill
+            button.snp.makeConstraints { make in
+                make.width.equalTo(30)
+                make.height.equalTo(44)
+            }
+        }
+        
+        let customBackBarButton = UIBarButtonItem(customView: button)
+        customBackBarButton.tintColor = .black
+        genderViewController.navigationItem.leftBarButtonItem = customBackBarButton
+        
         self.navigationController?.pushViewController(genderViewController, animated: true)
     }
     


### PR DESCRIPTION
### 🌴 작업한 브랜치
- #110 


### ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->
skipButton을 눌렀을 때 커스텀한 "<" 버튼이 아니라 디폴트 백버튼 "<back"이 떠서 커스텀한 내용을 아래 코드처럼 skipButton 함수에도 넣었다.

```swift
 @objc func skipButtonTapped() {
        let genderViewController = GenderViewController(nickname: nickname, birthYear: nil, birthMonth: nil, birthDay: nil)
        
        let button = UIButton().then { button in
            button.setImage(.backBarButton, for: .normal)
            button.addTarget(self, action: #selector(executePop), for: .touchUpInside)
            button.imageView?.contentMode = .scaleAspectFill
            button.snp.makeConstraints { make in
                make.width.equalTo(30)
                make.height.equalTo(44)
            }
        }
        
        let customBackBarButton = UIBarButtonItem(customView: button)
        customBackBarButton.tintColor = .black
        genderViewController.navigationItem.leftBarButtonItem = customBackBarButton
        
        self.navigationController?.pushViewController(genderViewController, animated: true)
    }
```



### ❗️PR Point
<!-- 부족했던 점 혹은 개선하고 싶은 방향이 있다면 얘기해주세요 -->

<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->

|뷰|설명|
|:------:|:---:|
|        |     |


- Resolved: #110 
