### PR TITLE
[Fix] #316 - 홈 뷰 컴포넌트들의 계층 변경

### DIFF
--- a/Offroad-iOS/Offroad-iOS/Presentation/Home/View/HomeView.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Home/View/HomeView.swift
@@ -162,9 +162,9 @@ extension HomeView {
             backgroundImageView,
             nicknameLabel,
             characterNameView,
-            buttonStackView,
             characterBaseImageView,
             characterMotionView,
+            buttonStackView,
             titleView,
             questStackView
         )


### PR DESCRIPTION
### 🌴 작업한 브랜치
- #316


### ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->
로티 화면이 홈 화면의 다른 버튼을 가려 터치가 제한되는 문제를 해결하였습니다. 
로티 화면이 화면 우측 상단에 들어가는 버튼들(buttonStackView)보다 더 위의 계층에 위치해서 터치 이벤트를 가로채는 현상이 있어, buttonStackView의 계층 구조를 로티 이미지 및 기본 캐릭터 이미지보다 더 위로 오도록 설정하였습니다. 
<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### ❗️PR Point
<!-- 부족했던 점 혹은 개선하고 싶은 방향이 있다면 얘기해주세요 -->

<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->

|뷰|설명|
|:------:|:---:|
|        |     |


- Resolved: #316 
