### PR TITLE
[Fix] #348 - refreshToken 만료 시 로그인이 되지 않던 문제 해결

### DIFF
--- a/Offroad-iOS/Offroad-iOS/Presentation/Splash/ViewController/SplashViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Splash/ViewController/SplashViewController.swift
@@ -66,10 +66,9 @@ extension SplashViewController {
                 } else if characterName == "" {
                     self.presentViewController(viewController: ChoosingCharacterViewController())
                 } else {
+                    self.getCharacterListInfo()
                     self.presentViewController(viewController: OffroadTabBarController())
                 }
-                
-                self.getCharacterListInfo()
             default:
                 break
             }

--- a/Offroad-iOS/Offroad-iOS/Presentation/Splash/ViewController/SplashViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Splash/ViewController/SplashViewController.swift
@@ -19,11 +19,6 @@ final class SplashViewController: UIViewController {
         view = rootView
     }
     
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        getCharacterListInfo()
-    }
-    
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         
@@ -59,7 +54,8 @@ extension SplashViewController {
     }
     
     private func checkUserChoosingInfo() {
-        NetworkService.shared.adventureService.getAdventureInfo(category: "NONE") { response in
+        NetworkService.shared.adventureService.getAdventureInfo(category: "NONE") { [weak self] response in
+            guard let self else { return }
             switch response {
             case .success(let data):
                 let userNickname = data?.data.nickname ?? ""
@@ -72,6 +68,8 @@ extension SplashViewController {
                 } else {
                     self.presentViewController(viewController: OffroadTabBarController())
                 }
+                
+                self.getCharacterListInfo()
             default:
                 break
             }


### PR DESCRIPTION
### 🌴 작업한 브랜치
- #348 


### ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->
SplashViewController에서 로그인 전 캐릭터 정보를 요청하는 코드가 있었고, 
refreshToken 만료 시에 이 코드가 요청 응답에 실패하면 이로 인해 로그인이 진행되지 않는 문제를 발견하였습니다. 
이를 해결하기 위해 SplashViewController에서 캐릭터 정보를 요청하는 코드를 로그인 성공 이후로 옮겼습니다. 
<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### ❗️PR Point
<!-- 부족했던 점 혹은 개선하고 싶은 방향이 있다면 얘기해주세요 -->

<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->

|뷰|설명|
|:------:|:---:|
|        |     |


- Resolved: #348 
