### PR TITLE
[Feat] #222 - 기기 화면 비율에 따른 분기처리

### DIFF
--- a/Offroad-iOS/Offroad-iOS/Global/Extensions/UIScreen+.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Extensions/UIScreen+.swift
@@ -22,11 +22,8 @@ extension UIScreen {
     /// screen의 긴 변의 길이가 짧은 변의 길이의 두 배가 넘는 지의 여부를 계산하는 변수.
     /// 사용 중인 기기가 홈 버튼이 있는 기종인지 여부를 판단하기 위해 사용할 수 있음.
     var isAspectRatioTall: Bool {
-        let isVerticalDirection: Bool = bounds.size.height > bounds.size.width
-        let longSideLength: CGFloat = isVerticalDirection ? bounds.size.height : bounds.size.width
-        let shortSideLength: CGFloat = isVerticalDirection ? bounds.size.width : bounds.size.height
-        
-        return longSideLength >= (shortSideLength * 2)
+        let (width, height) = (bounds.size.width, bounds.size.height)
+        return max(width, height) >= min(width, height) * 2
     }
     
 }

--- a/Offroad-iOS/Offroad-iOS/Global/Extensions/UIScreen+.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Extensions/UIScreen+.swift
@@ -13,4 +13,20 @@ extension UIScreen {
     static var current: UIScreen {
         UIWindow.current.screen
     }
+    
+    /// 현재 screen의 사이즈를 반환하는 타입 변수
+    static var currentScreenSize: CGSize {
+        current.bounds.size
+    }
+    
+    /// screen의 긴 변의 길이가 짧은 변의 길이의 두 배가 넘는 지의 여부를 계산하는 변수.
+    /// 사용 중인 기기가 홈 버튼이 있는 기종인지 여부를 판단하기 위해 사용할 수 있음.
+    var isAspectRatioTall: Bool {
+        let isVerticalDirection: Bool = bounds.size.height > bounds.size.width
+        let longSideLength: CGFloat = isVerticalDirection ? bounds.size.height : bounds.size.width
+        let shortSideLength: CGFloat = isVerticalDirection ? bounds.size.width : bounds.size.height
+        
+        return longSideLength >= (shortSideLength * 2)
+    }
+    
 }

--- a/Offroad-iOS/Offroad-iOS/Presentation/TabBar/ViewControllers/OffroadTabBarController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/TabBar/ViewControllers/OffroadTabBarController.swift
@@ -14,7 +14,7 @@ class OffroadTabBarController: UITabBarController {
     let centerTabBarItemSideLength: CGFloat = 85
     let tabBarItemWidth: CGFloat = 77
     var originalTabBarHeight: CGFloat = 0
-    private let tabBarHeight: CGFloat = 92
+    var tabBarHeight: CGFloat = UIScreen.current.isAspectRatioTall ? 92 : 60
     private var hideTabBarAnimator = UIViewPropertyAnimator(duration: 0.4, dampingRatio: 1)
     private var showTabBarAnimator = UIViewPropertyAnimator(duration: 0.4, dampingRatio: 1)
     

--- a/Offroad-iOS/Offroad-iOS/Presentation/TabBar/ViewControllers/OffroadTabBarViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/TabBar/ViewControllers/OffroadTabBarViewController.swift
@@ -16,9 +16,8 @@ class OffroadTabBarViewController: UIViewController {
     
     override func viewWillLayoutSubviews() {
         super.viewWillLayoutSubviews()
-        guard let offroadTabBarController = self.tabBarController as? OffroadTabBarController else { return }
-        // 92: 현재 오브 탭바의 높이
-        additionalSafeAreaInsets.bottom = 92 - offroadTabBarController.originalTabBarHeight
+        guard let orbTabBarController = self.tabBarController as? OffroadTabBarController else { return }
+        additionalSafeAreaInsets.bottom = orbTabBarController.tabBarHeight - orbTabBarController.originalTabBarHeight
     }
     
 }


### PR DESCRIPTION
### 🌴 작업한 브랜치
- #222 


### ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->
현재 탭바의 높이를 92로 고정한 상황입니다. 
홈 버튼이 있는 기기의 경우, 탭바의 높이가 92이면 부자연스럽게 커 보여서, 
홈 버튼이 있는 기기의 경우 탭바의 높이를 살짝 낮추어(60) 보다 자연스러워 보일 수 있도록 구현하였습니다. 

<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### ❗️PR Point
<!-- 부족했던 점 혹은 개선하고 싶은 방향이 있다면 얘기해주세요 -->
- 스크린샷에서 볼 수 있듯, 현재 홈 버튼이 있는 기기의 화면 비율에서는 UI 일부가 잘리거나 맞지 않는 현상이 발생합니다. 
이에 대한 대응을 하면 좋으나, 현재는 홈 버튼이 있는 기기에 맞게 UI 작업하는 것은 후순위로 미루어진 상태이므로, 
지금 당장 수정할 필요는 없습니다. 
(마이페이지에서 아래 선택 항목들만 스크롤이 되도록 구현되어 있는데, 마이페이지 전체가 스크롤 되는 것이 더 깔끔할 것 같아 보여 이 부분은 제가 별도의 브랜치를 생성하여 구현할 예정입니다. )
- 앞서 언급한대로 홈 버튼이 있는 기기 화면 비율에 맞게 대응하는 것은 후순위의 작업입니다. 
따라서 이 때의 탭바 높이인 60 역시 제가 임의로 설정한 것으로, 추후 디자이너분들이 작업하시면서 변경될 수 있습니다. 
이 브랜치에서의 작업은 홈 버튼이 있는 기기인지 확인하는 데에 그 목적이 있다고 생각해 주시면 될 것 같습니다. 
<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->

|뷰|설명|
|:------:|:---:|
| <img src="https://github.com/user-attachments/assets/2c31df36-c678-460e-ba15-582c8a572885" width=200> |     |


- Resolved: #222 
