### PR TITLE
[Feat] #204 - 쿠폰 적용 API 연결(시도) 및 연속 팝업 구현

### DIFF
--- a/Offroad-iOS/Offroad-iOS/Global/Components/PopupController/OFRAlertController.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Components/PopupController/OFRAlertController.swift
@@ -267,4 +267,8 @@ extension OFRAlertController {
         configure(defaultTextField)
     }
     
+    func configureMessageLabel(_ configure: (UILabel) -> Void) {
+        configure(self.backgroundView.alertView.messageLabel)
+    }
+    
 }

--- a/Offroad-iOS/Offroad-iOS/Global/Components/PopupController/OFRAlertController.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Components/PopupController/OFRAlertController.swift
@@ -73,6 +73,10 @@ class OFRAlertController: UIViewController {
         backgroundView.alertView.buttons
     }
     
+    var xButton: UIButton {
+        backgroundView.alertView.closeButton
+    }
+    
     //MARK: - Life Cycle
     
     private override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {

--- a/Offroad-iOS/Offroad-iOS/Global/Components/PopupController/OFRAlertController.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Components/PopupController/OFRAlertController.swift
@@ -119,10 +119,12 @@ class OFRAlertController: UIViewController {
         showKeyboardIfNeeded()
     }
     
-    override func dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {
+    override func dismiss(animated: Bool, completion: (() -> Void)? = nil) {
         view.endEditing(true)
-        hideAlertView {
-            super.dismiss(animated: flag, completion: completion)
+        if animated {
+            hideAlertView { super.dismiss(animated: false, completion: completion) }
+        } else {
+            super.dismiss(animated: false, completion: completion)
         }
     }
     
@@ -139,7 +141,9 @@ extension OFRAlertController {
     
     @objc private func alertButtonTapped(sender: OFRAlertButton) {
         print(#function)
-        sender.action.handler(sender.action)
+        self.dismiss(animated: true) {
+            sender.action.handler(sender.action)
+        }
     }
     
     @objc private func keyboardWillShow(_ notification: Notification) {

--- a/Offroad-iOS/Offroad-iOS/Global/Components/PopupController/OFRAlertController.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Components/PopupController/OFRAlertController.swift
@@ -19,7 +19,7 @@ class OFRAlertController: UIViewController {
     
     private let transitionDelegate = ZeroDurationTransitionDelegate()
     private let presentationAnimator = UIViewPropertyAnimator(duration: 0.4, dampingRatio: 0.7)
-    private let dismissalAnimator = UIViewPropertyAnimator(duration: 0.3, dampingRatio: 1)
+    private let dismissalAnimator = UIViewPropertyAnimator(duration: 0.2, dampingRatio: 1)
     
     /**
      팝업의 제목
@@ -136,7 +136,7 @@ extension OFRAlertController {
     //MARK: - @objc Func
     
     @objc private func closeButtonDidTapped() {
-        dismiss(animated: false)
+        dismiss(animated: true)
     }
     
     @objc private func alertButtonTapped(sender: OFRAlertButton) {

--- a/Offroad-iOS/Offroad-iOS/Network/Coupon/CouponService.swift
+++ b/Offroad-iOS/Offroad-iOS/Network/Coupon/CouponService.swift
@@ -47,6 +47,7 @@ final class CouponService: BaseService, CouponServiceProtocol {
                     statusCode: response.statusCode,
                     data: response.data
                 )
+                completion(networkResult)
             case .failure(let error):
                 print(error.localizedDescription)
             }

--- a/Offroad-iOS/Offroad-iOS/Network/Coupon/DTO/Response/CouponListResponseDTO.swift
+++ b/Offroad-iOS/Offroad-iOS/Network/Coupon/DTO/Response/CouponListResponseDTO.swift
@@ -23,7 +23,6 @@ struct AvailableCoupon: Codable {
     let couponImageUrl: String
     let description: String
     let isNewGained: Bool
-    let placeId: Int
 }
 
 struct UsedCoupon: Codable {

--- a/Offroad-iOS/Offroad-iOS/Presentation/MyPage/Coupon/View/AcquiredCouponView.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/MyPage/Coupon/View/AcquiredCouponView.swift
@@ -45,7 +45,7 @@ class AcquiredCouponView: UIView {
     }
     
     lazy var collectionViewForAvailableCoupons = UICollectionView(frame: .zero, collectionViewLayout: collectionViewLayoutForAvailableCoupons).then {
-        $0.register(AvailableCouponCell.self, forCellWithReuseIdentifier: "AvailableCouponCell")
+        $0.register(AvailableCouponCell.self, forCellWithReuseIdentifier: AvailableCouponCell.className)
         $0.backgroundColor = .clear
         $0.showsVerticalScrollIndicator = false
     }
@@ -63,7 +63,7 @@ class AcquiredCouponView: UIView {
     }
     
     lazy var collectionViewForUsedCoupons = UICollectionView(frame: .zero, collectionViewLayout: collectionViewLayoutForUsedCoupons).then {
-        $0.register(UsedCouponCell.self, forCellWithReuseIdentifier: "UsedCouponCell")
+        $0.register(UsedCouponCell.self, forCellWithReuseIdentifier: UsedCouponCell.className)
         $0.backgroundColor = .clear
         $0.showsVerticalScrollIndicator = false
     }

--- a/Offroad-iOS/Offroad-iOS/Presentation/MyPage/Coupon/ViewController/AcquiredCouponViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/MyPage/Coupon/ViewController/AcquiredCouponViewController.swift
@@ -45,7 +45,7 @@ class AcquiredCouponViewController: UIViewController {
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
         
-        reloadCollectionViews()
+        fetchAcquiredCouponsData()
     }
 }
 

--- a/Offroad-iOS/Offroad-iOS/Presentation/MyPage/Coupon/ViewController/AcquiredCouponViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/MyPage/Coupon/ViewController/AcquiredCouponViewController.swift
@@ -74,6 +74,9 @@ extension AcquiredCouponViewController{
     private func fetchAcquiredCouponsData() {
         NetworkService.shared.couponService.getAcquiredCouponList { [weak self] result in
             guard let self else { return }
+            
+            let alertController: OFRAlertController
+            let action = OFRAlertAction(title: "확인", style: .default) { _ in return }
             switch result {
             case .success(let response):
                 guard let response else {
@@ -83,7 +86,10 @@ extension AcquiredCouponViewController{
                 self.usedCoupons = response.data.usedCoupons
                 self.reloadCollectionViews()
             default:
-                fatalError()
+                alertController = OFRAlertController(title: "에러", message: "\(result)", type: .normal)
+                alertController.addAction(action)
+                alertController.xButton.isHidden = true
+                self.present(alertController, animated: true)
             }
         }
     }

--- a/Offroad-iOS/Offroad-iOS/Presentation/MyPage/Coupon/ViewController/CouponDetailViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/MyPage/Coupon/ViewController/CouponDetailViewController.swift
@@ -62,17 +62,16 @@ class CouponDetailViewController: UIViewController {
     
     private func redeemCoupon(code: String) {
         let requestDTO = CouponRedemptionRequestDTO(code: code, couponId: coupon.id)
-        NetworkService.shared.couponService.postCouponRedemption(
-            // 현재 result를 받아오지 못하고, 서버에서 404에러를 응답함. (없는 장소 Id라고 뜸)
-            body: requestDTO) { result in
-                switch result {
-                case .success(let response):
-                    guard let response else { return }
-                    print("쿠폰 사용 결과: " + "\(response.data.success)")
-                default:
-                    return
-                }
+        // 현재 result를 받아오지 못하고, 서버에서 404에러를 응답함. (없는 장소 Id라고 뜸)
+        NetworkService.shared.couponService.postCouponRedemption(body: requestDTO) { result in
+            switch result {
+            case .success(let response):
+                guard let response else { return }
+                print("쿠폰 사용 결과: " + "\(response.data.success)")
+            default:
+                return
             }
+        }
     }
     
 }
@@ -86,20 +85,17 @@ extension CouponDetailViewController {
     }
     
     @objc private func didTapUseButton() {
+        
         let alertController = OFRAlertController(title: "쿠폰 사용", message: "코드를 입력 후 사장님에게 보여주세요", type: .textField)
         let okAction = OFRAlertAction(title: "확인", style: .default) { action in
-            print("확인 버튼 눌림")
-            alertController.dismiss(animated: true) { [weak self] in
-                guard let self else { return }
-                let alertController = OFRAlertController(title: "사용 완료", message: "쿠폰 사용이 완료되었어요!", type: .normal)
-                let action = OFRAlertAction(title: "확인", style: .default) { action in
-                    alertController.dismiss(animated: true)
-                }
-                alertController.addAction(action)
-                self.present(alertController, animated: true)
-            }
-            return
+            
+            // 여기서 쿠폰 사용 API 호출하기
+            let alertController = OFRAlertController(title: "사용 완료", message: "쿠폰 사용이 완료되었어요!", type: .normal)
+            let action = OFRAlertAction(title: "확인", style: .default) { _ in return }
+            alertController.addAction(action)
+            self.present(alertController, animated: true)
         }
+        
         alertController.addAction(okAction)
         alertController.showsKeyboardWhenPresented = true
         alertController.configureDefaultTextField { textField in

--- a/Offroad-iOS/Offroad-iOS/Presentation/MyPage/Coupon/ViewController/CouponDetailViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/MyPage/Coupon/ViewController/CouponDetailViewController.swift
@@ -70,8 +70,7 @@ class CouponDetailViewController: UIViewController {
         
         couponCodeInputSubject.subscribe { [weak self] codeInput in
             guard let self else { return }
-            //self.redeemCoupon(code: codeInput)
-            self.redeemCouponTest(code: codeInput)
+            self.redeemCoupon(code: codeInput)
         }.disposed(by: disposeBag)
         
         
@@ -97,10 +96,8 @@ class CouponDetailViewController: UIViewController {
         }.disposed(by: disposeBag)
     }
     
-    /// 현재는 서버 문제가 해결될 때까지 호출될 일이 없으므로, 어디에서도 불리지 않음. 서버 문제가 해결될 때 까지는 추가로 구현한 redeemCouponTest 함수를 이용
     private func redeemCoupon(code: String) {
         let requestDTO = CouponRedemptionRequestDTO(code: code, couponId: coupon.id)
-        // 현재 result를 받아오지 못하고, 서버에서 404에러를 응답함. (없는 장소 Id라고 뜸)
         NetworkService.shared.couponService.postCouponRedemption(body: requestDTO) { [weak self] result in
             guard let self else { return }
             
@@ -109,14 +106,17 @@ class CouponDetailViewController: UIViewController {
                 guard let response else { return }
                 print("쿠폰 사용 결과: " + "\(response.data.success)")
                 self.afterCouponRedemptionSubject.onNext(response.data.success)
-                //completion(response.data.success)
             default:
                 return
             }
         }
     }
     
-    /// 테스트용 함수 코드가 0000일 경우 0.3초 후에 응답값 true, 그렇지 않을 경우 응답값 false.
+    /**
+     테스트용 함수.
+     
+     코드가 0000일 경우 0.3초 후에 응답값 true, 그렇지 않을 경우 응답값 false.
+     */
     private func redeemCouponTest(code: String) {
         DispatchQueue.global().asyncAfter(deadline: .now() + 0.3) { [weak self] in
             guard let self else { return }


### PR DESCRIPTION
### 🌴 작업한 브랜치
- #204 


### ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->
- ~서버에서 쿠폰 적용 API 수정이 완료되지 않아, 쿠폰 적용 API를 붙이지는 못했고,   
대신 테스트용 함수를 추가하여 이를 바탕으로 쿠폰 사용 로직을 구현하였습니다.~
-> 정기 회의 후 쿠폰 적용 API의 수정된 내용을 반영하였습니다. 
- 팝업이 사라질 때 로직을 일부 수정하였습니다. 
  - 버튼이 눌리면 실행될 함수(클로저)를 dismiss가 완료된 후의 시점으로 변경  
  (기존에는 dismiss 되기 전에 실행했음)
  - 팝업이 사라지는 애니메이션 속도를 수정하였습니다. 
- 쿠폰 번호 입력을 누르고 서버 통신(지금은 테스트 함수)을 통해 다음 팝업으로 피드백이 뜨는 과정을 RxSwift로 구현하였습니다. 
  - 이 부분은 추후 개선하여 MVVM 아키텍처로 구현하면 좋을 것 같습니다. 
<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### ❗️PR Point
<!-- 부족했던 점 혹은 개선하고 싶은 방향이 있다면 얘기해주세요 -->
- ~테스트용으로 만든 거라, 현재는 쿠폰 코드가 0000일 경우 사용이 완료되었다고 뜨고,   
0000이 아닌 다른 모든 코드는 사용이 실패했다고 뜹니다. 잘 작동되는지 확인 바랍니다.~
-> 정기 회의 후 쿠폰 적용 API 변경된 부분 적용하여 0000을 입력해도 실패했다고 뜹니다. 정확한 쿠폰 코드를 입력해야 합니다. 
- 쿠폰 사용이 실패했을 때 메시지 옆에 뜨는 느낌표 모양의 아이콘은 구현하지 못했습니다.  
이는 추후 팝업 틀이 완료되면 반영하여 구현하면 좋을 것 같습니다. 
<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->

|뷰|설명|
|:------:|:---:|
|  <img src="https://github.com/user-attachments/assets/efe84461-94d3-48ad-9910-19e2e27a38cd" width=250>   |     |


- Resolved: #204 
