### PR TITLE
[Feat] #312 - 캐릭터 목록 중 획득하지 않은 캐릭터 탭 제한

### DIFF
--- a/Offroad-iOS/Offroad-iOS/Presentation/MyPage/CharacterList/ViewController/CharacterListViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/MyPage/CharacterList/ViewController/CharacterListViewController.swift
@@ -124,6 +124,14 @@ extension CharacterListViewController: UICollectionViewDelegate {
         navigationController?.pushViewController(characterDetailViewController, animated: true)
     }
     
+    func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool {
+        if viewModel.characterListDataSource[indexPath.item].isGained {
+            return true
+        } else {
+            return false
+        }
+    }
+    
 }
 
 //MARK: - SelectMainCharacterDelegate


### PR DESCRIPTION
### 🌴 작업한 브랜치
- #312 


### ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->
캐릭터 목록 뷰에서, 획득하지 않은 캐릭터를 탭 했을 때, 캐릭터 상세 뷰로 넘어가는 이슈가 있었습니다. 
이를 해결하기 위해, 획득하지 않은 캐릭터의 경우는 select될 수 없도록 구현하였습니다. 
<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### ❗️PR Point
<!-- 부족했던 점 혹은 개선하고 싶은 방향이 있다면 얘기해주세요 -->

<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->

|뷰|설명|
|:------:|:---:|
|        |     |


- Resolved: #312 
