### PR TITLE
[Fix] #270 - 버그 일부 수정, png/svg 형식 무관하게 이미지 받아오도록 구현

### DIFF
--- a/Offroad-iOS/Offroad-iOS.xcodeproj/project.pbxproj
+++ b/Offroad-iOS/Offroad-iOS.xcodeproj/project.pbxproj
@@ -80,6 +80,7 @@
 		4E58FC052C7DFEAC002A951B /* QuestListResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E58FC042C7DFEAC002A951B /* QuestListResponseDTO.swift */; };
 		4E59A11C2C4228C500B548C6 /* AVCameraPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E59A11B2C4228C500B548C6 /* AVCameraPreview.swift */; };
 		4E6659382CEB96E70024ABEE /* MyInfoManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E6659372CEB96E70024ABEE /* MyInfoManager.swift */; };
+		4E66593D2CECA0CE0024ABEE /* StringLiterals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E66593C2CECA0CE0024ABEE /* StringLiterals.swift */; };
 		4E6A5BC32C2E8C290027FDF0 /* Then in Frameworks */ = {isa = PBXBuildFile; productRef = 4E6A5BC22C2E8C290027FDF0 /* Then */; };
 		4E700C852CB3CA1E00C664C2 /* ORBOverlayViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E700C842CB3CA1E00C664C2 /* ORBOverlayViewController.swift */; };
 		4E8B478F2C382A4800D9B8EE /* Lottie in Frameworks */ = {isa = PBXBuildFile; productRef = 4E8B478E2C382A4800D9B8EE /* Lottie */; };
@@ -359,6 +360,7 @@
 		4E58FC042C7DFEAC002A951B /* QuestListResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestListResponseDTO.swift; sourceTree = "<group>"; };
 		4E59A11B2C4228C500B548C6 /* AVCameraPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AVCameraPreview.swift; sourceTree = "<group>"; };
 		4E6659372CEB96E70024ABEE /* MyInfoManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyInfoManager.swift; sourceTree = "<group>"; };
+		4E66593C2CECA0CE0024ABEE /* StringLiterals.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringLiterals.swift; sourceTree = "<group>"; };
 		4E700C842CB3CA1E00C664C2 /* ORBOverlayViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ORBOverlayViewController.swift; sourceTree = "<group>"; };
 		4E9252F45B6891FFCE593629 /* Pods-Offroad-iOSTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Offroad-iOSTests.debug.xcconfig"; path = "Target Support Files/Pods-Offroad-iOSTests/Pods-Offroad-iOSTests.debug.xcconfig"; sourceTree = "<group>"; };
 		4E99007B2CDB952C007EEFF7 /* ORBCharacterChatWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ORBCharacterChatWindow.swift; sourceTree = "<group>"; };
@@ -714,6 +716,7 @@
 			children = (
 				4EDC3D4A2C312850006A1493 /* FontLiterals.swift */,
 				4E1E94102C39870700A7B08A /* ColorLiterals.swift */,
+				4E66593C2CECA0CE0024ABEE /* StringLiterals.swift */,
 			);
 			path = Literals;
 			sourceTree = "<group>";
@@ -2577,6 +2580,7 @@
 				8791EDF82C7E1D2B00E7F8B9 /* CouponDetailViewController.swift in Sources */,
 				4E3A32732CE51185007228D0 /* CharacterChatGetResponseDTO.swift in Sources */,
 				D0E796032C452271005B47A5 /* BaseService.swift in Sources */,
+				4E66593D2CECA0CE0024ABEE /* StringLiterals.swift in Sources */,
 				4ECEEA6E2CB2C15E0029369A /* ORBTabBarShapeView.swift in Sources */,
 				D00A48642C633959008B286A /* SettingViewController.swift in Sources */,
 				4E9900842CDBD730007EEFF7 /* ORBCharacterChatBox.swift in Sources */,

--- a/Offroad-iOS/Offroad-iOS/Global/Extensions/UIImageView+.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Extensions/UIImageView+.swift
@@ -25,10 +25,16 @@ extension UIImageView {
                 return
             }
             
-            guard let svgImage = SVGKImage(data: data) else { return }
-            
-            DispatchQueue.main.async {
-                self.image = svgImage.renderedUIImage
+            if let notSvgImage = UIImage(data: data) {
+                DispatchQueue.main.async {
+                    self.image = notSvgImage
+                }
+            } else if let svgImage = SVGKImage(data: data) {
+                DispatchQueue.main.async {
+                    self.image = svgImage.renderedUIImage
+                }
+            } else {
+                return
             }
         }
         

--- a/Offroad-iOS/Offroad-iOS/Global/Literals/StringLiterals.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Literals/StringLiterals.swift
@@ -1,0 +1,8 @@
+//
+//  StringLiterals.swift
+//  Offroad-iOS
+//
+//  Created by 김민성 on 11/19/24.
+//
+
+import Foundation

--- a/Offroad-iOS/Offroad-iOS/Global/Literals/StringLiterals.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Literals/StringLiterals.swift
@@ -5,4 +5,26 @@
 //  Created by 김민성 on 11/19/24.
 //
 
-import Foundation
+struct ErrorMessages {
+    static let networkError = "네트워크 연결 상태를 확인해주세요."
+    static let versionError = "최신 버전으로 업데이트해주세요." // 임의 작성. 기획과 논의 필요
+    static let locationUnauthorized = "위치 정보 사용 동의 후 이용 가능합니다."
+    static let cameraUsageUnauthorized = "카메라 권한 허용 후 이용 가능합니다."
+    static let birthDateError = "다시 한 번 확인해주세요."
+}
+
+
+struct AlertMessage {
+    static let adventureSuccessTitle = "탐험 성공"
+    static let adventureSuccessMessage = "탐험에 성공했어요!\n이곳에 무엇이 있는지 천천히 살펴볼까요?"
+    static let adventureFailureTitle = "탐험 실패"
+    static let adventureFailureLocationMessage = "탐험에 실패했어요.\n위치를 다시 한 번 확인해주세요."
+    static let adventureFailureQRMessage = "탐험에 실패했어요.\nQR코드를 다시 한 번 확인해주세요."
+}
+
+struct LoadingMesage {
+    static let loading = "로딩 중입니다."
+    /// 현재 로직 상 사용할 일 없음. (퀘스트 클리어 팝업은 로딩 없이 바로 띄우기 때문)
+    static let questClearing = "클리어한 퀘스트가 있어요. 잠시마 기다려주세요."
+    static let login = "로그인 중입니다."
+}

--- a/Offroad-iOS/Offroad-iOS/Global/Protocols/SVGFetchable.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Protocols/SVGFetchable.swift
@@ -19,10 +19,16 @@ extension SVGFetchable {
     
     func fetchSVG(svgURLString: String, completion: @escaping (UIImage?) -> Void) {
         DispatchQueue.global().async {
-            guard let svgURL = URL(string: svgURLString) else { completion(nil); return }
-            guard let svgData = try? Data(contentsOf: svgURL) else { completion(nil); return }
-            guard let svgImage = SVGKImage(data: svgData) else { completion(nil); return }
-            completion(svgImage.renderedUIImage)
+            guard let imageURL = URL(string: svgURLString) else { completion(nil); return }
+            guard let imageData = try? Data(contentsOf: imageURL) else { completion(nil); return }
+            
+            if let image = UIImage(data: imageData) {
+                completion(image)
+            } else if let svgImage = SVGKImage(data: imageData) {
+                completion(svgImage.renderedUIImage)
+            } else {
+                completion(nil)
+            }
         }
     }
     

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/ORBCharacterChatManager.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/ORBCharacterChatManager.swift
@@ -48,6 +48,11 @@ extension ORBCharacterChatManager {
     
     func startChat() {
         chatWindow.makeKeyAndVisible()
+        self.chatViewController.configureCharacterChatBox(
+            character: "", message: "",
+            mode: .withoutReplyButtonShrinked,
+            animated: false
+        )
         self.chatViewController.rootView.userChatInputView.becomeFirstResponder()
     }
     

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/ORBCharacterChatViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/ORBCharacterChatViewController.swift
@@ -264,7 +264,7 @@ extension ORBCharacterChatViewController {
 //                self.changeChatBoxMode(to: .withoutReplyButtonExpanded, animated: true)
                 self.hideCharacterChatBox()
             case .networkFail:
-                self.showToast(message: "네트워크 연결 상태를 확인해주세요.", inset: 66)
+                self.showToast(message: ErrorMessages.networkError, inset: 66)
 //                self.changeChatBoxMode(to: .withoutReplyButtonExpanded, animated: true)
                 self.hideCharacterChatBox()
             case .decodeErr:

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/ChatLog/ViewControllers/CharacterChatLogViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/ChatLog/ViewControllers/CharacterChatLogViewController.swift
@@ -172,7 +172,7 @@ extension CharacterChatLogViewController {
                 self.scrollToBottom(animated: false)
                 showChatButton()
             case .networkFail:
-                showToast(message: "네트워크 연결 상태를 확인해주세요.", inset: 66)
+                showToast(message: ErrorMessages.networkError, inset: 66)
             case .decodeErr:
                 showToast(message: "디코딩 에러.", inset: 66)
             default:
@@ -269,7 +269,7 @@ extension CharacterChatLogViewController {
                 if isConnected {
                     self.requestChatLogDataSource()
                 } else {
-                    showToast(message: "네트워크 연결 상태를 확인해주세요.", inset: 66)
+                    showToast(message: ErrorMessages.networkError, inset: 66)
                 }
             }).disposed(by: disposeBag)
     }
@@ -405,7 +405,7 @@ extension CharacterChatLogViewController {
             case .registerErr:
                 self.showToast(message: "register Error occurred", inset: 66)
             case .networkFail:
-                self.showToast(message: "네트워크 연결 상태를 확인해주세요.", inset: 66)
+                self.showToast(message: ErrorMessages.networkError, inset: 66)
             case .decodeErr:
                 self.showToast(message: "decode Error occurred", inset: 66)
             }
@@ -440,7 +440,7 @@ extension CharacterChatLogViewController {
                 self.scrollToBottom(animated: false)
                 showChatButton()
             case .networkFail:
-                showToast(message: "네트워크 연결 상태를 확인해주세요.", inset: 66)
+                showToast(message: ErrorMessages.networkError, inset: 66)
             case .decodeErr:
                 showToast(message: "디코딩 에러.", inset: 66)
             default:

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/ChatLog/ViewControllers/CharacterChatLogViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/ChatLog/ViewControllers/CharacterChatLogViewController.swift
@@ -58,6 +58,7 @@ class CharacterChatLogViewController: OffroadTabBarViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
+        navigationController?.view.isUserInteractionEnabled = false
         guard let tabBarController = tabBarController as? OffroadTabBarController else { return }
         tabBarController.showTabBarAnimation()
         rootView.backgroundView.isHidden = false
@@ -67,6 +68,7 @@ class CharacterChatLogViewController: OffroadTabBarViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         
+        navigationController?.view.isUserInteractionEnabled = true
         rootView.backgroundView.isHidden = false
         guard let tabBarController = tabBarController as? OffroadTabBarController else { return }
         tabBarController.enableTabBarInteraction()
@@ -155,11 +157,11 @@ extension CharacterChatLogViewController {
     private func requestChatLogDataSource() {
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
-            self.tabBarController?.view.startLoading()
+            self.view.startLoading()
         }
         NetworkService.shared.characterChatService.getChatLog(completion: { [weak self] result in
             guard let self else { return }
-            self.tabBarController?.view.stopLoading()
+            self.view.stopLoading()
             switch result {
             case .success(let responseDTO):
                 guard let responseDTO else {

--- a/Offroad-iOS/Offroad-iOS/Presentation/Home/View/HomeView.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Home/View/HomeView.swift
@@ -186,6 +186,7 @@ extension HomeView {
             $0.edges.equalToSuperview()
         }
 
+        nicknameLabel.setContentHuggingPriority(.defaultHigh + 1, for: .vertical)
         nicknameLabel.snp.makeConstraints {
             $0.top.equalTo(safeAreaLayoutGuide).inset(26)
             $0.leading.equalToSuperview().inset(24)
@@ -208,15 +209,15 @@ extension HomeView {
         }
         
         characterBaseImageView.snp.makeConstraints {
-            $0.top.greaterThanOrEqualTo(characterNameView.snp.bottom)
+            $0.top.equalTo(characterNameView.snp.bottom).offset(25)
             $0.bottom.equalTo(titleView.snp.top).offset(-25)
-            $0.centerX.equalToSuperview()
+            $0.horizontalEdges.equalToSuperview()
         }
         
         characterMotionView.snp.makeConstraints {
-            $0.top.greaterThanOrEqualTo(characterNameView.snp.bottom)
+            $0.top.equalTo(characterNameView.snp.bottom).offset(25)
             $0.bottom.equalTo(titleView.snp.top).offset(-25)
-            $0.centerX.equalToSuperview()
+            $0.horizontalEdges.equalToSuperview()
         }
         
         titleView.snp.makeConstraints {

--- a/Offroad-iOS/Offroad-iOS/Presentation/MyPage/CharacterList/ViewController/CharacterDetailViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/MyPage/CharacterList/ViewController/CharacterDetailViewController.swift
@@ -105,7 +105,7 @@ extension CharacterDetailViewController {
             viewDidAppear.take(1)
         ).subscribe(onNext: { [weak self] _, _ in
             guard let self else { return }
-            self.showToast(message: "네트워크 연결 상태를 확인해주세요.", inset: 66)
+            self.showToast(message: ErrorMessages.networkError, inset: 66)
         }).disposed(by: disposeBag)
         
         rootView.customBackButton.rx.tap.bind(onNext: { [weak self] in
@@ -134,7 +134,7 @@ extension CharacterDetailViewController {
                     self.viewModel.getCharacterDetailInfo()
                     self.viewModel.characterMotionInfo()
                 } else {
-                    self.showToast(message: "네트워크 연결 상태를 확인해주세요.", inset: 66)
+                    self.showToast(message: ErrorMessages.networkError, inset: 66)
                 }
             }).disposed(by: disposeBag)
     }

--- a/Offroad-iOS/Offroad-iOS/Presentation/MyPage/CharacterList/ViewController/CharacterListViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/MyPage/CharacterList/ViewController/CharacterListViewController.swift
@@ -67,7 +67,7 @@ final class CharacterListViewController: UIViewController {
             viewModel.networkingFailure
         ).subscribe(onNext: { [weak self] _ in
             guard let self else { return }
-            self.showToast(message: "네트워크 연결 상태를 확인해주세요.", inset: 66)
+            self.showToast(message: ErrorMessages.networkError, inset: 66)
         }).disposed(by: disposeBag)
         
         NetworkMonitoringManager.shared.networkConnectionChanged
@@ -76,7 +76,7 @@ final class CharacterListViewController: UIViewController {
                 if isConnected {
                     self.viewModel.getCharacterListInfo()
                 } else {
-                    self.showToast(message: "네트워크 연결 상태를 확인해주세요.", inset: 66)
+                    self.showToast(message: ErrorMessages.networkError, inset: 66)
                 }
             }).disposed(by: disposeBag)
         

--- a/Offroad-iOS/Offroad-iOS/Presentation/MyPage/Settings/Notice/ViewController/NoticeViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/MyPage/Settings/Notice/ViewController/NoticeViewController.swift
@@ -79,7 +79,7 @@ extension NoticeViewController {
         Observable.combineLatest(viewDidAppear.take(1), netWorkdDidFail)
             .subscribe { [weak self] _ in
                 guard let self else { return }
-                self.showToast(message: "네트워크 연결 상태를 확인해주세요.", inset: 66)
+                self.showToast(message: ErrorMessages.networkError, inset: 66)
             }
             .disposed(by: disposeBag)
         

--- a/Offroad-iOS/Offroad-iOS/Presentation/MyPage/View/MyPageView.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/MyPage/View/MyPageView.swift
@@ -99,6 +99,10 @@ extension MyPageView {
             $0.roundCorners(cornerRadius: 10)
         }
         
+        characterProfileImageView.do {
+            $0.contentMode = .scaleAspectFit
+        }
+        
         adventureDaysLabel.do {
             $0.textColor = .main(.main2)
             $0.textAlignment = .center

--- a/Offroad-iOS/Offroad-iOS/Presentation/Nickname/ViewController/BirthViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Nickname/ViewController/BirthViewController.swift
@@ -143,7 +143,7 @@ final class BirthViewController: UIViewController {
         let currentDay = Calendar.current.component(.day, from: Date())
         
         if year == currentYear && month == currentMonth && day > currentDay {
-            birthView.notionLabel.text = "다시 한 번 확인해주세요."
+            birthView.notionLabel.text = ErrorMessages.birthDateError
             return false
         }
         
@@ -174,7 +174,7 @@ extension BirthViewController {
                 $0.layer.borderColor = UIColor.grayscale(.gray100).cgColor
             }
             else {
-                birthView.notionLabel.text = "다시 한 번 확인해주세요."
+                birthView.notionLabel.text = ErrorMessages.birthDateError
             }
         }
         if sender.text?.isEmpty ?? true {
@@ -255,7 +255,7 @@ extension BirthViewController {
         
         [birthView.yearTextField, birthView.monthTextField, birthView.dayTextField].forEach {
             if $0.layer.borderColor == UIColor.primary(.errorNew).cgColor {
-                birthView.notionLabel.text = "다시 한 번 확인해주세요."
+                birthView.notionLabel.text = ErrorMessages.birthDateError
             }
         }
     }
@@ -277,7 +277,7 @@ extension BirthViewController {
         
         [birthView.yearTextField, birthView.monthTextField, birthView.dayTextField].forEach {
             if $0.layer.borderColor == UIColor.primary(.errorNew).cgColor {
-                birthView.notionLabel.text = "다시 한 번 확인해주세요."
+                birthView.notionLabel.text = ErrorMessages.birthDateError
             }
         }
         
@@ -311,7 +311,7 @@ extension BirthViewController {
             
             self.navigationController?.pushViewController(nextVC, animated: true)
         } else {
-            birthView.notionLabel.text = "다시 한 번 확인해주세요."
+            birthView.notionLabel.text = ErrorMessages.birthDateError
         }
     }
     
@@ -372,14 +372,14 @@ extension BirthViewController {
                 $0.layer.borderColor = UIColor.grayscale(.gray100).cgColor
             }
             else {
-                birthView.notionLabel.text = "다시 한 번 확인해주세요."
+                birthView.notionLabel.text = ErrorMessages.birthDateError
             }
         }
         
         let allFieldsFilled = [birthView.yearTextField, birthView.monthTextField, birthView.dayTextField].allSatisfy { $0.text?.isEmpty == false }
         
         if allFieldsFilled && !validateInputs() {
-            birthView.notionLabel.text = "다시 한 번 확인해주세요."
+            birthView.notionLabel.text = ErrorMessages.birthDateError
         }
     }
 }

--- a/Offroad-iOS/Offroad-iOS/Presentation/PlaceList/ViewControllers/PlaceListViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/PlaceList/ViewControllers/PlaceListViewController.swift
@@ -92,7 +92,7 @@ extension PlaceListViewController {
         Observable.combineLatest(netWorkdDidFail, viewDidAppear)
             .subscribe { [weak self] _ in
                 guard let self else { return }
-                self.showToast(message: "네트워크 연결 상태를 확인해주세요.", inset: 66)
+                self.showToast(message: ErrorMessages.networkError, inset: 66)
             }
             .disposed(by: disposeBag)
     }

--- a/Offroad-iOS/Offroad-iOS/Presentation/QuestMap/ViewControllers/QuestMapViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/QuestMap/ViewControllers/QuestMapViewController.swift
@@ -170,7 +170,7 @@ extension QuestMapViewController {
             .subscribe(onNext: { [weak self] in
                 guard let self else { return }
                 self.tabBarController?.view.stopLoading()
-                self.showToast(message: "네트워크 연결 상태를 확인해주세요.", inset: 66)
+                self.showToast(message: ErrorMessages.networkError, inset: 66)
             }).disposed(by: disposeBag)
         
         viewModel.shouldRequestLocationAuthorization
@@ -279,8 +279,8 @@ extension QuestMapViewController {
     }
     
     private func popupAdventureResult(isSuccess: Bool, image: UIImage?, completeQuests: [CompleteQuest]?) {
-        let title: String = isSuccess ? "탐험 성공" : "탐험 실패"
-        let message: String = isSuccess ? "탐험에 성공했어요!\n이곳에 무엇이 있는지 천천히 살펴볼까요?" : "탐험에 실패했어요.\n위치를 다시 한 번 확인해주세요."
+        let title: String = isSuccess ? AlertMessage.adventureSuccessTitle : AlertMessage.adventureFailureTitle
+        let message: String = isSuccess ? AlertMessage.adventureSuccessMessage : AlertMessage.adventureFailureLocationMessage
         let buttonTitle: String = isSuccess ? "홈으로" : "확인"
         let alertController = ORBAlertController(title: title, message: message, type: .explorationResult)
         alertController.configureExplorationResultImage { $0.image = image }

--- a/Offroad-iOS/Offroad-iOS/Presentation/QuestQR/ViewControllers/QuestQRViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/QuestQR/ViewControllers/QuestQRViewController.swift
@@ -215,13 +215,13 @@ extension QuestQRViewController: AVCaptureMetadataOutputObjectsDelegate {
                         self.showAlert(title: "디코딩 실패한 듯", stringValue: "...")
                         return
                     }
-                    let notiTitle = data.isQRMatched ? "탐험 성공" : "탐험 실패"
+                    let notiTitle = data.isQRMatched ? AlertMessage.adventureSuccessTitle : AlertMessage.adventureFailureTitle
                     let imageURL = data.characterImageUrl
                     let alertController: ORBAlertController
                     if data.isQRMatched {
-                        alertController = ORBAlertController(title: "탐험 실패", message: "탐험에 실패했어요. \nQR코드를 다시 한 번 확인해 주세요.", type: .explorationResult)
+                        alertController = ORBAlertController(title: AlertMessage.adventureFailureTitle, message: AlertMessage.adventureFailureQRMessage, type: .explorationResult)
                     } else {
-                        alertController = ORBAlertController(title: "탐험 성공", message: "탐험에 성공했어요!\n이곳에 무엇이 있는지 천천히 살펴볼까요?", type: .explorationResult)
+                        alertController = ORBAlertController(title: AlertMessage.adventureSuccessTitle, message: AlertMessage.adventureSuccessMessage, type: .explorationResult)
                     }
                     let okAction = ORBAlertAction(title: "홈으로", style: .default, handler: { _ in return })
                     alertController.addAction(okAction)
@@ -230,7 +230,7 @@ extension QuestQRViewController: AVCaptureMetadataOutputObjectsDelegate {
                     }
                     self.tabBarController?.present(alertController, animated: false)
                 default:
-                    self.showAlert(title: "서버에서 응답이 안왔어여", stringValue: stringValue)
+                    self.showAlert(title: ErrorMessages.networkError, stringValue: stringValue)
                     return
                 }
             }

--- a/Offroad-iOS/Offroad-iOS/Presentation/Splash/ViewController/SplashViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Splash/ViewController/SplashViewController.swift
@@ -78,18 +78,6 @@ extension SplashViewController {
         }
     }
     
-//    private func getRepresentativeCharacterName() {
-//        NetworkService.shared.adventureService.getAdventureInfo(category: "NONE") { [weak self] response in
-//            guard let self else { return }
-//            switch response {
-//            case .success(let data):
-//                MyInfoManager.shared.representativeCharacterName = data?.data.characterName
-//            default:
-//                showToast(message: "네트워크 연결 상태를 확인해주세요.", inset: 66)
-//            }
-//        }
-//    }
-    
     private func getCharacterListInfo() {
         NetworkService.shared.characterService.getCharacterListInfo { [weak self] result in
             guard let self else { return }
@@ -107,7 +95,7 @@ extension SplashViewController {
                 }
                 MyInfoManager.shared.representativeCharacterID = responseDTO.data.representativeCharacterId
             case .networkFail:
-                showToast(message: "네트워크 연결 상태를 확인해주세요.", inset: 66)
+                showToast(message: ErrorMessages.networkError, inset: 66)
             default:
                 break
             }


### PR DESCRIPTION
### 🌴 작업한 브랜치
- #270 

### ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->
- StringLiterals 파일 추가 및 일부 적용
- 캐릭터한테 먼저 채팅 시작하기 위해 키보드 올라올 때 캐릭터 채팅 박스 일부가 보이던 문제 해결
- 채팅 로그 뷰 로딩 시 화면이 깜박거리는것처럼 보이던 문제 해결
- HomeView UI 개선 (캐릭터 이미지 크기 동적으로 조절)
- 마이페이지 프로필 이미지 사진 비율 조정
- svg, png 형식과 무관하게 이미지 파일 받아올 수 있도록 구현

<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### ❗️PR Point
<!-- 부족했던 점 혹은 개선하고 싶은 방향이 있다면 얘기해주세요 -->
지금은 SVG 받아오는 함수 로직만 일부 변경한 거라서, 추후 더 정교하고 광범위하게 개선할 예정입니다. 이 점 참고해 주세요~!
<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->
다음과 같이 투명한 배경의 png 이미지를 잘 받아오는 것을 확인할 수 있었습니다.

예시 이미지 링크는 다음과 같습니다.
[예시 이미지](https://www.apple.com/kr/iphone-16/c/images/overview/welcome/hero_alt__ey5khbzf04eq_large_2x.png)

| UIImageView의 확장 함수를 사용하는 경우 | SVGFetchable 프로토콜을 사용하는 경우  |
|:------:|:---:|
|   <img src="https://github.com/user-attachments/assets/8cdfd662-4970-4bf5-9e61-b7ff90addd22" width=200> | <img src="https://github.com/user-attachments/assets/e49dc7d3-d8a2-4803-bd75-5203c385ee8f" width=200> |


- Resolved: #270 
