### PR TITLE
[Fix] #271 - 공지사항 API 수정사항 반영

### DIFF
--- a/Offroad-iOS/Offroad-iOS/Network/Notice/DTO/Response/NoticeResponseDTO.swift
+++ b/Offroad-iOS/Offroad-iOS/Network/Notice/DTO/Response/NoticeResponseDTO.swift
@@ -23,4 +23,5 @@ struct NoticeInfo: Codable {
     let updateAt: String
     let hasExternalLinks: Bool
     let externalLinks: [String]
+    let externalLinksTitles: [String]
 }

--- a/Offroad-iOS/Offroad-iOS/Presentation/MyPage/Settings/Notice/NoticePost/View/NoticePostView.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/MyPage/Settings/Notice/NoticePost/View/NoticePostView.swift
@@ -163,7 +163,7 @@ extension NoticePostView {
         
         if data.hasExternalLinks {
             contentButton.isHidden = false
-            contentButton.setTitle("링크 열기", for: .normal)
+            contentButton.setTitle("\(data.externalLinksTitles.first ?? "")", for: .normal)
         }
     }
 }

--- a/Offroad-iOS/Offroad-iOS/Presentation/MyPage/Settings/Notice/NoticePost/View/NoticePostView.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/MyPage/Settings/Notice/NoticePost/View/NoticePostView.swift
@@ -152,13 +152,16 @@ extension NoticePostView {
         
         titleLabel.text = data.isImportant ? "\(importantText) \(data.title)" : data.title
         titleLabel.highlightText(targetText: importantText, color: .sub(.sub2))
-        
-        let date = ISO8601DateFormatter().date(from: data.updateAt)
-        
+                
         let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy / MM / dd"
+        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
+        dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
         
-        dateLabel.text = dateFormatter.string(from: date ?? Date())
+        if let date = dateFormatter.date(from: data.updateAt) {
+            dateFormatter.dateFormat = "yyyy / MM / dd"
+            dateLabel.text = dateFormatter.string(from: date)
+        }
+        
         contentLabel.text = data.content
         
         if data.hasExternalLinks {


### PR DESCRIPTION
### 🌴 작업한 브랜치
- #271


### ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->
- 기존에는 서버에서 링크 제목을 넘겨주지 않아서 임의로 "링크 열기"라는 제목으로 UIbutton의 title을 설정했으나, 서버에서 링크 제목을 넘겨주는 방식으로 변경되었기 때문에 반영하였습니다.

++ 추가적으로 기존 날짜 포맷팅 방식에서, `ISO8601DateFormatter`를 사용하였으나 서버에서 넘겨준 문자열이 ISO 8601 형식과 완전히 일치하지 않아 nil값으로 넘어가게 되고, 그에 따라 항상 현재 날짜가 표기되는 버그를 발견하여 이를 해결하였습니다.

<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->

|iPhone 16 Pro|
|:------:|
|<img src="https://github.com/user-attachments/assets/e34aecbc-191a-4b76-a76c-d8ede2d4650c" width="300px"/>|


- Resolved: #271
