### PR TITLE
[Fix] #324 - 캐릭터 채팅 API 중 500에러 대응

### DIFF
--- a/Offroad-iOS/Offroad-iOS/Network/Base/BaseService.swift
+++ b/Offroad-iOS/Offroad-iOS/Network/Base/BaseService.swift
@@ -23,6 +23,7 @@ class BaseService {
         case 404: return .apiArr
         case 405: return .pathErr
         case 409: return .requestErr
+        case 500: return .serverErr
         default: return .networkFail
         }
     }
@@ -37,6 +38,7 @@ class BaseService {
         case 404: return .apiArr
         case 405: return .pathErr
         case 409: return .requestErr
+        case 500: return .serverErr
         default: return .networkFail
         }
     }

--- a/Offroad-iOS/Offroad-iOS/Network/Base/NetworkResult.swift
+++ b/Offroad-iOS/Offroad-iOS/Network/Base/NetworkResult.swift
@@ -16,5 +16,6 @@ enum NetworkResult<T> {
     case pathErr                    // 경로 에러 발생했을 때 (405)
     case registerErr                // 데이터 등록 오류가 발생했을 때 (409)
     case networkFail                // 네트워크 연결 실패했을 때
+    case serverErr                // 서버에서 에러가 발생했을 때 (500대)
     case decodeErr                  // 데이터는 받아왔으나 DTO 형식으로 decode가 되지 않을 때
 }

--- a/Offroad-iOS/Offroad-iOS/Network/CharacterChat/CharacterChatService.swift
+++ b/Offroad-iOS/Offroad-iOS/Network/CharacterChat/CharacterChatService.swift
@@ -28,16 +28,11 @@ final class CharacterChatService: BaseService, CharacterChatServiceProtocol {
                 )
                 completion(networkResult)
             case .failure(let error):
-                print(error.localizedDescription)
-                switch error {
-                case .underlying(let erorr, let response):
-                    print(error.localizedDescription)
-                    if response == nil {
-                        completion(.networkFail)
-                    }
-                default:
-                    print(error.localizedDescription)
-                }
+                let networkResult: NetworkResult<CharacterChatPostResponseDTO> = self.fetchNetworkResult(
+                    statusCode: error.response?.statusCode ?? 0,
+                    data: error.response?.data ?? Data()
+                )
+                completion(networkResult)
             }
         }
     }

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/ViewControllers/ORBCharacterChatViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/ViewControllers/ORBCharacterChatViewController.swift
@@ -274,6 +274,9 @@ extension ORBCharacterChatViewController {
             case .networkFail:
                 self.showToast(message: ErrorMessages.networkError, inset: 66)
                 self.hideCharacterChatBox()
+            case .serverErr:
+                self.showToast(message: "오브가 답변하기 힘든 질문이예요.\n다른 이야기를 해볼까요?", inset: 66)
+                self.hideCharacterChatBox()
             case .decodeErr:
                 self.showToast(message: "decode Error occurred", inset: 66)
                 self.hideCharacterChatBox()

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/ChatLog/Views/ReusableView/CharacterChatLogCell.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/ChatLog/Views/ReusableView/CharacterChatLogCell.swift
@@ -125,7 +125,6 @@ extension CharacterChatLogCell {
             messageLabelTrailingConstraint.isActive = true
             messageLabel.snp.remakeConstraints { make in
                 make.top.bottom.equalToSuperview().inset(14)
-//                make.trailing.equalToSuperview().inset(20)
                 make.leading.equalToSuperview().inset(20)
             }
             chatBubbleView.snp.remakeConstraints { make in
@@ -184,37 +183,5 @@ extension CharacterChatLogCell {
         updateConstraints()
         layoutIfNeeded()
     }
-    
-//    func startChatLoading() {
-//        guard role == .character else { return }
-//        animator.stopAnimation(true)
-//        messageLabel.isHidden = true
-//        loadingAnimationView.isHidden = false
-//        loadingAnimationView.play()
-//        animator.addAnimations { [weak self] in
-//            guard let self else { return }
-//            self.messageLabelTrailingConstraint.isActive = false
-//            self.loadingAnimationViewTrailingConstraint.isActive = true
-//            self.contentView.layoutIfNeeded()
-//        }
-//        animator.startAnimation()
-//    }
-//    
-//    func stopChatLoading(newMessage: String? = nil) {
-//        guard role == .character else { return }
-//        animator.stopAnimation(true)
-//        messageLabel.isHidden = false
-//        messageLabel.numberOfLines = 0
-//        if let newMessage { messageLabel.text = newMessage }
-//        loadingAnimationView.isHidden = true
-//        loadingAnimationView.stop()
-//        animator.addAnimations { [weak self] in
-//            guard let self else { return }
-//            self.loadingAnimationViewTrailingConstraint.isActive = false
-//            self.messageLabelTrailingConstraint.isActive = true
-//            self.contentView.layoutIfNeeded()
-//        }
-//        animator.startAnimation()
-//    }
     
 }


### PR DESCRIPTION
### 🌴 작업한 브랜치
- #324 


### ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->
캐릭터 채팅 API를 사용할 때, 응답의 길이가 너무 길어져서 서버에서 에러가 나 500대 에러를 발생하는 이슈가 있습니다. 
이 경우에 대해 별도의 에러처리가 없어서 이를 반영하였습니다. 
서버에서 500에러가 났을 경우, "오브가 답변하기 힘든 질문이에요, 다른 이야기를 해볼까요?" 라는 토스트를 띄우게 됩니다. 
추가로 채팅 뷰일 경우 캐릭터 채팅 박스가 올라가고, 채팅 로그 뷰일 경우, 캐릭터가 답장하던 말풍선이나 내가 직전에 보냈던 채팅 기록을 지우게 됩니다. 

이를 구현하기 위해, `NetworkResult` 타입에 `serverErr` 케이스를 추가하였으며, 
BaseService의 메서드인 `fetchNetworkResult`의 경우 NetworkResult 타입을 반환하므로, status별 반환 케이스에 500 에러를 추가하였습니다. 
<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### ❗️PR Point
<!-- 부족했던 점 혹은 개선하고 싶은 방향이 있다면 얘기해주세요 -->
답변이 길어서 서버의 에러가 나는 경우는 답변이 길 것 같은 질문을 하면 되는데, 
"대표적인 CS 면접질문 10개만 뽑아줘."
라고 보낼 경우 (지금까지는) 100% 확률로 서버 에러가 발생했습니다. 

이를 통해 인위적으로 서버 에러를 일으킬 수 있으므로 테스트를 하고자 할 경우, 해당 문구를 보내면 될 것 같습니다. 
<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->

|채팅 뷰|채팅 로그 뷰|
|:------:|:---:|
|    <img src="https://github.com/user-attachments/assets/b9d12c87-9dcd-43c3-9402-a96a99dc6c1c" width=200>    |   <img src="https://github.com/user-attachments/assets/3d74a50b-a6e5-46ff-abff-825d86d7d4f5" width=200>  |


- Resolved: #324 
