### PR TITLE
[Fix] #334 - 채팅 실패 시 말풍선 사라지는 로직 개선

### DIFF
--- a/Offroad-iOS/Offroad-iOS.xcodeproj/project.pbxproj
+++ b/Offroad-iOS/Offroad-iOS.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 		4E3A32A42CE8E353007228D0 /* CharacterChatLogViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E3A32A32CE8E353007228D0 /* CharacterChatLogViewModel.swift */; };
 		4E3F009E2C40D20800B9A31A /* OffroadTabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E3F009D2C40D20800B9A31A /* OffroadTabBarController.swift */; };
 		4E416CE82C45DBE200CF6AB4 /* OffroadPlace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E416CE72C45DBE200CF6AB4 /* OffroadPlace.swift */; };
+		4E456CC02CF4003D0011B50F /* UICollectionView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E456CBF2CF4003D0011B50F /* UICollectionView+.swift */; };
 		4E46E5F72CB997B4000A1EEE /* ORBToastManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E46E5F62CB997B4000A1EEE /* ORBToastManager.swift */; };
 		4E46E5F92CB99944000A1EEE /* ORBToastWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E46E5F82CB99944000A1EEE /* ORBToastWindow.swift */; };
 		4E46E5FB2CBA3F55000A1EEE /* UIWindowScene+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E46E5FA2CBA3F55000A1EEE /* UIWindowScene+.swift */; };
@@ -342,6 +343,7 @@
 		4E3A32A32CE8E353007228D0 /* CharacterChatLogViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CharacterChatLogViewModel.swift; sourceTree = "<group>"; };
 		4E3F009D2C40D20800B9A31A /* OffroadTabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OffroadTabBarController.swift; sourceTree = "<group>"; };
 		4E416CE72C45DBE200CF6AB4 /* OffroadPlace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OffroadPlace.swift; sourceTree = "<group>"; };
+		4E456CBF2CF4003D0011B50F /* UICollectionView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UICollectionView+.swift"; sourceTree = "<group>"; };
 		4E46E5F62CB997B4000A1EEE /* ORBToastManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ORBToastManager.swift; sourceTree = "<group>"; };
 		4E46E5F82CB99944000A1EEE /* ORBToastWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ORBToastWindow.swift; sourceTree = "<group>"; };
 		4E46E5FA2CBA3F55000A1EEE /* UIWindowScene+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIWindowScene+.swift"; sourceTree = "<group>"; };
@@ -688,6 +690,7 @@
 				4E4A8FD62C4A5752001FB498 /* UIImage+.swift */,
 				87738CCF2C8DC15200E107C7 /* UIColor+.swift */,
 				4E99008A2CE0CB61007EEFF7 /* UITextView+.swift */,
+				4E456CBF2CF4003D0011B50F /* UICollectionView+.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -2725,6 +2728,7 @@
 				4E0394E12C2AC059007F0517 /* NSObject+.swift in Sources */,
 				D0E796502C453B47005B47A5 /* AdventureService.swift in Sources */,
 				4E08B95B2C5E4F860082EFB8 /* ORBSegmentedControl.swift in Sources */,
+				4E456CC02CF4003D0011B50F /* UICollectionView+.swift in Sources */,
 				87E046942C3D2B38002D12C2 /* BirthViewController.swift in Sources */,
 				4EF6B0412CC3F1B900066640 /* ORBAlertViewTextFieldWithSubMessage.swift in Sources */,
 				4E3A32892CE733F2007228D0 /* LoadingView.swift in Sources */,

--- a/Offroad-iOS/Offroad-iOS/Global/Extensions/UICollectionView+.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Extensions/UICollectionView+.swift
@@ -1,0 +1,33 @@
+//
+//  UICollectionView+.swift
+//  Offroad-iOS
+//
+//  Created by 김민성 on 11/25/24.
+//
+
+import UIKit
+
+extension UICollectionView {
+    
+    /// 컬렉션뷰의 마지막에서 n번째 `IndexPath`를 반환하는 메서드.
+    /// - Parameter index: 마지막에서 몇 번째 IndexPath를 반환할 지 정하는 값. 1일 경우, 마지막 item의 IndexPath를 반환하며, 0일 경우 `nil`을 반환한다.
+    /// - Returns: 마지막에서 `index`번째의 IndexPath. 컬렉션뷰에 item이 하나도 없거나 마지막에서 `index`번째의 `IndexPath`가 존재하지 않을 경우(`index`가 전체 item의 갯수보다 클 경우) `nil`을 반환
+    ///
+    /// 마지막에서 `index`번째 item의 `IndexPath`를 반환한다. 해당하는 값을 구할 수 없을 경우 `nil`을 반환한다.
+    func getIndexPathFromLast(index: Int) -> IndexPath? {
+        guard index > 0, numberOfSections > 0 else { return nil }
+        var countLeft: Int = index
+        for section in stride(from: numberOfSections - 1, through: 0, by: -1) {
+            let itemCount = numberOfItems(inSection: section)
+            guard itemCount > 0 else { continue }
+            for item in stride(from: itemCount - 1, through: 0, by: -1) {
+                countLeft -= 1
+                if countLeft == 0 {
+                    return IndexPath(item: item, section: section)
+                }
+            }
+        }
+        return nil
+    }
+    
+}

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/ChatLog/ViewControllers/CharacterChatLogViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/ChatLog/ViewControllers/CharacterChatLogViewController.swift
@@ -320,6 +320,7 @@ extension CharacterChatLogViewController {
     
     private func scrollToBottom(animated: Bool) {
         let numberOfSections = rootView.chatLogCollectionView.numberOfSections
+        guard numberOfSections > 0 else { return }
         let numberOfItemsInLastSection = rootView.chatLogCollectionView.numberOfItems(inSection: numberOfSections-1)
         let lastIndexPath = IndexPath(item: numberOfItemsInLastSection-1, section: numberOfSections-1)
         rootView.chatLogCollectionView.scrollToItem(at: lastIndexPath, at: .top, animated: animated)
@@ -444,6 +445,13 @@ extension CharacterChatLogViewController {
         }
     }
     
+    
+    /// 채팅의 결과가 나왔을 때, 채팅 로그를 업데이트하는 메서드
+    /// - Parameter chatSuccess: 채팅이 성공했는지, 실패했는지 여부
+    ///
+    /// 채팅이 성공했을 경우, 로딩 중이던 캐릭터의 말풍선이 캐릭터가 답변한 내용으로 변경됨.
+    ///
+    /// 채팅이 실패했을 경우, 로딩 중이던 캐릭터의 말풍선과 직전에 내가 했던 말풍선을 지움.
     private func updateChatLog(chatSuccess: Bool = true) {
         NetworkService.shared.characterChatService.getChatLog(completion: { [weak self] result in
             guard let self else { return }
@@ -456,20 +464,38 @@ extension CharacterChatLogViewController {
                 }
                 self.chatLogDataList = responseDTO.data.map({ ChatDataModel(data: $0) })
                 
-                let lastSection = chatLogDataSource.count - 1
-                let lastSectionCount = chatLogDataSource[lastSection].count
-                let lastIndexPath = IndexPath(
-                    item: lastSectionCount-1,
-                    section: lastSection
-                )
-                let secondLastIndexPath = IndexPath(
-                    item: lastSectionCount-2,
-                    section: lastSection
-                )
+//                let lastSection = chatLogDataSource.count - 1
+//                let lastSectionCount = chatLogDataSource[lastSection].count
+                
+//                let lastIndexPath = IndexPath(
+//                    item: lastSectionCount-1,
+//                    section: lastSection
+//                )
+                
                 // 채팅이 실패하여 collectionView의 item을 삭제해야 하는 경우,
                 // 아래 collectionView에서 performBatchUpdates 시에, dataSource에서 사라진 indexPath를 참조하여 deleteItems 해야 하므로,
                 // dataSource 업데이트 전 lastIndexPath와 secondLastIndexPath를 상수로 저장한 후 dataSource 업데이트해야 함.
                 self.chatLogDataSource = viewModel.groupChatsByDate(chats: chatLogDataList)
+                
+                guard
+                    let lastIndexPath = self.rootView.chatLogCollectionView.getIndexPathFromLast(index: 1),
+                    let secondLastIndexPath = self.rootView.chatLogCollectionView.getIndexPathFromLast(index: 2) else {
+                    self.showToast(message: "알 수 없는 오류가 발생했어요. 채팅을 다시 시도해 주세요.", inset: 66)
+                    self.navigationController?.popViewController(animated: true)
+                    return
+                }
+//                print("1: \(lastIndexPath)")
+//                print("2: \(self.rootView.chatLogCollectionView.getIndexPathFromLast(index: 1))")
+//                let secondLastIndexPath = IndexPath(
+//                    item: lastSectionCount-2,
+//                    section: lastSection
+//                )
+                
+//                guard let secondLastIndexPath = self.rootView.chatLogCollectionView.getIndexPathFromLast(index: 2) else { return }
+//                print("1: \(secondLastIndexPath)")
+//                print("2: \(self.rootView.chatLogCollectionView.getIndexPathFromLast(index: 2))")
+                
+                
                 
                 if chatSuccess {
                     self.rootView.chatLogCollectionView.performBatchUpdates {
@@ -478,6 +504,10 @@ extension CharacterChatLogViewController {
                 } else {
                     self.rootView.chatLogCollectionView.performBatchUpdates {
                         self.rootView.chatLogCollectionView.deleteItems(at: [lastIndexPath, secondLastIndexPath])
+                        let lastSection = self.rootView.chatLogCollectionView.numberOfSections - 1
+                        if self.chatLogDataSource.count == 0 || self.chatLogDataSource.last?.count == 0 {
+                            self.rootView.chatLogCollectionView.deleteSections([lastSection])
+                        }
                     }
                 }
                 self.scrollToBottom(animated: false)

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/ChatLog/ViewControllers/CharacterChatLogViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/ChatLog/ViewControllers/CharacterChatLogViewController.swift
@@ -453,7 +453,7 @@ extension CharacterChatLogViewController {
     ///
     /// 채팅이 실패했을 경우, 로딩 중이던 캐릭터의 말풍선과 직전에 내가 했던 말풍선을 지움.
     ///
-    /// 에러 발생 시, 채팅 로그 뷰컨트롤러를 nagivation stack에서 pop 하며 에러 메시지 토스트 표시
+    /// 지우려는 말풍선의 indexPath를 구할 수 없는 경우, 채팅 로그 뷰컨트롤러를 nagivation stack에서 pop 하며 에러 메시지 토스트 표시
     private func updateChatLog(chatSuccess: Bool = true) {
         NetworkService.shared.characterChatService.getChatLog(completion: { [weak self] result in
             guard let self else { return }

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/ChatLog/ViewControllers/CharacterChatLogViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/ChatLog/ViewControllers/CharacterChatLogViewController.swift
@@ -319,10 +319,7 @@ extension CharacterChatLogViewController {
     }
     
     private func scrollToBottom(animated: Bool) {
-        let numberOfSections = rootView.chatLogCollectionView.numberOfSections
-        guard numberOfSections > 0 else { return }
-        let numberOfItemsInLastSection = rootView.chatLogCollectionView.numberOfItems(inSection: numberOfSections-1)
-        let lastIndexPath = IndexPath(item: numberOfItemsInLastSection-1, section: numberOfSections-1)
+        guard let lastIndexPath = rootView.chatLogCollectionView.getIndexPathFromLast(index: 1) else { return }
         rootView.chatLogCollectionView.scrollToItem(at: lastIndexPath, at: .top, animated: animated)
     }
     
@@ -471,7 +468,8 @@ extension CharacterChatLogViewController {
                     let lastIndexPath = self.rootView.chatLogCollectionView.getIndexPathFromLast(index: 1),
                     let secondLastIndexPath = self.rootView.chatLogCollectionView.getIndexPathFromLast(index: 2) else {
                     self.showToast(message: "알 수 없는 오류가 발생했어요. 채팅을 다시 시도해 주세요.", inset: 66)
-                    self.navigationController?.popViewController(animated: true)
+                    self.rootView.chatLogCollectionView.reloadData()
+                    self.scrollToBottom(animated: true)
                     return
                 }
                 

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/ChatLog/ViewControllers/CharacterChatLogViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/ChatLog/ViewControllers/CharacterChatLogViewController.swift
@@ -452,6 +452,8 @@ extension CharacterChatLogViewController {
     /// 채팅이 성공했을 경우, 로딩 중이던 캐릭터의 말풍선이 캐릭터가 답변한 내용으로 변경됨.
     ///
     /// 채팅이 실패했을 경우, 로딩 중이던 캐릭터의 말풍선과 직전에 내가 했던 말풍선을 지움.
+    ///
+    /// 에러 발생 시, 채팅 로그 뷰컨트롤러를 nagivation stack에서 pop 하며 에러 메시지 토스트 표시
     private func updateChatLog(chatSuccess: Bool = true) {
         NetworkService.shared.characterChatService.getChatLog(completion: { [weak self] result in
             guard let self else { return }
@@ -463,18 +465,6 @@ extension CharacterChatLogViewController {
                     return
                 }
                 self.chatLogDataList = responseDTO.data.map({ ChatDataModel(data: $0) })
-                
-//                let lastSection = chatLogDataSource.count - 1
-//                let lastSectionCount = chatLogDataSource[lastSection].count
-                
-//                let lastIndexPath = IndexPath(
-//                    item: lastSectionCount-1,
-//                    section: lastSection
-//                )
-                
-                // 채팅이 실패하여 collectionView의 item을 삭제해야 하는 경우,
-                // 아래 collectionView에서 performBatchUpdates 시에, dataSource에서 사라진 indexPath를 참조하여 deleteItems 해야 하므로,
-                // dataSource 업데이트 전 lastIndexPath와 secondLastIndexPath를 상수로 저장한 후 dataSource 업데이트해야 함.
                 self.chatLogDataSource = viewModel.groupChatsByDate(chats: chatLogDataList)
                 
                 guard
@@ -484,18 +474,6 @@ extension CharacterChatLogViewController {
                     self.navigationController?.popViewController(animated: true)
                     return
                 }
-//                print("1: \(lastIndexPath)")
-//                print("2: \(self.rootView.chatLogCollectionView.getIndexPathFromLast(index: 1))")
-//                let secondLastIndexPath = IndexPath(
-//                    item: lastSectionCount-2,
-//                    section: lastSection
-//                )
-                
-//                guard let secondLastIndexPath = self.rootView.chatLogCollectionView.getIndexPathFromLast(index: 2) else { return }
-//                print("1: \(secondLastIndexPath)")
-//                print("2: \(self.rootView.chatLogCollectionView.getIndexPathFromLast(index: 2))")
-                
-                
                 
                 if chatSuccess {
                     self.rootView.chatLogCollectionView.performBatchUpdates {


### PR DESCRIPTION
### 🌴 작업한 브랜치
- #334 


### ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->
채팅에 실패할 경우 (예를 들어 답변이 길어져서 서버에서 500대 에러가 난 경우) 
채팅 로그 뷰에서는 채팅에 실패한 말풍선을 삭제해야 합니다.

이때 가장 최근의 말풍선 2개(캐릭터 로딩 말풍선과 직전에 내가 보낸 말풍선) 를 제거해야 하는데, 
삭제 후 collectoinView의 마지막 섹션이 여전히 존재하는 경우 에러가 발생하며 앱이 꺼지게 됩니다.
(예를 들어, 오늘 처음 메시지를 보낸 경우, 마지막 섹션이 추가되며  item이 추가되는데, 삭제 시에는 item만 삭제되고 section은 삭제되지 않은 상황)
이때, 변경된 dataSource에는 해당 섹션이 남아있지 않아서 에러를 일으키는 것을 확인하였고, 이를 해결하였습니다.

- 주로 변경된 코드는 `ChracterChatLogViewController`의 `updateChatLog(chatSuccess:)` 메서드이며, 아이템이 삭제될 때 마지막 섹션이 비어있거나 DataSource가 빈 데이터인 경우 마지막 섹션을 지우도록 구현하였습니다. 

-  UICollectionView의 item들 중 마지막에서 n번째 `IndexPath`를 반환하는 확장 함수를 구현하였습니다. 
이를 위해 `UICollectionView+.swift` 파일을 추가하였으며, `getIndexPathFromLast(index:)` 메서드를 구현하였습니다. 

- 만에 하나 IndexPath를 제대로 불러오지 못하는 경우, 컬렉션뷰는 `reloadData()`를 호출하도록 구현하였습니다. 
<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### ❗️PR Point
<!-- 부족했던 점 혹은 개선하고 싶은 방향이 있다면 얘기해주세요 -->
테스트를 위해서는 채팅 로그가 없는 빈 채팅 로그, 혹은 오늘 처음 채팅하는 경우(채팅 시 새로운 섹션이 생기는 경우) 캐릭터에게 500대 서버 에러를 일으킬 수 있는 질문을 하시면 됩니다. 
저의 경우는
"대표적인 CS 면접 질문 10개만 뽑아줘."
"강남역 근처의 대표적인 맛집 10곳을 추천해줘"
와 같이 답변에 긴 목록을 나열해야 하는 질문의 경우 500대 서버 에러가 났습니다. 
<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->

|뷰|설명|
|:------:|:---:|
|    <img src="https://github.com/user-attachments/assets/02f8024d-e5e0-4351-b89f-cf1bf5da507a" width=200>    |     |


- Resolved: #334 
