### PR TITLE
[Fix/#114] 공원 탐험 성공 시 팝업이 뜨지 않는 문제 해결

### DIFF
--- a/Offroad-iOS/Offroad-iOS.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Offroad-iOS/Offroad-iOS.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -110,5 +110,5 @@
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/Offroad-iOS/Offroad-iOS/Presentation/QuestMap/ViewControllers/PlaceInfoPopupViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/QuestMap/ViewControllers/PlaceInfoPopupViewController.swift
@@ -135,6 +135,21 @@ extension PlaceInfoPopupViewController {
                         )
                         marker.hidden = false
                         self.dismiss(animated: false)
+                    } else {
+                        let questResultViewController = QuestResultViewController(
+                            result: .success,
+                            superViewController: tabBarController,
+                            placeInfo: placeInformation,
+                            imageURL: characterImageURL
+                        )
+                        questResultViewController.modalPresentationStyle = .formSheet
+                        guard let tabBarController = self.presentingViewController as? UITabBarController else {
+                            return
+                        }
+                        marker.hidden = false
+                        self.dismiss(animated: false) {
+                            tabBarController.present(questResultViewController, animated: true)
+                        }
                     }
                     return
                 }


### PR DESCRIPTION
### 🌴 작업한 브랜치
- #114 


### ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->
- 공원 탐험 성공 시 팝업이 뜨지 않는 문제를 해결하였습니다.
- ### 저도 드디어 Xcode 및 Swift 버전을 업데이트하여 Package.resolved의 버전이 3이 되었습니다!!!  
  - 파일 변경 내용 중 Package.resolved 파일이 있으며,  
    이는 제 Xcode의 버전이 올라가면서 2->3으로 바뀌며 생긴 현상으로, 충돌이 아니니 걱정 마세요!
<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### ❗️PR Point
<!-- 부족했던 점 혹은 개선하고 싶은 방향이 있다면 얘기해주세요 -->

<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->

|뷰|설명|
|:------:|:---:|
| <img src="https://github.com/user-attachments/assets/7b5e8558-22c4-4e53-b41b-82786bedab00" width="200"/> | <img src="https://github.com/user-attachments/assets/9d82e783-788c-4c51-93f1-4a6abf1b9249" width="200"/> |
| 공원 탐험에 성공했을 시 뜨는 팝업 | 홈 화면으로 이동 시 뜨는 로티 화면 |

- Resolved: #114 
