### PR TITLE
[Fix] #177 - setLineSpacing(spacing:), setLineHeight(percentage:) 함수 수정

### DIFF
--- a/Offroad-iOS/Offroad-iOS/Global/Extensions/UILabel+.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Extensions/UILabel+.swift
@@ -41,6 +41,9 @@ extension UILabel {
         let attributeString = NSMutableAttributedString(string: text)
         let style = NSMutableParagraphStyle()
         style.lineSpacing = spacing
+        style.alignment = textAlignment
+        style.lineBreakMode = lineBreakMode
+        style.lineBreakStrategy = lineBreakStrategy
         attributeString.addAttribute(.paragraphStyle,
                                      value: style,
                                      range: NSRange(location: 0, length: attributeString.length))
@@ -58,6 +61,9 @@ extension UILabel {
         let style = NSMutableParagraphStyle()
         let lineSpacing = font.ascender * ((percentage-100)/100) + font.descender
         style.lineSpacing = lineSpacing
+        style.alignment = textAlignment
+        style.lineBreakMode = lineBreakMode
+        style.lineBreakStrategy = lineBreakStrategy
         attributeString.addAttribute(.paragraphStyle,
                                      value: style,
                                      range: NSRange(location: 0, length: attributeString.length))


### PR DESCRIPTION
### 🌴 작업한 브랜치
- #177 


### ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->
setLineSpacing(spacing:), setLineHeight(percentage:) 함수에서, textAlignment등 과 같은 속성을 style에 적용하여 이를 attributedString에 적용하는 식으로 구현하여,
UILabel의 속성(textAlignment 등)에 값을 할당해도 적용하지 않는 문제 발생

즉, 어떤 UILabel인스턴스의 textAlignment 속성을 .center로 할당해도, setLineSpacing이나 setLineHeight와 같은 함수를 사용하면 textAlignment가 적용되지 않는 문제 발생. 

이를 해결하기 위해 확장 함수 내의 style 의 일부 속성에 UILabel의 속성값을 그대로 할당하였음. 
<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### ❗️PR Point
<!-- 부족했던 점 혹은 개선하고 싶은 방향이 있다면 얘기해주세요 -->

<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->

|뷰|설명|
|:------:|:---:|
|        |     |


- Resolved: #177 
