### PR TITLE
[Fix] #320 - 홈 화면의 칭호 변경 팝업 관련 문제 수정

### DIFF
--- a/Offroad-iOS/Offroad-iOS/Presentation/Home/TitlePopup/View/TitlePopupView.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Home/TitlePopup/View/TitlePopupView.swift
@@ -25,7 +25,7 @@ final class TitlePopupView: UIView {
     private let popupView = UIView()
     private let myTitleLabel = UILabel()
     private let closeButton = UIButton()
-    private let titleCollectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewLayout())
+    let titleCollectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewLayout())
     private let changeTitleButton = StateToggleButton(state: .isDisabled, title: "바꾸기")
         
     // MARK: - Life Cycle

--- a/Offroad-iOS/Offroad-iOS/Presentation/Home/TitlePopup/ViewController/TitlePopupViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Home/TitlePopup/ViewController/TitlePopupViewController.swift
@@ -23,6 +23,11 @@ final class TitlePopupViewController: UIViewController {
         didSet {
             rootView.reloadCollectionView()
             userTitleIndex = titleModelList?.firstIndex(where: { $0.emblemName == userTitleString }) ?? Int()
+            rootView.titleCollectionView.selectItem(
+                at: IndexPath(item: userTitleIndex, section: 0),
+                animated: false,
+                scrollPosition: []
+            )
         }
     }
     
@@ -127,10 +132,6 @@ extension TitlePopupViewController: UICollectionViewDataSource {
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: TitleCollectionViewCell.className, for: indexPath) as? TitleCollectionViewCell else { return UICollectionViewCell() }
         if let titleModelList {
             cell.configureCell(data: titleModelList[indexPath.item])
-            
-            if indexPath.item == userTitleIndex {
-                cell.changeCellState(true)
-            }
         }
         
         return cell
@@ -145,7 +146,7 @@ extension TitlePopupViewController: UICollectionViewDelegateFlowLayout {
     }
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        collectionView.cellForItem(at: indexPath)?.isSelected = true
+        collectionView.selectItem(at: indexPath, animated: false, scrollPosition: [])
         indexPath.item == userTitleIndex ? rootView.toggleChangeTitleButtonState(false) : rootView.toggleChangeTitleButtonState(true)
 
         if let titleModelList {

--- a/Offroad-iOS/Offroad-iOS/Presentation/Home/ViewController/HomeViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Home/ViewController/HomeViewController.swift
@@ -143,7 +143,7 @@ extension HomeViewController {
         titlePopupViewController.modalPresentationStyle = .overCurrentContext
         titlePopupViewController.delegate = self
         
-        present(titlePopupViewController, animated: false)
+        tabBarController?.present(titlePopupViewController, animated: false)
     }
 }
 


### PR DESCRIPTION
### 🌴 작업한 브랜치
- #320 


### ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->
홈 화면의 칭호 변경 팝업 관련 문제를 수정하였습니다. 
- 칭호 변경 팝업이 떴을 때, 탭바의 다른 탭을 누를 수 있던 문제를 해결하였습니다. 
- 칭호 변경 팝업에서 다른 칭호를 선택해도 기존 칭호가 계속 선택되어있던 것처럼 보이던 문제를 해결하였습니다. 
<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### ❗️PR Point
<!-- 부족했던 점 혹은 개선하고 싶은 방향이 있다면 얘기해주세요 -->

<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->

|뷰|설명|
|:------:|:---:|
|   <img src="https://github.com/user-attachments/assets/de163884-6a1f-41a8-861a-d2eacdb834bf" width=200>   |     |


- Resolved: #320 
