### PR TITLE
[Fix] #327 - 홈 뷰와 마이페이지의 새로고침 로직 개선

### DIFF
--- a/Offroad-iOS/Offroad-iOS/Global/MyInfoManager/MyInfoManager.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/MyInfoManager/MyInfoManager.swift
@@ -7,7 +7,12 @@
 
 import Foundation
 
+import RxSwift
+import RxRelay
+
 final class MyInfoManager {
+    
+    //MARK: - Properties
     
     var representativeCharacterID: Int? = nil
     var completerQuestCount: Int? = nil
@@ -20,8 +25,15 @@ final class MyInfoManager {
         return characterInfo[representativeCharacterID]
     }
     
+    //MARK: - Rx Properties
+    
+    let didSuccessAdventure = PublishRelay<Void>()
+    let didChangeRepresentativeCharacter = PublishRelay<Void>()
+    let didChangeEmblem = PublishRelay<Void>()
     
     static let shared = MyInfoManager()
+    
+    //MARK: - Life Cycle
     
     private init() { }
     

--- a/Offroad-iOS/Offroad-iOS/Global/MyInfoManager/MyInfoManager.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/MyInfoManager/MyInfoManager.swift
@@ -30,6 +30,7 @@ final class MyInfoManager {
     let didSuccessAdventure = PublishRelay<Void>()
     let didChangeRepresentativeCharacter = PublishRelay<Void>()
     let didChangeEmblem = PublishRelay<Void>()
+    let shouldUpdateCharacterAnimation = PublishRelay<String>()
     
     static let shared = MyInfoManager()
     

--- a/Offroad-iOS/Offroad-iOS/Presentation/Home/ViewController/HomeViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Home/ViewController/HomeViewController.swift
@@ -8,11 +8,13 @@
 import UIKit
 
 import Photos
+import RxSwift
 
 final class HomeViewController: OffroadTabBarViewController {
     
     //MARK: - Properties
     
+    private var disposeBag = DisposeBag()
     private let rootView = HomeView()
     
     private var userEmblemString = ""
@@ -35,6 +37,9 @@ final class HomeViewController: OffroadTabBarViewController {
         super.viewDidLoad()
         
         setupTarget()
+        getUserAdventureInfo()
+        getUserQuestInfo()
+        bindData()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -44,8 +49,7 @@ final class HomeViewController: OffroadTabBarViewController {
         offroadTabBarController.showTabBarAnimation()
         
         self.navigationController?.navigationBar.isHidden = true
-        getUserAdventureInfo()
-        getUserQuestInfo()
+        
     }
 }
 
@@ -105,6 +109,20 @@ extension HomeViewController {
                 break
             }
         }
+    }
+    
+    private func bindData() {
+        MyInfoManager.shared.didSuccessAdventure
+            .subscribe(onNext: { [weak self] in
+                guard let self else { return }
+                self.getUserQuestInfo()
+            }).disposed(by: disposeBag)
+        
+        MyInfoManager.shared.didChangeRepresentativeCharacter
+            .subscribe(onNext: { [weak self] in
+                guard let self else { return }
+                self.getUserAdventureInfo()
+            }).disposed(by: disposeBag)
     }
     
     //MARK: - Func

--- a/Offroad-iOS/Offroad-iOS/Presentation/Home/ViewController/HomeViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Home/ViewController/HomeViewController.swift
@@ -113,8 +113,10 @@ extension HomeViewController {
     
     private func bindData() {
         MyInfoManager.shared.didSuccessAdventure
+            .debug()
             .subscribe(onNext: { [weak self] in
                 guard let self else { return }
+                self.getUserAdventureInfo()
                 self.getUserQuestInfo()
             }).disposed(by: disposeBag)
         
@@ -122,6 +124,13 @@ extension HomeViewController {
             .subscribe(onNext: { [weak self] in
                 guard let self else { return }
                 self.getUserAdventureInfo()
+            }).disposed(by: disposeBag)
+        
+        MyInfoManager.shared.shouldUpdateCharacterAnimation
+            .debug()
+            .subscribe(onNext: { [weak self] category in
+                guard let self else { return }
+                self.categoryString = category
             }).disposed(by: disposeBag)
     }
     

--- a/Offroad-iOS/Offroad-iOS/Presentation/MyPage/CharacterList/ViewModel/CharacterDetailViewModel.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/MyPage/CharacterList/ViewModel/CharacterDetailViewModel.swift
@@ -90,6 +90,7 @@ extension CharacterDetailViewModel {
             case .success:
                 representativeCharacterId = characterId
                 MyInfoManager.shared.representativeCharacterID = characterId
+                MyInfoManager.shared.didChangeRepresentativeCharacter.accept(())
                 representativeCharacterChanged.onNext(())
             case .networkFail:
                 self.networkingFailure.onNext(())

--- a/Offroad-iOS/Offroad-iOS/Presentation/MyPage/ViewControllers/MyPageViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/MyPage/ViewControllers/MyPageViewController.swift
@@ -7,11 +7,14 @@
 
 import UIKit
 
+import RxSwift
+
 final class MyPageViewController: OffroadTabBarViewController {
     
     //MARK: - Properties
     
     private let rootView = MyPageView()
+    private let disposeBag = DisposeBag()
     
     // MARK: - Life Cycle
     
@@ -23,6 +26,8 @@ final class MyPageViewController: OffroadTabBarViewController {
         super.viewDidLoad()
         
         setupAddTarget()
+        getUserInfo()
+        bindData()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -30,8 +35,6 @@ final class MyPageViewController: OffroadTabBarViewController {
         
         guard let offroadTabBarController = self.tabBarController as? OffroadTabBarController else { return }
         offroadTabBarController.showTabBarAnimation()
-        
-        getUserInfo()
     }
 }
 
@@ -62,8 +65,17 @@ extension MyPageViewController {
         }
     }
     
-    // MARK: - @objc Func
-    
+    private func bindData() {
+        Observable.merge([MyInfoManager.shared.didSuccessAdventure.asObservable(),
+                          MyInfoManager.shared.didChangeRepresentativeCharacter.asObservable()])
+        .subscribe(onNext: { [weak self] in
+            guard let self else { return }
+            self.getUserInfo()
+        }).disposed(by: disposeBag)
+    }
+        
+        // MARK: - @objc Func
+        
     @objc private func myPageButtonTapped(_ sender: UIButton) {
         if sender == rootView.characterButton {
             let characterListViewController = CharacterListViewController()

--- a/Offroad-iOS/Offroad-iOS/Presentation/QuestMap/ViewControllers/QuestMapViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/QuestMap/ViewControllers/QuestMapViewController.swift
@@ -206,6 +206,7 @@ extension QuestMapViewController {
             guard let self else { return }
             if success {
                 self.viewModel.updateRegisteredPlaces(at: self.currentPositionTarget)
+                MyInfoManager.shared.shouldUpdateCharacterAnimation.accept(latestCategory ?? "NONE")
                 MyInfoManager.shared.didSuccessAdventure.accept(())
             }
             self.tabBarController?.view.stopLoading()
@@ -292,16 +293,6 @@ extension QuestMapViewController {
         let okAction = ORBAlertAction(title: buttonTitle, style: .default) { [weak self] _ in
             guard let self else { return }
             if isSuccess {
-                // 홈 화면에서 띄울 로티 결정
-                guard let homeNavigationController = tabBarController?.viewControllers?[0] as? UINavigationController else {
-                    print("navigationController not found")
-                    return
-                }
-                guard let homeViewController = homeNavigationController.viewControllers[0] as? HomeViewController else {
-                    print("home view not found")
-                    return
-                }
-                homeViewController.categoryString = latestCategory ?? "NONE"
                 self.tabBarController?.selectedIndex = 0
             }
             

--- a/Offroad-iOS/Offroad-iOS/Presentation/QuestMap/ViewControllers/QuestMapViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/QuestMap/ViewControllers/QuestMapViewController.swift
@@ -206,6 +206,7 @@ extension QuestMapViewController {
             guard let self else { return }
             if success {
                 self.viewModel.updateRegisteredPlaces(at: self.currentPositionTarget)
+                MyInfoManager.shared.didSuccessAdventure.accept(())
             }
             self.tabBarController?.view.stopLoading()
             self.popupAdventureResult(isSuccess: success, image: image, completeQuests: completeQuests)


### PR DESCRIPTION
### 🌴 작업한 브랜치
- #327 


### ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->
현재 홈 뷰 마이페이지에서는 뷰가 보일 때마다 매번 새로 데이터를 받아오고 있습니다.
`viewWillAppear()` 메서드에서 API를 사용하여 서버와 통신하는 식인데요,

이 때문에, 내비게이션 스택에서 pop을 하려고 제스처를 사용할 때, 일시적으로 화면이 깜박거리는 것 처럼 보입니다.
(사실 로딩으로 인해 화면이 어두워졌다 밝아지는 것인데, 사용자 입장에서는 찰나의 순간이라 깜박거리는 것 처럼 보일 수 있습니다. )

그래서 이 부분에 대한 문제를 근본적으로 해결하고자, 로직을 수정하였습니다. 
방법은 "정보가 업데이트될 때만 서버로부터 새 데이터를 받아온다" 입니다. 
지금은 같은 정보를 계속 새로 받아오고 있는 상황이라서 이를 개선하고자 하였습니다. 

이전에 만들어 놓은 `MyInfoManager`라는 싱글톤 객체가 있습니다. 
이 객체는 현재 대표 캐릭터의 이름을 저장하는데요 (채팅 로그 뷰에서 현재 대표 캐릭터의 이름을 알아야 하기 때문에...)
이 객체 안에서 RxSwift로 이벤트를 전달할 속성들을 일부 추가하였습니다. 

그리고 탐험 정보나 캐릭터 정보가 변경될 때마다 이 Relay들을 통해 탐험 정보나 캐릭터 정보가 변경되었다는 소식을 `MyInfoManager`로 전달하고, 
홈 화면이나 마이페이지에서는 이들 Relay를 구독하고 있다가 변경점이 생길 경우에 한해서 데이터를 업데이트 하게 됩니다. 
이러한 방식은 캐릭터 변경이나 탐험 성공 시 화면에 반영되는 정보가 즉각적으로 업데이트된다는 장점이 있으며, 
이 외에도 매번 화면이 보일 때마다 로딩을 진행하던 전에 비해 서버 통신도 적고, 깜박거리는것처럼 보이는 것 역시 최소화한다는 장점이 있습니다. 
또한 탐험에 성공했을 시에 바로 로티 애니메이션을 불러오기 때문에, 탐험 직후 홈으로 이동 시 로티를 불러오는 데 걸리는 시간으로 인해 깜박거리는 현상을 최소화하였습니다. 
<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### ❗️PR Point
<!-- 부족했던 점 혹은 개선하고 싶은 방향이 있다면 얘기해주세요 -->

<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->

|뷰|설명|
|:------:|:---:|
|  <img src="https://github.com/user-attachments/assets/e8abaac2-720c-4234-89ed-0995c4805835" width=200>  |   <img src="https://github.com/user-attachments/assets/c81c01b4-4875-4b95-86bb-70ab3442588e" width=200>  |


- Resolved: #327 
