### PR TITLE
[Fix] #306 - 캐릭터 채팅 시 원하는 캐릭터 ID별로 채팅 요청하는 기능 구현

### DIFF
--- a/Offroad-iOS/Offroad-iOS/Global/Components/NavigationController/ORBNavigationController.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Components/NavigationController/ORBNavigationController.swift
@@ -77,19 +77,19 @@ extension ORBNavigationController {
     
     private func setupSubscription() {
         ORBCharacterChatManager.shared.shouldPushCharacterChatLogViewController
-            .subscribe(onNext: { [weak self] characterName in
+            .subscribe(onNext: { [weak self] characterId in
                 guard let self else { return }
-                self.pushChatLogViewController(characterName: characterName)
+                self.pushChatLogViewController(characterId: characterId)
             }).disposed(by: disposeBag)
     }
     
     //MARK: - Func
     
-    func pushChatLogViewController(characterName: String) {
+    func pushChatLogViewController(characterId: Int) {
         guard !(viewControllers.last is CharacterChatLogViewController) else { return }
         guard view.window != nil else { return }
         guard let snapshot = topViewController?.view.snapshotView(afterScreenUpdates: true) else { return }
-        let chatLogViewController = CharacterChatLogViewController(background: snapshot, characterName: characterName)
+        let chatLogViewController = CharacterChatLogViewController(background: snapshot, characterId: characterId)
         pushViewController(chatLogViewController, animated: true)
     }
     

--- a/Offroad-iOS/Offroad-iOS/Network/CharacterChat/CharacterChatAPI.swift
+++ b/Offroad-iOS/Offroad-iOS/Network/CharacterChat/CharacterChatAPI.swift
@@ -10,7 +10,7 @@ import Foundation
 import Moya
 
 enum CharacterChatAPI {
-    case postChat(body: CharacterChatPostRequestDTO)
+    case postChat(characterId: Int? = nil, body: CharacterChatPostRequestDTO)
     case getChatLog(characterId: Int? = nil)
 }
 
@@ -32,8 +32,13 @@ extension CharacterChatAPI: BaseTargetType {
     
     var task: Moya.Task {
         switch self {
-        case .postChat(body: let body):
-            return .requestJSONEncodable(body)
+        case .postChat(characterId: let characterId, body: let body):
+            guard let characterId else { return .requestJSONEncodable(body) }
+            return .requestCompositeParameters(
+                bodyParameters: ["content": body.content],
+                bodyEncoding: JSONEncoding.default,
+                urlParameters: ["characterId" : characterId]
+            )
         case .getChatLog(characterId: let characterId):
             guard let characterId else { return .requestPlain }
             return .requestParameters(parameters: ["characterId" : characterId], encoding: URLEncoding.queryString)

--- a/Offroad-iOS/Offroad-iOS/Network/CharacterChat/CharacterChatAPI.swift
+++ b/Offroad-iOS/Offroad-iOS/Network/CharacterChat/CharacterChatAPI.swift
@@ -11,7 +11,7 @@ import Moya
 
 enum CharacterChatAPI {
     case postChat(body: CharacterChatPostRequestDTO)
-    case getChatLog
+    case getChatLog(characterId: Int? = nil)
 }
 
 extension CharacterChatAPI: BaseTargetType {
@@ -34,8 +34,9 @@ extension CharacterChatAPI: BaseTargetType {
         switch self {
         case .postChat(body: let body):
             return .requestJSONEncodable(body)
-        case .getChatLog:
-            return .requestPlain
+        case .getChatLog(characterId: let characterId):
+            guard let characterId else { return .requestPlain }
+            return .requestParameters(parameters: ["characterId" : characterId], encoding: URLEncoding.queryString)
         }
     }
     

--- a/Offroad-iOS/Offroad-iOS/Network/CharacterChat/CharacterChatService.swift
+++ b/Offroad-iOS/Offroad-iOS/Network/CharacterChat/CharacterChatService.swift
@@ -11,6 +11,7 @@ import Moya
 
 protocol CharacterChatServiceProtocol {
     func postChat(
+        characterId: Int?,
         body: CharacterChatPostRequestDTO,
         completion: @escaping (NetworkResult<CharacterChatPostResponseDTO>) -> Void
     )
@@ -21,8 +22,8 @@ final class CharacterChatService: BaseService, CharacterChatServiceProtocol {
     
     let provider = MoyaProvider<CharacterChatAPI>.init(session: Session(interceptor: TokenInterceptor.shared), plugins: [MoyaPlugin()])
     
-    func postChat(body: CharacterChatPostRequestDTO, completion: @escaping (NetworkResult<CharacterChatPostResponseDTO>) -> Void) {
-        provider.request(.postChat(body: body)) { result in
+    func postChat(characterId: Int? = nil, body: CharacterChatPostRequestDTO, completion: @escaping (NetworkResult<CharacterChatPostResponseDTO>) -> Void) {
+        provider.request(.postChat(characterId: characterId, body: body)) { result in
             switch result {
             case .success(let response):
                 let networkResult: NetworkResult<CharacterChatPostResponseDTO> = self.fetchNetworkResult(

--- a/Offroad-iOS/Offroad-iOS/Network/CharacterChat/CharacterChatService.swift
+++ b/Offroad-iOS/Offroad-iOS/Network/CharacterChat/CharacterChatService.swift
@@ -10,8 +10,11 @@ import Foundation
 import Moya
 
 protocol CharacterChatServiceProtocol {
-    func postChat(body: CharacterChatPostRequestDTO, completion: @escaping (NetworkResult<CharacterChatPostResponseDTO>) -> Void)
-    func getChatLog(completion: @escaping (NetworkResult<CharacterChatGetResponseDTO>) -> Void)
+    func postChat(
+        body: CharacterChatPostRequestDTO,
+        completion: @escaping (NetworkResult<CharacterChatPostResponseDTO>) -> Void
+    )
+    func getChatLog(characterId: Int?, completion: @escaping (NetworkResult<CharacterChatGetResponseDTO>) -> Void)
 }
 
 final class CharacterChatService: BaseService, CharacterChatServiceProtocol {
@@ -37,8 +40,8 @@ final class CharacterChatService: BaseService, CharacterChatServiceProtocol {
         }
     }
     
-    func getChatLog(completion: @escaping (NetworkResult<CharacterChatGetResponseDTO>) -> Void) {
-        provider.request(.getChatLog) { result in
+    func getChatLog(characterId: Int? = nil, completion: @escaping (NetworkResult<CharacterChatGetResponseDTO>) -> Void) {
+        provider.request(.getChatLog(characterId: characterId)) { result in
             switch result {
             case .success(let response):
                 let networkResult: NetworkResult<CharacterChatGetResponseDTO> = self.fetchNetworkResult(

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/ORBCharacterChatManager.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/ORBCharacterChatManager.swift
@@ -18,7 +18,7 @@ final class ORBCharacterChatManager {
     
     //MARK: - Properties
     
-    let shouldPushCharacterChatLogViewController = PublishSubject<String>()
+    let shouldPushCharacterChatLogViewController = PublishSubject<Int>()
     let shouldMakeKeyboardBackgroundTransparent = PublishRelay<Bool>()
     
     //MARK: - UI Properties

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/ViewControllers/ORBCharacterChatViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/ViewControllers/ORBCharacterChatViewController.swift
@@ -94,7 +94,7 @@ extension ORBCharacterChatViewController {
     @objc private func tapGestureHandler(sender: UITapGestureRecognizer) {
         guard rootView.characterChatBox.mode == .withReplyButtonShrinked
                 || rootView.characterChatBox.mode == .withReplyButtonExpanded else { return }
-        ORBCharacterChatManager.shared.shouldPushCharacterChatLogViewController.onNext(MyInfoManager.shared.representativeCharacterName ?? "")
+        ORBCharacterChatManager.shared.shouldPushCharacterChatLogViewController.onNext(MyInfoManager.shared.representativeCharacterID ?? 1)
     }
     
     //MARK: - Private Func

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/ViewControllers/ORBCharacterChatViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/ViewControllers/ORBCharacterChatViewController.swift
@@ -240,10 +240,10 @@ extension ORBCharacterChatViewController {
         rootView.characterChatBox.addGestureRecognizer(tapGesture)
     }
     
-    private func postCharacterChat(message: String) {
+    private func postCharacterChat(characterId: Int? = nil, message: String) {
         isCharacterResponding.accept(true)
         let dto = CharacterChatPostRequestDTO(content: message)
-        NetworkService.shared.characterChatService.postChat(body: dto) { [weak self] result in
+        NetworkService.shared.characterChatService.postChat(characterId: characterId, body: dto) { [weak self] result in
             guard let self else { return }
             switch result {
             case .success(let dto):

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/ChatLog/ViewControllers/CharacterChatLogViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/ChatLog/ViewControllers/CharacterChatLogViewController.swift
@@ -244,7 +244,7 @@ extension CharacterChatLogViewController {
         rootView.sendButton.rx.tap.bind(
             onNext: { [weak self] in
                 guard let self else { return }
-                self.postCharacterChat(message: self.rootView.userChatInputView.text)
+                self.postCharacterChat(characterId: characterId, message: self.rootView.userChatInputView.text)
                 self.rootView.sendButton.isEnabled = false
                 // 사용자 채팅 버블 추가
                 self.sendChatBubble(isUserChat: true, text: self.rootView.userChatInputView.text) { [weak self] isFinished in
@@ -410,10 +410,10 @@ extension CharacterChatLogViewController {
         }
     }
     
-    private func postCharacterChat(message: String) {
+    private func postCharacterChat(characterId: Int?, message: String) {
         isCharacterResponding.accept(true)
         let dto = CharacterChatPostRequestDTO(content: message)
-        NetworkService.shared.characterChatService.postChat(body: dto) { [weak self] result in
+        NetworkService.shared.characterChatService.postChat(characterId: characterId, body: dto) { [weak self] result in
             guard let self else { return }
             switch result {
             case .success(let dto):
@@ -457,7 +457,7 @@ extension CharacterChatLogViewController {
     ///
     /// 지우려는 말풍선의 indexPath를 구할 수 없는 경우, 채팅 로그 뷰컨트롤러를 nagivation stack에서 pop 하며 에러 메시지 토스트 표시
     private func updateChatLog(chatSuccess: Bool = true) {
-        NetworkService.shared.characterChatService.getChatLog(completion: { [weak self] result in
+        NetworkService.shared.characterChatService.getChatLog(characterId: characterId, completion: { [weak self] result in
             guard let self else { return }
             self.tabBarController?.view.stopLoading()
             switch result {

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/ChatLog/ViewControllers/CharacterChatLogViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/ChatLog/ViewControllers/CharacterChatLogViewController.swift
@@ -547,7 +547,7 @@ extension CharacterChatLogViewController: UICollectionViewDelegate {
         let scrollOffsetAtBottomEdge =
         max(scrollView.contentSize.height - (scrollView.bounds.height - rootView.safeAreaInsets.bottom - 135), 0)
         
-        if ceil(scrollView.contentOffset.y) >= scrollOffsetAtBottomEdge {
+        if ceil(scrollView.contentOffset.y) >= (scrollOffsetAtBottomEdge - 20) {
             showChatButton()
         } else {
             hideChatButton()

--- a/Offroad-iOS/Offroad-iOS/Presentation/MyPage/CharacterList/View/CharacterDetailView.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/MyPage/CharacterList/View/CharacterDetailView.swift
@@ -228,7 +228,6 @@ extension CharacterDetailView {
             button.layer.borderColor = UIColor.sub(.sub).cgColor
             button.layer.borderWidth = 1
             button.roundCorners(cornerRadius: 18)
-            button.isEnabled = false
         }
         
         scrollView.showsVerticalScrollIndicator = false

--- a/Offroad-iOS/Offroad-iOS/Presentation/MyPage/CharacterList/ViewController/CharacterDetailViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/MyPage/CharacterList/ViewController/CharacterDetailViewController.swift
@@ -82,7 +82,6 @@ extension CharacterDetailViewController {
                 guard let self else { return }
                 self.rootView.crownBadgeImageView.isHidden = false
                 self.rootView.selectButton.isEnabled = false
-                self.rootView.chatLogButton.isEnabled = self.viewModel.isCurrentCharacterRepresentative
                 self.delegate?.didSelectMainCharacter(characterId: self.viewModel.characterId)
                 self.showToast(message: "'\($0.characterName)'로 대표 캐릭터가 변경되었어요!", inset: 66, withImage: .btnChecked)
             }).disposed(by: disposeBag)
@@ -91,7 +90,6 @@ extension CharacterDetailViewController {
             .subscribe(onNext: { [weak self] characterDetailInfo in
                 guard let self else { return }
                 self.rootView.configurerCharacterDetailView(using: characterDetailInfo)
-                self.rootView.chatLogButton.isEnabled = self.viewModel.isCurrentCharacterRepresentative
             }).disposed(by: disposeBag)
         
         viewModel.networkingSuccess
@@ -117,7 +115,7 @@ extension CharacterDetailViewController {
         rootView.chatLogButton.rx.tap.bind(onNext: { [weak self] in
             guard let self else { return }
             guard let orbNavigationController = navigationController as? ORBNavigationController else { return }
-            orbNavigationController.pushChatLogViewController(characterName: rootView.nameLabel.text!)
+            orbNavigationController.pushChatLogViewController(characterId: viewModel.characterId)
         }).disposed(by: disposeBag)
         
         NetworkMonitoringManager.shared.networkConnectionChanged


### PR DESCRIPTION
### 🌴 작업한 브랜치
- #306 


### ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->
- 캐릭터와 채팅 시 캐릭터 ID별로 원하는 캐릭터에게 채팅을 보낼 수 있도록 구현하였습니다.
이를 통해 채팅 로그 뷰에서 "채팅 로그" 버튼을 누르면, 각 캐릭터에 해당하는 채팅 로그가 뜨도록 구현하였습니다. 
- 채팅 로그 뷰에서 "채팅하기" 버튼이 올라가고 내려가는 로직을 개선했습니다. 
원래는 컬렉션뷰 콘텐츠의 가장 아래쪽이 보일 때 딱 맞춰서 버튼이 내려가고 올라가게 구현했었는데, 
길이를 계산하는 과정에서 소수점이 안 맞았는지, 가장 아래로 스크롤했을 때에도 버튼이 자동으로 내려가는 현상을 발견하였고, 이를 수정하였습니다. (컨텐츠 끝에서 버튼이 내려가던 이전과 달리, 가장 아래에서 20포인트만큼 위로 스크롤한 경우 버튼이 내려갑니다.)
<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### ❗️PR Point
<!-- 부족했던 점 혹은 개선하고 싶은 방향이 있다면 얘기해주세요 -->

<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->

|뷰|설명|
|:------:|:---:|
|   <img src="https://github.com/user-attachments/assets/71df7402-b314-416c-a7bb-69284f33a14f" width=200>    |     |


- Resolved: #306 
