### PR TITLE
[Feat] #346 - 셀 선택 시 탭 피드백 적용

### DIFF
--- a/Offroad-iOS/Offroad-iOS/Presentation/MyPage/CharacterList/Cell/CharacterListCell.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/MyPage/CharacterList/Cell/CharacterListCell.swift
@@ -14,8 +14,6 @@ class CharacterListCell: UICollectionViewCell, SVGFetchable {
     
     // MARK: - Properties
     
-    let shrinkingAnimator = UIViewPropertyAnimator(duration: 0.3, dampingRatio: 1)
-    
     override var isHighlighted: Bool {
         didSet { dimmingView.isHidden = !isHighlighted }
     }
@@ -59,7 +57,7 @@ class CharacterListCell: UICollectionViewCell, SVGFetchable {
         $0.isHidden = true
     }
     
-    let dimmingView = UIView().then {
+    private let dimmingView = UIView().then {
         $0.backgroundColor = .blackOpacity(.black25)
         $0.isHidden = true
     }

--- a/Offroad-iOS/Offroad-iOS/Presentation/MyPage/CharacterList/Cell/CharacterListCell.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/MyPage/CharacterList/Cell/CharacterListCell.swift
@@ -12,6 +12,14 @@ import Kingfisher
 
 class CharacterListCell: UICollectionViewCell, SVGFetchable {
     
+    // MARK: - Properties
+    
+    let shrinkingAnimator = UIViewPropertyAnimator(duration: 0.3, dampingRatio: 1)
+    
+    override var isHighlighted: Bool {
+        didSet { dimmingView.isHidden = !isHighlighted }
+    }
+    
     // MARK: - UI Properties
     
     private let containerView = UIView().then {
@@ -51,6 +59,11 @@ class CharacterListCell: UICollectionViewCell, SVGFetchable {
         $0.isHidden = true
     }
     
+    let dimmingView = UIView().then {
+        $0.backgroundColor = .blackOpacity(.black25)
+        $0.isHidden = true
+    }
+    
     // MARK: - Life Cycle
     
     override init(frame: CGRect) {
@@ -78,7 +91,7 @@ extension CharacterListCell {
     // MARK: - Private Func
     
     private func setupHierarchy() {
-        contentView.addSubviews(containerView, characterLabel, shadowView, newBadgeView, mainCharacterBadgeView)
+        contentView.addSubviews(containerView, characterLabel, shadowView, newBadgeView, mainCharacterBadgeView, dimmingView)
         shadowView.addSubview(lockImageView)
         containerView.addSubview(characterListCellImageView)
     }
@@ -94,9 +107,8 @@ extension CharacterListCell {
         }
         
         characterListCellImageView.snp.makeConstraints { make in
-            make.width.equalTo(81)
-            make.height.equalTo(147)
-            make.centerX.centerY.equalToSuperview()
+            make.horizontalEdges.equalToSuperview().inset(17.5)
+            make.verticalEdges.equalToSuperview().inset(17.5)
         }
         
         characterLabel.snp.makeConstraints{ make in
@@ -124,6 +136,10 @@ extension CharacterListCell {
         mainCharacterBadgeView.snp.makeConstraints { make in
             make.top.trailing.equalTo(containerView).inset(8)
             make.size.equalTo(24)
+        }
+        
+        dimmingView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
         }
     }
     

--- a/Offroad-iOS/Offroad-iOS/Presentation/MyPage/CharacterList/View/CharacterListView.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/MyPage/CharacterList/View/CharacterListView.swift
@@ -78,6 +78,7 @@ class CharacterListView: UIView {
     private func setupStyle() {
         backgroundColor = .primary(.listBg)
         checkImage.contentMode = .scaleAspectFit
+        collectionView.delaysContentTouches = false
     }
 
     private func setupHierarchy() {

--- a/Offroad-iOS/Offroad-iOS/Presentation/MyPage/Coupon/Cell/CouponCell.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/MyPage/Coupon/Cell/CouponCell.swift
@@ -9,6 +9,12 @@ import UIKit
 
 final class CouponCell: UICollectionViewCell {
     
+    // MARK: - Properties
+    
+    override var isHighlighted: Bool {
+        didSet { dimmingView.isHidden = !isHighlighted }
+    }
+    
     // MARK: - UI Properties
     
     var couponInfo: CouponInfo? = nil
@@ -17,6 +23,7 @@ final class CouponCell: UICollectionViewCell {
     private let newTagImageView = UIImageView()
     private let isUsedView = UIView()
     private let isUsedImageView = UIImageView(image: .icnCouponListCheckmark)
+    private let dimmingView = UIView()
     
     // MARK: - Life Cycle
     
@@ -67,6 +74,11 @@ final class CouponCell: UICollectionViewCell {
         isUsedView.do { view in
             view.backgroundColor = .blackOpacity(.black25)
         }
+        
+        dimmingView.do { view in
+            view.backgroundColor = .blackOpacity(.black25)
+            view.isHidden = true
+        }
     }
     
     private func setupHierarchy() {
@@ -74,7 +86,8 @@ final class CouponCell: UICollectionViewCell {
             couponimageView,
             couponNameLabel,
             isUsedView,
-            newTagImageView
+            newTagImageView,
+            dimmingView
         )
         isUsedView.addSubview(isUsedImageView)
     }
@@ -107,6 +120,10 @@ final class CouponCell: UICollectionViewCell {
         isUsedImageView.snp.makeConstraints { make in
             make.center.equalTo(couponimageView)
             make.size.equalTo(32)
+        }
+        
+        dimmingView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
         }
     }
     

--- a/Offroad-iOS/Offroad-iOS/Presentation/QuestMap/ViewModel/QuestMapViewModel.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/QuestMap/ViewModel/QuestMapViewModel.swift
@@ -86,7 +86,7 @@ extension QuestMapViewModel {
             currentLatitude: target.lat,
             currentLongitude: target.lng,
             limit: 100,
-            isBounded: true
+            isBounded: false
         )
         
         NetworkService.shared.placeService.getRegisteredPlace(requestDTO: requestPlaceDTO) { [weak self] response in


### PR DESCRIPTION
### 🌴 작업한 브랜치
- #346 


### ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->
- 캐릭터 목록 뷰와, 쿠폰 목록 뷰의 컬렉션 뷰 셀에서 탭 시 쉐이딩되는 효과를 구현하였습니다. 
- 지도에서 데이터가 불러오지 않는 것을 확인하고, 지도에서 장소 목록을 요청 시 isBounded = false 로 임시로 설정하였으며, 추후 API가 변경 시에 수정된 API를 적용할 예정입니다. 
<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### ❗️PR Point
<!-- 부족했던 점 혹은 개선하고 싶은 방향이 있다면 얘기해주세요 -->

<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->

|뷰|설명|
|:------:|:---:|
|    <img src="https://github.com/user-attachments/assets/3e2b3fbe-7678-4b68-b73d-1a9764570f3c" width=200>    |     |


- Resolved: #346 
