### PR TITLE
[Fix] #253 - 탭바 눌렀을 때 item이 바로 선택되지 않던 문제 해결

### DIFF
--- a/Offroad-iOS/Offroad-iOS/Presentation/TabBar/ViewControllers/OffroadTabBarController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/TabBar/ViewControllers/OffroadTabBarController.swift
@@ -15,6 +15,7 @@ class OffroadTabBarController: UITabBarController {
     var tabBarHeight: CGFloat = UIScreen.current.isAspectRatioTall ? 92 : 60
     private var hideTabBarAnimator = UIViewPropertyAnimator(duration: 0.4, dampingRatio: 1)
     private var showTabBarAnimator = UIViewPropertyAnimator(duration: 0.4, dampingRatio: 1)
+    private var isTabBarShown: Bool = false
     
     //MARK: - UI Properties
     
@@ -162,6 +163,8 @@ extension OffroadTabBarController {
     // MARK: - Func
     
     func hideTabBarAnimation(delayFactor: CGFloat = 0) {
+        isTabBarShown = false
+        disableTabBarInteraction()
         view.layoutIfNeeded()
         showTabBarAnimator.stopAnimation(true)
         hideTabBarAnimator.addAnimations({ [weak self] in
@@ -174,6 +177,8 @@ extension OffroadTabBarController {
     }
     
     func showTabBarAnimation(delayFactor: CGFloat = 0) {
+        guard !isTabBarShown else { return }
+        disableTabBarInteraction()
         if tabBar.isHidden {
             tabBar.frame.origin.y = UIScreen.current.bounds.height + 30
             tabBar.isHidden = false
@@ -183,6 +188,10 @@ extension OffroadTabBarController {
             guard let self else { return }
             self.tabBar.frame.origin.y = UIScreen.current.bounds.height - self.tabBarHeight
         }, delayFactor: delayFactor)
+        showTabBarAnimator.addCompletion { [weak self] _ in
+            guard let self else { return }
+            self.isTabBarShown = true
+        }
         showTabBarAnimator.startAnimation()
     }
 }
@@ -192,6 +201,7 @@ extension OffroadTabBarController {
 extension OffroadTabBarController: UINavigationControllerDelegate {
     
     func navigationController(_ navigationController: UINavigationController, willShow viewController: UIViewController, animated: Bool) {
+        guard !isTabBarShown else { return }
         disableTabBarInteraction()
     }
     


### PR DESCRIPTION
### 🌴 작업한 브랜치
- #253 


### ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->
탭바 버튼 중 My 탭을 누를 시, 한 번에 버튼 색이 밝아지지 않고, 버튼의 색이 일시적으로 어둡거나, 한 번 더 누를 때까지 밝은 색으로 뜨지 않는 문제를 해결하였습니다.

이를 위해 탭바가 올라왔는지 여부를 저장하는 `isTabBarShown`이라는 `flag` 를 만들었습니다. 

<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### ❗️PR Point
<!-- 부족했던 점 혹은 개선하고 싶은 방향이 있다면 얘기해주세요 -->

<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->

| 수정 전 | 수정 후 |
|:------:|:---:|
|  <img src="https://github.com/user-attachments/assets/e0952d4d-71f5-475d-9ba6-42ab5424c09f" width=200>     |  <img src="https://github.com/user-attachments/assets/194e4360-e283-4b90-a6f9-1ce2468d2c78" width=200>    |


- Resolved: #253 
