### PR TITLE
[Feat] #175 - LineHeight %값으로 적용할 수 있도록 UILabel 확장 함수 추가

### DIFF
--- a/Offroad-iOS/Offroad-iOS/Global/Extensions/UILabel+.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Extensions/UILabel+.swift
@@ -62,5 +62,4 @@ extension UILabel {
         attributedText = attributeString
     }
     
-    
 }

--- a/Offroad-iOS/Offroad-iOS/Global/Extensions/UILabel+.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Extensions/UILabel+.swift
@@ -49,6 +49,8 @@ extension UILabel {
     
     /// 피그마에서 폰트를 표현할 때 Line Height가 설정된 경우 행간을 구현
     /// - Parameter percentage: 피그마상에서 폰트의 Line Height 값. 백분율로 표시된다.
+    ///
+    /// 피그마상에서 라벨의 높이를 지정한 경우, UILabel에서도 높이를 명시적으로 설정해야 함.
     func setLineHeight(percentage: CGFloat) {
         guard let text = text else { return }
         

--- a/Offroad-iOS/Offroad-iOS/Global/Extensions/UILabel+.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Extensions/UILabel+.swift
@@ -46,4 +46,21 @@ extension UILabel {
                                      range: NSRange(location: 0, length: attributeString.length))
         attributedText = attributeString
     }
+    
+    /// 피그마에서 폰트를 표현할 때 Line Height가 설정된 경우 행간을 구현
+    /// - Parameter percentage: 피그마상에서 폰트의 Line Height 값. 백분율로 표시된다.
+    func setLineHeight(percentage: CGFloat) {
+        guard let text = text else { return }
+        
+        let attributeString = NSMutableAttributedString(string: text)
+        let style = NSMutableParagraphStyle()
+        let lineSpacing = font.ascender * ((percentage-100)/100) + font.descender
+        style.lineSpacing = lineSpacing
+        attributeString.addAttribute(.paragraphStyle,
+                                     value: style,
+                                     range: NSRange(location: 0, length: attributeString.length))
+        attributedText = attributeString
+    }
+    
+    
 }


### PR DESCRIPTION
### 🌴 작업한 브랜치
- #175 


### ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->
- 스타일 가이드의 font에 Line Height가 설정되어 있을 경우, (행간이 백분율로 표시) 
지금까지는 디자이너로부터 얼마큼 `lineSpacing`을 주어야 하는지 그 값을 직접 받아 적용하였음.
 
- 디자이너로부터 매번 값을 전달받아 적용하기 번거로워 이를 개선하였음
  - 백분율 값을 이용할 수 있도록 추가적인 함수를 UILabel에 확장 구현하였습니다. 
  - 추가된 메서드의 이름은 `setLineHeight(percentage:)` 입니다.
  - UIFont의 속성 중 `ascender`와 `descender`를 이용하여 필요한 값을 계산하였습니다. 
<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### ❗️PR Point
<!-- 부족했던 점 혹은 개선하고 싶은 방향이 있다면 얘기해주세요 -->
맞게 적용했음에도 UILabel 상에서 텍스트의 세로 위치가 아주 약간 다르게 보이는 상황이 있습니다. 
이 경우에는 UILabel의 높이를 명시적으로 설정해 주어야 합니다. 
원래는 UILabel에서 자체적으로 자체 크기를 설정하는데, 
피그마에서 명시적으로 크기(특히 높이)를 설정할 경우 이를 코드에도 명시적으로 적용해 주면 
피그마와 완전히 동일한 UI를 구현할 수 있습니다. 

<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->

|뷰|설명|
|:------:|:---:|
|        |     |


- Resolved: #175 
