### PR TITLE
[Fix] #314 - 쿠폰 목록 뷰에서 item이 한 개일 경우 셀이 가운데 정렬되던 문제 해결

### DIFF
--- a/Offroad-iOS/Offroad-iOS/Presentation/MyPage/Coupon/View/CouponListView.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/MyPage/Coupon/View/CouponListView.swift
@@ -35,7 +35,7 @@ class CouponListView: UIView {
         layout.minimumInteritemSpacing = interItemSpacing
         layout.minimumLineSpacing = lineSpacing
         layout.sectionInset = .init(top: verticalInset, left: horizontalInset, bottom: verticalInset, right: horizontalInset)
-        layout.estimatedItemSize = .init(width: itemWidth, height: itemWidth + 32)
+        layout.itemSize = .init(width: itemWidth, height: itemWidth + 32)
         return layout
     }
     


### PR DESCRIPTION
### 🌴 작업한 브랜치
- #314 


### ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->
쿠폰 목록 뷰에서 쿠폰 갯수가 1개일 때 셀의 위치가 가운데 정렬되는 문제가 있었으며, 이를 해결하였습니다. 
이를 위해 컬렉션뷰의 layout을 설정할 때, estimatedItemSize를 사용하던 것으로 itemSize로 바꾸었습니다. 
<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### ❗️PR Point
<!-- 부족했던 점 혹은 개선하고 싶은 방향이 있다면 얘기해주세요 -->

<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->
(예시 사진을 위해 임시로 코드를 조정하여 셀이 한 개만 보이도록 하였습니다. )
|전|후|
|:------:|:---:|
|     <img src="https://github.com/user-attachments/assets/5892eca3-cc89-4bf1-8f37-0e012cc67848" width=200>   |  <img src="https://github.com/user-attachments/assets/903a3c31-8dd8-43dd-baca-434334e33145" width=200>   |


- Resolved: #314 
