### PR TITLE
[Fix] #307 - 캐릭터 목록 뷰에 처음 진입 시, 캐릭터 이미지가 이상하게 뜨는 현상 해결

### DIFF
--- a/Offroad-iOS/Offroad-iOS/Application/AppDelegate.swift
+++ b/Offroad-iOS/Offroad-iOS/Application/AppDelegate.swift
@@ -21,6 +21,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             KakaoSDK.initSDK(appKey: nativeAppKey)
         }
         
+        // NetworkMonitoringManager 싱글톤 객체 생성
+        let _ = NetworkMonitoringManager.shared
+        
         return true
     }
 


### PR DESCRIPTION
### 🌴 작업한 브랜치
- #307 


### ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->
캐릭터 목록 뷰에 처음 진입 시, 캐릭터 이미지가 이상하게 뜨는 현상이 있었습니다. 
주로 앱을 시작하고 바로 캐릭터 목록 뷰에 진입하였을 때 캐릭터 목록의 이미지들이 이상하게 뒤죽박죽되는 현상입니다. 

원인은 `NetworkMonitoringManager`와 관련이 있었음을 확인하였습니다. 
해당 객체는 앱 내에서 네트워크 변경을 감지하기 위해 구현했던 싱글톤 객체인데, 
`PublishSubject`를 이용하여 네트워크 변경 시에 이를 감지하여 관련 토스트를 띄우는 역할을 하였습니다. 
캐릭터 목록 뷰에서 처음 이 Subject를 구독하게 되는데, 이 시점에 싱글톤 객체에도 처음 접근하기 때문에, 싱글톤 객체가 이때 생성되게 되고, 
이로 인해 캐릭터 목록 뷰에서 처음 캐릭터 목록을 보내는 API를 (의도치 않게) 두 번 호출하여 짧은 시간 내에 `reloadData()`가 중복으로 호출되게 됩니다. 

문제는 컬렉션뷰가 reload된 후에 얻는 이미지 URL을 이용하여 각 셀은 다시 자신의 이미지를 네트워크 통신을 통해 가져오게 된다는 점입니다. 
각 셀에서 이미지를 가져오는 통신을 하던 중에 `reloadData()`가 한 번 더 호출되면서 셀이 재사용되게 되고, 이때 셀이 재정렬되면서 객체의 순서가 바뀌는 경우 이미지 역시 뒤죽박죽되는 현상이 발생하게 됩니다. 

이를 해결하기 위해 앱 시작 시에 `NetworkMonitoringManager` 싱글톤 객체 생성함으로써, 
캐릭터 목록 뷰에서 `NetworkMonitoringManager` 객체를 생성하지 않아 `reloadData()`를 중복으로 호출하는 상황을 방지하였습니다. 
<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### ❗️PR Point
<!-- 부족했던 점 혹은 개선하고 싶은 방향이 있다면 얘기해주세요 -->
이 PR이 근본적으로 이를 해결하는 방법은 아니라고 생각합니다. 
현재 저희 앱은 여러 API가 있고, 특히 통신의 응답으로 이미지 URL을 받아오는 경우가 많은데요, 
이 이미지 URL을 이용해서 재사용되는 셀에 이미지를 표현하고자 할 경우 셀 데이터를 받아왔을 때, 
각 셀에서는 이미지를 받아오는 비동기 작업을 시작하게 됩니다. 
문제는 `reloadData()`가 호출되고 셀이 재사용되었을 때 이 이미지를 받아오는 네트워크 통신을 취소할 수 없다는 데에 있습니다. 
셀이 재사용될 경우 현재 이미지를 받아오는 작업을 취소하고 새 이미지를 받아와야 하는데, 기존 이미지를 받아오는 작업을 계속하고 있는 상황이 됩니다. 이러한 현상은 캐릭터 목록 뷰 외에도 각 셀에서 이미지를 가져오는 경우라면 모두 문제가 생길 가능성이 존재합니다. 
(현재는 받아오는 데이터가 많지 않고, 응답 속도도 빨라 이러한 문제를 체감하기는 힘듭니다.)
이는 `DispatchQueue`를 사용하는 경우 생기는 한계점으로, 원하는 시점에 네트워크 통신을 취소하기 위해서는 `OperationQueue`를 사용하는 것이 근본적으로 현 문제를 해결하는 방법이며 더 적합한 방법으로 생각되지만, 시간적인 여유가 없어 후순위로 미뤄둔 상태입니다. 
<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->

|뷰| <img src="https://github.com/user-attachments/assets/362f609c-6c74-438a-804d-f9d09f1df50e" width=200> |
|---|---|
| 설명 | 캐릭터 목록 이미지가 정상적인 순서대로 표시되는 것을 확인할 수 있습니다.  |


- Resolved: #307 
