### PR TITLE
[Feat] #281 - (로티가 화면 중앙에 오는) 로딩 뷰 구현

### DIFF
--- a/Offroad-iOS/Offroad-iOS.xcodeproj/project.pbxproj
+++ b/Offroad-iOS/Offroad-iOS.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		4E3A326F2CE5114C007228D0 /* CharacterChatPostRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E3A326E2CE5114C007228D0 /* CharacterChatPostRequestDTO.swift */; };
 		4E3A32712CE51176007228D0 /* CharacterChatPostResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E3A32702CE51176007228D0 /* CharacterChatPostResponseDTO.swift */; };
 		4E3A32732CE51185007228D0 /* CharacterChatGetResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E3A32722CE51185007228D0 /* CharacterChatGetResponseDTO.swift */; };
+		4E3A32892CE733F2007228D0 /* LoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E3A32882CE733F2007228D0 /* LoadingView.swift */; };
 		4E3F009E2C40D20800B9A31A /* OffroadTabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E3F009D2C40D20800B9A31A /* OffroadTabBarController.swift */; };
 		4E416CE82C45DBE200CF6AB4 /* OffroadPlace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E416CE72C45DBE200CF6AB4 /* OffroadPlace.swift */; };
 		4E46E5F72CB997B4000A1EEE /* ORBToastManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E46E5F62CB997B4000A1EEE /* ORBToastManager.swift */; };
@@ -324,6 +325,7 @@
 		4E3A326E2CE5114C007228D0 /* CharacterChatPostRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CharacterChatPostRequestDTO.swift; sourceTree = "<group>"; };
 		4E3A32702CE51176007228D0 /* CharacterChatPostResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CharacterChatPostResponseDTO.swift; sourceTree = "<group>"; };
 		4E3A32722CE51185007228D0 /* CharacterChatGetResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CharacterChatGetResponseDTO.swift; sourceTree = "<group>"; };
+		4E3A32882CE733F2007228D0 /* LoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingView.swift; sourceTree = "<group>"; };
 		4E3F009D2C40D20800B9A31A /* OffroadTabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OffroadTabBarController.swift; sourceTree = "<group>"; };
 		4E416CE72C45DBE200CF6AB4 /* OffroadPlace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OffroadPlace.swift; sourceTree = "<group>"; };
 		4E46E5F62CB997B4000A1EEE /* ORBToastManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ORBToastManager.swift; sourceTree = "<group>"; };
@@ -1134,6 +1136,14 @@
 			path = Response;
 			sourceTree = "<group>";
 		};
+		4E3A32872CE733D4007228D0 /* Loading */ = {
+			isa = PBXGroup;
+			children = (
+				4E3A32882CE733F2007228D0 /* LoadingView.swift */,
+			);
+			path = Loading;
+			sourceTree = "<group>";
+		};
 		4E3F00992C40D1C000B9A31A /* TabBar */ = {
 			isa = PBXGroup;
 			children = (
@@ -1399,6 +1409,7 @@
 		4EFCDFDB2C92B647006DEBB6 /* Overlay */ = {
 			isa = PBXGroup;
 			children = (
+				4E3A32872CE733D4007228D0 /* Loading */,
 				4E99007A2CDB9504007EEFF7 /* CharacterChat */,
 				4E700C812CB3C99900C664C2 /* Toast */,
 				4E700C802CB3C95E00C664C2 /* Alert */,
@@ -2593,6 +2604,7 @@
 				4E08B95B2C5E4F860082EFB8 /* ORBSegmentedControl.swift in Sources */,
 				87E046942C3D2B38002D12C2 /* BirthViewController.swift in Sources */,
 				4EF6B0412CC3F1B900066640 /* ORBAlertViewTextFieldWithSubMessage.swift in Sources */,
+				4E3A32892CE733F2007228D0 /* LoadingView.swift in Sources */,
 				D063E9922C57FE7400434A09 /* KeychainManager.swift in Sources */,
 				D004F85A2CA12B2200D5A2CD /* NoticeService.swift in Sources */,
 				4EF833EE2CC4268200D94314 /* ORBPopup.swift in Sources */,

--- a/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/Loading/LoadingView.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/Loading/LoadingView.swift
@@ -1,0 +1,70 @@
+//
+//  LoadingView.swift
+//  Offroad-iOS
+//
+//  Created by 김민성 on 11/15/24.
+//
+
+import UIKit
+
+import Lottie
+import SnapKit
+
+class LoadingView: UIView {
+    
+    //MARK: - UI Properties
+    
+    let shadeView = UIView()
+    let loadingAnimationView = LottieAnimationView(name: "loading2")
+    
+    //MARK: - Life Cycle
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setupStyle()
+        setupHierarchy()
+        setupLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+}
+
+extension LoadingView {
+    
+    //MARK: - Layout Func
+    
+    private func setupLayout() {
+        shadeView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
+        loadingAnimationView.snp.makeConstraints { make in
+            make.center.equalToSuperview()
+            make.size.equalTo(150)
+        }
+    }
+    
+    //MARK: - Private Func
+    
+    private func setupStyle() {
+        shadeView.do { view in
+            view.backgroundColor = .blackOpacity(.black55)
+        }
+        loadingAnimationView.do { animationView in
+            animationView.loopMode = .loop
+            animationView.contentMode = .scaleAspectFit
+            animationView.play()
+        }
+    }
+    
+    private func setupHierarchy() {
+        addSubviews(shadeView, loadingAnimationView)
+    }
+    
+}
+
+    
+   

--- a/Offroad-iOS/Offroad-iOS/Global/Extensions/UIView+.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Extensions/UIView+.swift
@@ -67,4 +67,33 @@ extension UIView {
             self.alpha = destinationAlpha
         }, completion: completion)
     }
+    
+    
+    func startLoading() {
+        // 이미 로딩중인 경우, 추가 로딩 뷰 띄우는 것 방지
+        for subView in subviews {
+            if subView is LoadingView { return }
+        }
+        
+        let someView = LoadingView()
+        someView.isHidden = true
+        addSubview(someView)
+        someView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
+        UIView.animate(withDuration: 0.2) {
+            someView.isHidden = false
+        }
+    }
+    
+    func stopLoading() {
+        for subview in subviews {
+            guard let loadingView = subview as? LoadingView else { continue }
+            UIView.animate(withDuration: 0.2, animations: {
+                loadingView.isHidden = true
+            }) { isFinished in
+                loadingView.removeFromSuperview()
+            }
+        }
+    }
 }

--- a/Offroad-iOS/Offroad-iOS/Presentation/QuestMap/ViewControllers/QuestMapViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/QuestMap/ViewControllers/QuestMapViewController.swift
@@ -57,6 +57,8 @@ class QuestMapViewController: OffroadTabBarViewController {
         setupDelegates()
         rootView.naverMapView.mapView.positionMode = .direction
         locationManager.startUpdatingHeading()
+        viewModel.requestAuthorization()
+        viewModel.updateRegisteredPlaces(at: currentPositionTarget)
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -66,7 +68,7 @@ class QuestMapViewController: OffroadTabBarViewController {
         guard let offroadTabBarController = tabBarController as? OffroadTabBarController else { return }
         offroadTabBarController.showTabBarAnimation()
         
-        rootView.naverMapView.mapView.positionMode = .direction
+//        rootView.naverMapView.mapView.positionMode = .direction
         viewModel.isCompassMode = false
     }
     
@@ -90,8 +92,7 @@ class QuestMapViewController: OffroadTabBarViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         
-        viewModel.requestAuthorization()
-        viewModel.updateRegisteredPlaces(at: currentPositionTarget)
+        
         let orangeLocationOverlayImage = rootView.locationOverlayImage
         rootView.naverMapView.mapView.locationOverlay.icon = orangeLocationOverlayImage
     }
@@ -158,6 +159,14 @@ extension QuestMapViewController {
     }
     
     private func bindData() {
+        viewModel.startLoading.subscribe(onNext: {
+            self.tabBarController?.view.startLoading()
+        }).disposed(by: disposeBag)
+        
+        viewModel.stopLoading.subscribe(onNext: {
+            self.tabBarController?.view.stopLoading()
+        }).disposed(by: disposeBag)
+        
         viewModel.networkFailureSubject
             .subscribe(onNext: { [weak self] in
                 guard let self else { return }
@@ -197,6 +206,7 @@ extension QuestMapViewController {
             if success {
                 self.viewModel.updateRegisteredPlaces(at: self.currentPositionTarget)
             }
+            self.tabBarController?.view.stopLoading()
             self.popupAdventureResult(isSuccess: success, image: image)
         }).disposed(by: disposeBag)
         

--- a/Offroad-iOS/Offroad-iOS/Presentation/QuestMap/ViewControllers/QuestMapViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/QuestMap/ViewControllers/QuestMapViewController.swift
@@ -68,7 +68,6 @@ class QuestMapViewController: OffroadTabBarViewController {
         guard let offroadTabBarController = tabBarController as? OffroadTabBarController else { return }
         offroadTabBarController.showTabBarAnimation()
         
-//        rootView.naverMapView.mapView.positionMode = .direction
         viewModel.isCompassMode = false
     }
     
@@ -219,7 +218,13 @@ extension QuestMapViewController {
         
         rootView.switchTrackingModeButton.rx.tap.bind { [weak self] _ in
             guard let self else { return }
-            self.switchTrackingMode()
+            switch self.viewModel.locationManager.authorizationStatus {
+            case .authorizedAlways, .authorizedWhenInUse:
+                self.switchTrackingMode()
+            default:
+                self.viewModel.requestAuthorization()
+                return
+            }
         }.disposed(by: disposeBag)
         
         rootView.questListButton.rx.tap.bind { [weak self] _ in
@@ -396,6 +401,19 @@ extension QuestMapViewController: CLLocationManagerDelegate {
         cameraUpdate.animation = .easeOut
         rootView.naverMapView.mapView.moveCamera(cameraUpdate)
         rootView.naverMapView.mapView.locationOverlay.icon = orangeLocationOverlayImage
+    }
+    
+    func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+        switch manager.authorizationStatus {
+        case .authorizedAlways:
+            flyToMyPosition()
+            rootView.naverMapView.mapView.positionMode = .direction
+        case .authorizedWhenInUse:
+            flyToMyPosition()
+            rootView.naverMapView.mapView.positionMode = .direction
+        default:
+            return
+        }
     }
     
 }

--- a/Offroad-iOS/Offroad-iOS/Presentation/QuestMap/ViewModel/QuestMapViewModel.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/QuestMap/ViewModel/QuestMapViewModel.swift
@@ -32,6 +32,8 @@ final class QuestMapViewModel: SVGFetchable {
     let completeQuestList = PublishSubject<[CompleteQuest]?>()
     let adventureResultSubject = PublishSubject<AdventuresPlaceAuthenticationResultData>()
     
+    let startLoading = PublishRelay<Void>()
+    let stopLoading = PublishRelay<Void>()
     let networkFailureSubject = PublishSubject<Void>()
     let markersSubject = BehaviorSubject<[OffroadNMFMarker]>(value: [])
     let customOverlayImage = NMFOverlayImage(image: .icnQuestMapPlaceMarker)
@@ -79,6 +81,7 @@ extension QuestMapViewModel {
     }
     
     func updateRegisteredPlaces(at target: NMGLatLng) {
+        startLoading.accept(())
         let requestPlaceDTO = RegisteredPlaceRequestDTO(
             currentLatitude: target.lat,
             currentLongitude: target.lng,
@@ -88,6 +91,7 @@ extension QuestMapViewModel {
         
         NetworkService.shared.placeService.getRegisteredPlace(requestDTO: requestPlaceDTO) { [weak self] response in
             guard let self else { return }
+            self.stopLoading.accept(())
             switch response {
             case .success(let data):
                 let markers = data!.data.places.map {
@@ -115,6 +119,7 @@ extension QuestMapViewModel {
             longitude: currentLocation.lng
         )
         
+        startLoading.accept(())
         NetworkService.shared.adventureService.authenticatePlaceAdventure(
             adventureAuthDTO: dto,
             completion: { [weak self] result in

--- a/Offroad-iOS/Offroad-iOS/Presentation/QuestMap/ViewModel/QuestMapViewModel.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/QuestMap/ViewModel/QuestMapViewModel.swift
@@ -20,7 +20,7 @@ final class QuestMapViewModel: SVGFetchable {
     
     var disposeBag = DisposeBag()
     
-    private let locationManager = CLLocationManager()
+    let locationManager = CLLocationManager()
     private var currentZoomLevel: Double = 14
     private var searchedPlaceArray: [RegisteredPlaceInfo] = []
     var selectedMarker: OffroadNMFMarker? = nil


### PR DESCRIPTION
### 🌴 작업한 브랜치
- #281 


### ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->
로딩 뷰를 구현했습니다. 
UIView의 확장으로 함수를 만들어 구현했습니다. 
사용법은 매우 간단합니다. 
로딩을 표현하고자 하는 뷰에서 로딩 시작, 끝 시점에 각각 `startLoading()`, `stopLoading()` 메서드를 호출하면 됩니다. 
예를 들어, 네트워크 API를 호출하는 시점에 원하는 뷰에서 `startLoading()` 메서드를 호출하고, 네트워크 통신이 끝난 시점에 `stopLoading()` 메서드를 호출하면 됩니다. 

만약 탭바까지 로딩 화면으로 덮고 싶다면, 탭바컨트롤러에 접근하여 탭바컨트롤러의 뷰에서 해당 메서드들을 호출하면 됩니다. 
<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### ❗️PR Point
<!-- 부족했던 점 혹은 개선하고 싶은 방향이 있다면 얘기해주세요 -->
잘 동작하는지 확인하기 위한 예시로, 지도 뷰에서 로딩 화면을 적용하였습니다. 
*지도 뷰에 로딩 화면 적용하면서, 로직도 일부 개선하였습니다.
<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->

|뷰|설명|
|:------:|:---:|
|   <img src="https://github.com/user-attachments/assets/79d26850-0355-401f-ab0e-13efb34adac5" width=200>   |     |


- Resolved: #281 
