### PR TITLE
[Fix] #190 - QA 수정사항 반영

### DIFF
--- a/Offroad-iOS/Offroad-iOS/Network/Place/DTO/Responce/RegisteredPlaceResponseDTO.swift
+++ b/Offroad-iOS/Offroad-iOS/Network/Place/DTO/Responce/RegisteredPlaceResponseDTO.swift
@@ -22,7 +22,9 @@ struct RegisteredPlaceInfo: Codable {
     let address: String
     let shortIntroduction: String
     let placeCategory: String
+    let placeArea: String
     let latitude: Double
     let longitude: Double
     let visitCount: Int
+    let categoryImageUrl: String
 }

--- a/Offroad-iOS/Offroad-iOS/Presentation/PlaceList/Models/PlaceListDummyDataManager.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/PlaceList/Models/PlaceListDummyDataManager.swift
@@ -17,9 +17,11 @@ class PlaceListDummyDataManager {
             address: "경기도 파주시 지목로 143",
             shortIntroduction: "파주 브런치 맛집 대형 카페",
             placeCategory: "CAFFE",
+            placeArea: "시간이 머무는 마을",
             latitude: 0,
             longitude: 0,
-            visitCount: 332
+            visitCount: 332,
+            categoryImageUrl: "https://offroad.s3.ap-northeast-2.amazonaws.com/images/place/caffe.svg?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20240919T144138Z&X-Amz-SignedHeaders=host&X-Amz-Expires=300&X-Amz-Credential=AKIA2UC3FF46A2F5JIHY%2F20240919%2Fap-northeast-2%2Fs3%2Faws4_request&X-Amz-Signature=5a80937ea9f197d6757f6de12c7d5841e9753a08acebcde754d1b093b000ec9a"
         )
         
         let cameloYeonNam = RegisteredPlaceInfo(
@@ -28,9 +30,11 @@ class PlaceListDummyDataManager {
             address: "서울 마포구 연희로1길 57 1.5층",
             shortIntroduction: "다양한 파스타와 리조또가 있는 연남동 양식 맛집",
             placeCategory: "RESTAURANT",
+            placeArea: "트렌트의 시작점",
             latitude: 0,
             longitude: 0,
-            visitCount: 332
+            visitCount: 332,
+            categoryImageUrl: "https://offroad.s3.ap-northeast-2.amazonaws.com/images/place/restaurant.svg?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20240919T144138Z&X-Amz-SignedHeaders=host&X-Amz-Expires=300&X-Amz-Credential=AKIA2UC3FF46A2F5JIHY%2F20240919%2Fap-northeast-2%2Fs3%2Faws4_request&X-Amz-Signature=b086c4f00111420465ac09ecc942eede74a7f32a46994349e258a503983b01c7"
         )
         
         let cafeDelcamino = RegisteredPlaceInfo(
@@ -39,9 +43,11 @@ class PlaceListDummyDataManager {
             address: "서울 마포구 독막로15길 3-14 2층",
             shortIntroduction: "시원한 커피와 디저트, 그리고 편안한 빈티지 스타일을 즐길 수 있는 카페",
             placeCategory: "CAFFE",
+            placeArea: "시간이 머무는 마을",
             latitude: 0,
             longitude: 0,
-            visitCount: 332
+            visitCount: 332,
+            categoryImageUrl: "https://offroad.s3.ap-northeast-2.amazonaws.com/images/place/caffe.svg?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20240919T144138Z&X-Amz-SignedHeaders=host&X-Amz-Expires=300&X-Amz-Credential=AKIA2UC3FF46A2F5JIHY%2F20240919%2Fap-northeast-2%2Fs3%2Faws4_request&X-Amz-Signature=5a80937ea9f197d6757f6de12c7d5841e9753a08acebcde754d1b093b000ec9a"
         )
         
         let YanghwajinPark = RegisteredPlaceInfo(
@@ -50,9 +56,11 @@ class PlaceListDummyDataManager {
             address: "서울 마포구 토정로 2 양화진공영주차장",
             shortIntroduction: "조선시대 당시 한강을 보호하기 위해 지어진 양화진이 위치한 역사공원",
             placeCategory: "PARK",
+            placeArea: "시간이 머무는 마을",
             latitude: 0,
             longitude: 0,
-            visitCount: 332
+            visitCount: 332,
+            categoryImageUrl: "https://offroad.s3.ap-northeast-2.amazonaws.com/images/place/park.svg?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20240919T144138Z&X-Amz-SignedHeaders=host&X-Amz-Expires=300&X-Amz-Credential=AKIA2UC3FF46A2F5JIHY%2F20240919%2Fap-northeast-2%2Fs3%2Faws4_request&X-Amz-Signature=c36d2725725134b3b40d6a16131863e3158ed17ea9a322ddf9a56763e35a8bc7"
         )
         
         let hanyangDoseongMuseum = RegisteredPlaceInfo(
@@ -61,9 +69,11 @@ class PlaceListDummyDataManager {
             address: "서울 종로구 율곡로 283 1~3층",
             shortIntroduction: "조선시대부터 현재에 이르기까지 한양도성의 역사와 문화를 담은 박물관",
             placeCategory: "CULTURE",
+            placeArea: "시간이 머무는 마을",
             latitude: 0,
             longitude: 0,
-            visitCount: 332
+            visitCount: 332,
+            categoryImageUrl: "https://offroad.s3.ap-northeast-2.amazonaws.com/images/place/culture.svg?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20240919T144138Z&X-Amz-SignedHeaders=host&X-Amz-Expires=300&X-Amz-Credential=AKIA2UC3FF46A2F5JIHY%2F20240919%2Fap-northeast-2%2Fs3%2Faws4_request&X-Amz-Signature=f6497ed2205d6306643e72b7dc525df80e9fe5ceb5883c2e6297201905a1cd25"
         )
         
         let jamsilSportsComplex = RegisteredPlaceInfo(
@@ -72,9 +82,11 @@ class PlaceListDummyDataManager {
             address: "서울 송파구 올림픽로 25 서울종합운동장",
             shortIntroduction: "서울 올림픽대회의 개·폐회식과 육상, 축구 등을 치룬 바 있는 역사적 의미를 갖는 경기장",
             placeCategory: "SPORTS",
+            placeArea: "시간이 머무는 마을",
             latitude: 0,
             longitude: 0,
-            visitCount: 2024
+            visitCount: 2024,
+            categoryImageUrl: "https://offroad.s3.ap-northeast-2.amazonaws.com/images/place/sports.svg?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20240919T144138Z&X-Amz-SignedHeaders=host&X-Amz-Expires=300&X-Amz-Credential=AKIA2UC3FF46A2F5JIHY%2F20240919%2Fap-northeast-2%2Fs3%2Faws4_request&X-Amz-Signature=e866ab43a815a43c886c43eceeffb2446d57c6cbc62ae6e8df5cacac727190b1"
         )
         
         let array = [brickRouge, cameloYeonNam, cafeDelcamino, YanghwajinPark, hanyangDoseongMuseum, jamsilSportsComplex]

--- a/Offroad-iOS/Offroad-iOS/Presentation/PlaceList/ViewControllers/PlaceListViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/PlaceList/ViewControllers/PlaceListViewController.swift
@@ -39,7 +39,7 @@ class PlaceListViewController: UIViewController {
         setupCollectionView()
         setupDelegates()
         
-        reloadCollectionViewData(limit: 100, isBounded: true)
+        reloadCollectionViewData(limit: 100, isBounded: false)
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -112,6 +112,7 @@ extension PlaceListViewController {
     private func reloadCollectionViewData(coordinate: CLLocationCoordinate2D? = nil, limit: Int, isBounded: Bool) {
         guard let currentCoordinate else {
             print("현재 위치 좌표를 구할 수 없음")
+            // 위치 정보 불러올 수 없을 경우 피드백 논의하기
             return
         }
         let placeRequestDTO = RegisteredPlaceRequestDTO(
@@ -196,7 +197,6 @@ extension PlaceListViewController: UICollectionViewDataSource {
 extension PlaceListViewController: UICollectionViewDelegate {
     
     func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool {
-        
         let animator = UIViewPropertyAnimator(duration: 0.3, dampingRatio: 1)
         animator.addAnimations {
             if collectionView.indexPathsForSelectedItems?.contains(indexPath) ?? false {

--- a/Offroad-iOS/Offroad-iOS/Presentation/PlaceList/Views/PlaceCollectionViewCell.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/PlaceList/Views/PlaceCollectionViewCell.swift
@@ -274,6 +274,7 @@ extension PlaceCollectionViewCell {
     //MARK: - Func
     
     func configureCell(with place: RegisteredPlaceInfo, showingVisitingCount: Bool) {
+        placeSectionLabel.text = place.placeArea
         placeNameLabel.text = place.name
         addressLabel.text = place.address
         placeDescriptionLabel.text = place.shortIntroduction
@@ -305,8 +306,6 @@ extension PlaceCollectionViewCell {
         default:
             return
         }
-        
-        placeSectionLabel.text = "장소 섹션 라벨(임시)"
         
         contentView.layoutIfNeeded()
     }

--- a/Offroad-iOS/Offroad-iOS/Presentation/QuestList/Views/QuestListCollectionViewCell.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/QuestList/Views/QuestListCollectionViewCell.swift
@@ -231,10 +231,10 @@ extension QuestListCollectionViewCell {
         questProgressLabel.text = "달성도 (\(quest.currentCount)/\(quest.totalCount))"
         questProgressLabel.highlightText(targetText: "달성도", color: .grayscale(.gray400))
         
-        questDescriptionLabel.text = quest.description
+        questDescriptionLabel.text = quest.description == "" ? "데이터 없음" : quest.description
         
-        questClearConditionLabel.text = quest.requirement
-        questRewardDescriptionLabel.text = quest.reward
+        questClearConditionLabel.text = quest.requirement == "" ? "데이터 없음" : quest.requirement
+        questRewardDescriptionLabel.text = quest.reward == "" ? "데이터 없음" : quest.reward
         
         contentView.layoutIfNeeded()
     }

--- a/Offroad-iOS/Offroad-iOS/Presentation/QuestList/Views/QuestListCollectionViewCell.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/QuestList/Views/QuestListCollectionViewCell.swift
@@ -173,6 +173,7 @@ extension QuestListCollectionViewCell {
         
         checkBoxImageView.snp.makeConstraints { make in
             make.centerY.equalTo(questClearConditionLabel)
+            make.top.greaterThanOrEqualTo(questInfoView.snp.top).inset(9)
             make.leading.equalToSuperview().inset(12)
             make.size.equalTo(25)
         }
@@ -180,6 +181,7 @@ extension QuestListCollectionViewCell {
         giftBoxImageVIew.snp.makeConstraints { make in
             make.top.greaterThanOrEqualTo(checkBoxImageView.snp.bottom).offset(4)
             make.leading.equalToSuperview().inset(12)
+            make.bottom.lessThanOrEqualTo(questInfoView.snp.bottom).inset(9)
             make.size.equalTo(25)
         }
 


### PR DESCRIPTION
### 🌴 작업한 브랜치
- #190


### ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->
- QA 수정사항은 반영하였습니다. 
  - 장소 목록 뷰
    - 장소 구역(예, 시간이 머무는 마을) 표시 라벨의 데이터를 받아올 수 있도록 구현하였습니다.   
    (기존에는 서버 응답 데이터에 해당 데이터가 없어 "장소 섹션 라벨(임시)" 라는 문자열리터럴을 입력했었습니다.)
  - 퀘스트 목록 뷰
    - 퀘스트 목록 뷰의 셀 내부 UI를 개선하였습니다.   
    (데이터가 없을 경우 셀의 내부가 좁게 보이는 현상을 개선하였습니다. 
    - 퀘스트 목록 뷰의 셀에 데이터가 없을 경우 "데이터 없음" 데이터를 띄우도록 empty case를 추가하였습니다.   
    (현재 서버의 응답 데이터에 퀘스트 설명, 달성 조건, 보상 등이 빈 문자열로 오기 때문에, 해당 기능을 추가했음)
    empty case와 관련해서는 추후 기획-디자인 논의가 끝난 후 정해지는 내용에 따라 변경될 가능성이 높습니다. 현재 임시로 구현한 것으로 봐 주시면 될 것 같습니다. 
<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### ❗️PR Point
<!-- 부족했던 점 혹은 개선하고 싶은 방향이 있다면 얘기해주세요 -->
- main 브랜치의 최신사항을 반영하는과정에서 커밋 이름에 [Merge/# 190] 이 들어가야 하는 걸 실수로 [Merge/# 174] 라고 들어가 버렸네요..(d3483316a33ae07577caefe2a82d34371be9f4ac)
ㅠ__ㅠ  
헷갈리지 마시라고 알려드립니다...!


<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->

|    |  장소 목록 뷰 | 퀘스트 목록 뷰  |
|:--:|:---:|:---:|
| 뷰 |  <img src="https://github.com/user-attachments/assets/3de9b6e9-1ee1-43bb-8ac8-99c2f2b450e7" width=200>  |  <img src="https://github.com/user-attachments/assets/39f9a2a6-0ac1-419c-ba34-c264998d8844" width=200> |
| 설명 | 장소 구역 라벨 표시 | 셀 UI 개선 |


- Resolved: #190 
