### PR TITLE
[Feat] #299 - 전송 버튼 누른 후 캐릭터 답장 오기 전까지 전송 버튼 비활성화

### DIFF
--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/ViewControllers/ORBCharacterChatViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/ViewControllers/ORBCharacterChatViewController.swift
@@ -23,6 +23,8 @@ class ORBCharacterChatViewController: UIViewController {
     let userChatInputViewTextInputViewHeightRelay = PublishRelay<CGFloat>()
     // userChatDisplayView의 textInputVie의 height를 전달
     let userChatDisplayViewTextInputViewHeightRelay = PublishRelay<CGFloat>()
+    let isCharacterResponding = BehaviorRelay<Bool>(value: false)
+    let isTextViewEmpty = BehaviorRelay<Bool>(value: true)
     
     let characterChatBoxPositionAnimator = UIViewPropertyAnimator(duration: 0.5, dampingRatio: 1)
     let characterChatBoxModeChangingAnimator = UIViewPropertyAnimator(duration: 0.4, dampingRatio: 1)
@@ -154,7 +156,6 @@ extension ORBCharacterChatViewController {
         rootView.sendButton.rx.tap.bind { [weak self] in
             guard let self else { return }
             self.postCharacterChat(message: self.rootView.userChatInputView.text)
-            self.rootView.sendButton.isEnabled = false
             // 로티 뜨도록 구현
             self.configureCharacterChatBox(character: MyInfoManager.shared.representativeCharacterName ?? "", message: "", mode: .loading, animated: true)
             self.showCharacterChatBox()
@@ -186,7 +187,7 @@ extension ORBCharacterChatViewController {
                     self.rootView.userChatDisplayView.isHidden = true
                     self.rootView.loadingAnimationView.isHidden = false
                     self.rootView.loadingAnimationView.play()
-                    self.rootView.sendButton.isEnabled = true
+                    self.isTextViewEmpty.accept(false)
                     self.updateChatDisplayViewHeight(height: 20)
                 } else {
                     print("입력된 텍스트 없음")
@@ -195,7 +196,7 @@ extension ORBCharacterChatViewController {
                     self.rootView.loadingAnimationView.currentProgress = 0
                     self.rootView.loadingAnimationView.pause()
                     self.rootView.loadingAnimationView.isHidden = true
-                    self.rootView.sendButton.isEnabled = false
+                    self.isTextViewEmpty.accept(true)
                 }
             }).disposed(by: disposeBag)
         
@@ -225,6 +226,13 @@ extension ORBCharacterChatViewController {
             self.rootView.updateConstraints()
             self.rootView.layoutIfNeeded()
         }).disposed(by: disposeBag)
+        
+        Observable.combineLatest(isCharacterResponding, isTextViewEmpty)
+            .map { return (!$0 && !$1) }
+            .subscribe { [weak self] shouldEnableSendButton in
+                guard let self else { return }
+                self.rootView.sendButton.isEnabled = shouldEnableSendButton
+            }.disposed(by: disposeBag)
     }
     
     private func setupGestures() {
@@ -233,6 +241,7 @@ extension ORBCharacterChatViewController {
     }
     
     private func postCharacterChat(message: String) {
+        isCharacterResponding.accept(true)
         let dto = CharacterChatPostRequestDTO(content: message)
         NetworkService.shared.characterChatService.postChat(body: dto) { [weak self] result in
             guard let self else { return }
@@ -269,7 +278,7 @@ extension ORBCharacterChatViewController {
                 self.showToast(message: "decode Error occurred", inset: 66)
                 self.hideCharacterChatBox()
             }
-            self.rootView.sendButton.isEnabled = true
+            self.isCharacterResponding.accept(false)
         }
     }
     

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/ViewControllers/ORBCharacterChatViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/ViewControllers/ORBCharacterChatViewController.swift
@@ -154,7 +154,7 @@ extension ORBCharacterChatViewController {
         rootView.sendButton.rx.tap.bind { [weak self] in
             guard let self else { return }
             self.postCharacterChat(message: self.rootView.userChatInputView.text)
-            print("메시지 전송: \(self.rootView.userChatInputView.text!)")
+            self.rootView.sendButton.isEnabled = false
             // 로티 뜨도록 구현
             self.configureCharacterChatBox(character: MyInfoManager.shared.representativeCharacterName ?? "", message: "", mode: .loading, animated: true)
             self.showCharacterChatBox()
@@ -269,6 +269,7 @@ extension ORBCharacterChatViewController {
                 self.showToast(message: "decode Error occurred", inset: 66)
                 self.hideCharacterChatBox()
             }
+            self.rootView.sendButton.isEnabled = true
         }
     }
     

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/ChatLog/ViewControllers/CharacterChatLogViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/ChatLog/ViewControllers/CharacterChatLogViewController.swift
@@ -237,9 +237,8 @@ extension CharacterChatLogViewController {
         rootView.sendButton.rx.tap.bind(
             onNext: { [weak self] in
                 guard let self else { return }
-                
                 self.postCharacterChat(message: self.rootView.userChatInputView.text)
-                
+                self.rootView.sendButton.isEnabled = false
                 // 사용자 채팅 버블 추가
                 self.sendChatBubble(isUserChat: true, text: self.rootView.userChatInputView.text) { [weak self] isFinished in
                     guard let self else { return }
@@ -428,6 +427,7 @@ extension CharacterChatLogViewController {
             case .decodeErr:
                 self.showToast(message: "decode Error occurred", inset: 66)
             }
+            self.rootView.sendButton.isEnabled = true
         }
     }
     

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/ChatLog/ViewControllers/CharacterChatLogViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/ChatLog/ViewControllers/CharacterChatLogViewController.swift
@@ -29,6 +29,8 @@ class CharacterChatLogViewController: OffroadTabBarViewController {
     // userChatInputView의 textInputView의 height를 전달
     let userChatInputViewTextInputViewHeightRelay = PublishRelay<CGFloat>()
     let userChatInputViewHeightAnimator = UIViewPropertyAnimator(duration: 0.3, dampingRatio: 1)
+    let isCharacterResponding = BehaviorRelay<Bool>(value: false)
+    let isTextViewEmpty = BehaviorRelay<Bool>(value: true)
     
     var disposeBag = DisposeBag()
     var characterName: String
@@ -224,13 +226,13 @@ extension CharacterChatLogViewController {
                     print("입력된 텍스트: \(text)")
                     self.rootView.loadingAnimationView.isHidden = false
                     self.rootView.loadingAnimationView.play()
-                    self.rootView.sendButton.isEnabled = true
+                    self.isTextViewEmpty.accept(false)
                 } else {
                     print("입력된 텍스트 없음")
                     self.rootView.loadingAnimationView.currentProgress = 0
                     self.rootView.loadingAnimationView.pause()
                     self.rootView.loadingAnimationView.isHidden = true
-                    self.rootView.sendButton.isEnabled = false
+                    self.isTextViewEmpty.accept(true)
                 }
             }).disposed(by: disposeBag)
         
@@ -292,6 +294,13 @@ extension CharacterChatLogViewController {
                     showToast(message: ErrorMessages.networkError, inset: 66)
                 }
             }).disposed(by: disposeBag)
+        
+        Observable.combineLatest(isCharacterResponding, isTextViewEmpty)
+            .map { return (!$0 && !$1) }
+            .subscribe { [weak self] shouldEnableSendButton in
+                guard let self else { return }
+                self.rootView.sendButton.isEnabled = shouldEnableSendButton
+            }.disposed(by: disposeBag)
     }
     
     private func setupNotifications() {
@@ -399,6 +408,7 @@ extension CharacterChatLogViewController {
     }
     
     private func postCharacterChat(message: String) {
+        isCharacterResponding.accept(true)
         let dto = CharacterChatPostRequestDTO(content: message)
         NetworkService.shared.characterChatService.postChat(body: dto) { [weak self] result in
             guard let self else { return }
@@ -427,7 +437,7 @@ extension CharacterChatLogViewController {
             case .decodeErr:
                 self.showToast(message: "decode Error occurred", inset: 66)
             }
-            self.rootView.sendButton.isEnabled = true
+            self.isCharacterResponding.accept(false)
         }
     }
     


### PR DESCRIPTION
### 🌴 작업한 브랜치
- #299 


### ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->
캐릭터에게 채팅을 보내고 난 후, 답장이 오기 전까지 전송 버튼을 비활성화해야 합니다. 
지금은 해당 로직이 구현되어있지 않아서, 이를 구현하였습니다.
<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### ❗️PR Point
<!-- 부족했던 점 혹은 개선하고 싶은 방향이 있다면 얘기해주세요 -->

<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->

|캐릭터 채팅 시|채팅 로그|
|:------:|:---:|
|     <img src="https://github.com/user-attachments/assets/e56ab5d1-ddd9-4dc7-b008-d1a0c1af3b0a" width=200>   |   <img src="https://github.com/user-attachments/assets/2ed6ef86-2fc1-407a-b236-6be4ce3175f4" width=200>  |


- Resolved: #299 
