### PR TITLE
[Feat] #263 - 리프레시 토큰 재발급 로직 구현

### DIFF
--- a/Offroad-iOS/Offroad-iOS.xcodeproj/project.pbxproj
+++ b/Offroad-iOS/Offroad-iOS.xcodeproj/project.pbxproj
@@ -167,6 +167,7 @@
 		D018BB112C4054D20048B6DF /* TitleModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D018BB102C4054D20048B6DF /* TitleModel.swift */; };
 		D03C835E2C61E44700F3094D /* TokenIntercepter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D03C835D2C61E44700F3094D /* TokenIntercepter.swift */; };
 		D03C83622C620AF100F3094D /* MyPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D03C83612C620AF100F3094D /* MyPageView.swift */; };
+		D05C31DF2CDEB574004761A7 /* AppUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = D05C31DE2CDEB55A004761A7 /* AppUtility.swift */; };
 		D063E9852C492D6700434A09 /* SVGKit in Frameworks */ = {isa = PBXBuildFile; productRef = D063E9842C492D6700434A09 /* SVGKit */; };
 		D063E9872C492D6700434A09 /* SVGKitSwift in Frameworks */ = {isa = PBXBuildFile; productRef = D063E9862C492D6700434A09 /* SVGKitSwift */; };
 		D063E98C2C49328300434A09 /* SVGKImage+.swift in Sources */ = {isa = PBXBuildFile; fileRef = D063E98B2C49328200434A09 /* SVGKImage+.swift */; };
@@ -424,6 +425,7 @@
 		D018BB1B2C43E4740048B6DF /* Offroad-iOS.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Offroad-iOS.entitlements"; sourceTree = "<group>"; };
 		D03C835D2C61E44700F3094D /* TokenIntercepter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenIntercepter.swift; sourceTree = "<group>"; };
 		D03C83612C620AF100F3094D /* MyPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageView.swift; sourceTree = "<group>"; };
+		D05C31DE2CDEB55A004761A7 /* AppUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUtility.swift; sourceTree = "<group>"; };
 		D063E98B2C49328200434A09 /* SVGKImage+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SVGKImage+.swift"; sourceTree = "<group>"; };
 		D063E98D2C49483000434A09 /* UIImageView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImageView+.swift"; sourceTree = "<group>"; };
 		D063E98F2C496EA500434A09 /* LottieAnimationView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LottieAnimationView+.swift"; sourceTree = "<group>"; };
@@ -1632,6 +1634,7 @@
 		D018BB0C2C401F5F0048B6DF /* Components */ = {
 			isa = PBXGroup;
 			children = (
+				D05C31DE2CDEB55A004761A7 /* AppUtility.swift */,
 				4EFCDFDB2C92B647006DEBB6 /* Overlay */,
 				4E38B7D82C6471EC0011D997 /* SegmentedControl */,
 				D00A488A2C78306C008B286A /* CustomView */,
@@ -2415,6 +2418,7 @@
 				D0E7960A2C4522CF005B47A5 /* NetworkService.swift in Sources */,
 				D00A48772C634530008B286A /* SettingBaseView.swift in Sources */,
 				D00A487A2C634710008B286A /* SettingBaseCollectionViewCell.swift in Sources */,
+				D05C31DF2CDEB574004761A7 /* AppUtility.swift in Sources */,
 				D0EAF2262C3B7D7F00566543 /* LoginViewController.swift in Sources */,
 				D063E9A12C6107D300434A09 /* CollectedTitlesViewController.swift in Sources */,
 				4EC3EC932CA9049F008139BE /* CouponCollectionViewController.swift in Sources */,

--- a/Offroad-iOS/Offroad-iOS/Global/Components/AppUtility.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Components/AppUtility.swift
@@ -1,0 +1,26 @@
+//
+//  AppUtility.swift
+//  Offroad-iOS
+//
+//  Created by 조혜린 on 11/9/24.
+//
+
+import UIKit
+
+final class AppUtility {
+    static let shared = AppUtility()
+        
+    private init() {}
+    
+    static func changeRootViewController(to viewController: UIViewController) {
+        let window = UIWindow.current
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            UIView.transition(with: window, duration: 1.0, options: .transitionCrossDissolve, animations: {
+                window.rootViewController = viewController
+            }, completion: nil)
+            
+            window.makeKeyAndVisible()
+        }
+    }
+}

--- a/Offroad-iOS/Offroad-iOS/Network/Auth/AuthService.swift
+++ b/Offroad-iOS/Offroad-iOS/Network/Auth/AuthService.swift
@@ -43,7 +43,11 @@ final class AuthService: BaseService, AuthServiceProtocol {
                 )
                 completion(networkResult)
             case .failure(let err):
-                print(err)
+                let networkResult: NetworkResult<RefreshTokenResponseDTO> = self.fetchNetworkResult(
+                    statusCode: err.response?.statusCode ?? Int(),
+                    data: err.response?.data ?? Data()
+                )
+                completion(networkResult)
             }
         }
     }

--- a/Offroad-iOS/Offroad-iOS/Presentation/Login/AuthManager/TokenIntercepter.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Login/AuthManager/TokenIntercepter.swift
@@ -5,7 +5,7 @@
 //  Created by 조혜린 on 8/6/24.
 //
 
-import Foundation
+import UIKit
 
 import Alamofire
 
@@ -51,6 +51,9 @@ final class TokenInterceptor: RequestInterceptor {
                 KeychainManager.shared.saveRefreshToken(token: refreshToken)
                 
                 completion(.retry)
+            case .unAuthentication:
+                let loginViewController = LoginViewController()
+                AppUtility.changeRootViewController(to: loginViewController)
             default:
                 completion(.doNotRetry)
             }


### PR DESCRIPTION
### 🌴 작업한 브랜치
- #263


### ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->
리프레시 토큰을 재발급하는 로직을 구현하였습니다.

![image](https://github.com/user-attachments/assets/f998ad75-5b64-4951-b7b0-54e0643cf0f1)

리프레시 토큰이 만료되면 해당 에러가 발생하면서 멈추게 되는데 이 때 LoginViewController로 이동하도록 하였습니다.


- 프로젝트 전역해서 사용할 수 있도록 AppUtility 클래스를 작성하고 rootViewcontroller를 변경해주는 함수를 작성하였습니다.

  ```
  final class AppUtility {
      static let shared = AppUtility()
  
      private init() {}
  
      static func changeRootViewController(to viewController: UIViewController) {
          let window = UIWindow.current
  
          DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
              UIView.transition(with: window, duration: 1.0, options: .transitionCrossDissolve, animations: {
                  window.rootViewController = viewController
              }, completion: nil)
  
              window.makeKeyAndVisible()
          }
      }
  }
  ```

커밋에 이슈번호를 잘못 포함하여 해당 이슈에서는 커밋 이력이 중복되어 보일 수 있습니다..! 이 점 양해해주세요..!!


- Resolved: #263
