### PR TITLE
[Feat] #170 - 로그아웃 이벤트 구현

### DIFF
--- a/Offroad-iOS/Offroad-iOS/Presentation/MyPage/Settings/DeleteAccount/ViewController/DeleteAccountViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/MyPage/Settings/DeleteAccount/ViewController/DeleteAccountViewController.swift
@@ -64,17 +64,17 @@ extension DeleteAccountViewController {
         NetworkService.shared.profileService.postDeleteAccount(body: deleteAccountRequestDTO) { response in
             switch response {
             case .success:
-                print("회원 탈퇴 성공!!!!")
+                KeychainManager.shared.deleteAccessToken()
+                KeychainManager.shared.deleteRefreshToken()
                 UserDefaults.standard.set(false, forKey: "isLoggedIn")
                 
                 let splashViewController = SplashViewController()
                 
-                splashViewController.modalPresentationStyle = .overFullScreen
-                splashViewController.modalTransitionStyle = .crossDissolve
-                
-                
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-                    self.present(splashViewController, animated: true)
+                    if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+                       let window = windowScene.windows.first(where: { $0.isKeyWindow }) {
+                        window.rootViewController = splashViewController
+                    }
                 }
             default:
                 break

--- a/Offroad-iOS/Offroad-iOS/Presentation/MyPage/Settings/DeleteAccount/ViewController/DeleteAccountViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/MyPage/Settings/DeleteAccount/ViewController/DeleteAccountViewController.swift
@@ -71,10 +71,7 @@ extension DeleteAccountViewController {
                 let splashViewController = SplashViewController()
                 
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-                    if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-                       let window = windowScene.windows.first(where: { $0.isKeyWindow }) {
-                        window.rootViewController = splashViewController
-                    }
+                    UIWindow.current.rootViewController = splashViewController
                 }
             default:
                 break

--- a/Offroad-iOS/Offroad-iOS/Presentation/MyPage/Settings/Logout/ViewController/LogoutViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/MyPage/Settings/Logout/ViewController/LogoutViewController.swift
@@ -42,6 +42,18 @@ extension LogoutViewController {
     //MARK: - @Objc Func
     
     @objc private func yesButtonTapped() {
+        KeychainManager.shared.deleteAccessToken()
+        KeychainManager.shared.deleteRefreshToken()
+        UserDefaults.standard.set(false, forKey: "isLoggedIn")
+        
+        let splashViewController = SplashViewController()
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+            if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+               let window = windowScene.windows.first(where: { $0.isKeyWindow }) {
+                window.rootViewController = splashViewController
+            }
+        }
     }
     
     @objc private func noButtonTapped() {

--- a/Offroad-iOS/Offroad-iOS/Presentation/MyPage/Settings/Logout/ViewController/LogoutViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/MyPage/Settings/Logout/ViewController/LogoutViewController.swift
@@ -49,10 +49,7 @@ extension LogoutViewController {
         let splashViewController = SplashViewController()
         
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-            if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-               let window = windowScene.windows.first(where: { $0.isKeyWindow }) {
-                window.rootViewController = splashViewController
-            }
+            UIWindow.current.rootViewController = splashViewController
         }
     }
     

--- a/Offroad-iOS/Offroad-iOS/Presentation/Splash/ViewController/SplashViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Splash/ViewController/SplashViewController.swift
@@ -26,7 +26,7 @@ final class SplashViewController: UIViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         
-        if UserDefaults.standard.bool(forKey: "isLoggedIn") {
+        if UserDefaults.standard.bool(forKey: "isLoggedIn") && KeychainManager.shared.loadAccessToken() != nil {
             checkUserChoosingInfo()
         } else {
             presentViewController(viewController: LoginViewController())


### PR DESCRIPTION
### 🌴 작업한 브랜치
- #170

### ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->
로 그아웃 이벤트 구현

- 로그아웃 시 로그인 이력을 저장하는 Userdefault와 KeyChain에 저장되어있는 토큰 정보를 삭제하였습니다.
- 로그아웃 이후 스플래시 뷰로 이동하도록 하였습니다.


### 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->

|iPhone 15 Pro|
|:------:|
|<img src="https://github.com/user-attachments/assets/0b59d195-aa92-4059-a91e-8eab080892f7" width="393px"/>|


- Resolved: #170