### PR TITLE
[Fix] #365 - ErrorResponseDTO 사용할 수 있도록 개선

### DIFF
--- a/Offroad-iOS/Offroad-iOS/Network/Adventure/AdventureService.swift
+++ b/Offroad-iOS/Offroad-iOS/Network/Adventure/AdventureService.swift
@@ -64,7 +64,7 @@ final class AdventureService: BaseService, AdventureServiceProtocol {
                 case .underlying(let error, let response):
                     print(error.localizedDescription)
                     if response == nil {
-                        completion(.networkFail)
+                        completion(.networkFail())
                     }
                 default:
                     return

--- a/Offroad-iOS/Offroad-iOS/Network/Base/BaseService.swift
+++ b/Offroad-iOS/Offroad-iOS/Network/Base/BaseService.swift
@@ -11,41 +11,56 @@ class BaseService {
     
     /// 200 받았을 때 decoding 할 데이터가 있는 경우 (대부분의 GET)
     func fetchNetworkResult<T: Decodable>(statusCode: Int, data: Data) -> NetworkResult<T> {
+        var decodeErrorResponse: ErrorResponseDTO? {
+            fetchDecodeData(data: data, responseType: ErrorResponseDTO.self)
+        }
+        
         switch statusCode {
         case 200, 201, 202:
             if let decodedData = fetchDecodeData(data: data, responseType: T.self) {
                 return .success(decodedData)
-            } else { return .decodeErr }
+            } else { return .decodeErr() }
         case 204: return .success(nil)
-        case 400: return .requestErr
-        case 401: return .unAuthentication
-        case 403: return .unAuthorization
-        case 404: return .apiArr
-        case 405: return .pathErr
-        case 409: return .requestErr
-        case 500: return .serverErr
-        default: return .networkFail
+        case 400: return .requestErr(decodeErrorResponse)
+        case 401: return .unAuthentication(decodeErrorResponse)
+        case 403: return .unAuthorization(decodeErrorResponse)
+        case 404: return .apiArr(decodeErrorResponse)
+        case 405: return .pathErr(decodeErrorResponse)
+        case 409: return .requestErr(decodeErrorResponse)
+        case 500...599: return .serverErr(decodeErrorResponse)
+        default: return .networkFail(decodeErrorResponse)
         }
     }
     
     /// 200 받았을 때 decoding 할 데이터가 없는 경우 (대부분의 PATCH, PUT, DELETE)
     func fetchNetworkResult(statusCode: Int, data: Data) -> NetworkResult<Any> {
+        var decodeErrorResponse: ErrorResponseDTO? {
+            fetchDecodeData(data: data, responseType: ErrorResponseDTO.self)
+        }
+        
         switch statusCode {
         case 200, 201, 204: return .success(nil)
-        case 400: return .requestErr
-        case 401: return .unAuthentication
-        case 403: return .unAuthorization
-        case 404: return .apiArr
-        case 405: return .pathErr
-        case 409: return .requestErr
-        case 500: return .serverErr
-        default: return .networkFail
+        case 400: return .requestErr(decodeErrorResponse)
+        case 401: return .unAuthentication(decodeErrorResponse)
+        case 403: return .unAuthorization(decodeErrorResponse)
+        case 404: return .apiArr(decodeErrorResponse)
+        case 405: return .pathErr(decodeErrorResponse)
+        case 409: return .requestErr(decodeErrorResponse)
+        case 500...599: return .serverErr(decodeErrorResponse)
+        default: return .networkFail()
         }
     }
     
     func fetchDecodeData<T: Decodable>(data: Data, responseType: T.Type) -> T? {
         let decoder = JSONDecoder()
         if let decodedData = try? decoder.decode(responseType, from: data){
+            return decodedData
+        } else { return nil }
+    }
+    
+    func fetchErrorMessageData(data: Data) -> ErrorResponseDTO? {
+        let decoder = JSONDecoder()
+        if let decodedData = try? decoder.decode(ErrorResponseDTO.self, from: data) {
             return decodedData
         } else { return nil }
     }

--- a/Offroad-iOS/Offroad-iOS/Network/Base/BaseService.swift
+++ b/Offroad-iOS/Offroad-iOS/Network/Base/BaseService.swift
@@ -26,7 +26,6 @@ class BaseService {
         case 403: return .unAuthorization(decodeErrorResponse)
         case 404: return .apiArr(decodeErrorResponse)
         case 405: return .pathErr(decodeErrorResponse)
-        case 409: return .requestErr(decodeErrorResponse)
         case 500...599: return .serverErr(decodeErrorResponse)
         default: return .networkFail(decodeErrorResponse)
         }
@@ -45,7 +44,6 @@ class BaseService {
         case 403: return .unAuthorization(decodeErrorResponse)
         case 404: return .apiArr(decodeErrorResponse)
         case 405: return .pathErr(decodeErrorResponse)
-        case 409: return .requestErr(decodeErrorResponse)
         case 500...599: return .serverErr(decodeErrorResponse)
         default: return .networkFail(decodeErrorResponse)
         }
@@ -58,10 +56,4 @@ class BaseService {
         } else { return nil }
     }
     
-    func fetchErrorMessageData(data: Data) -> ErrorResponseDTO? {
-        let decoder = JSONDecoder()
-        if let decodedData = try? decoder.decode(ErrorResponseDTO.self, from: data) {
-            return decodedData
-        } else { return nil }
-    }
 }

--- a/Offroad-iOS/Offroad-iOS/Network/Base/BaseService.swift
+++ b/Offroad-iOS/Offroad-iOS/Network/Base/BaseService.swift
@@ -19,7 +19,7 @@ class BaseService {
         case 200, 201, 202:
             if let decodedData = fetchDecodeData(data: data, responseType: T.self) {
                 return .success(decodedData)
-            } else { return .decodeErr() }
+            } else { return .decodeErr }
         case 204: return .success(nil)
         case 400: return .requestErr(decodeErrorResponse)
         case 401: return .unAuthentication(decodeErrorResponse)
@@ -47,7 +47,7 @@ class BaseService {
         case 405: return .pathErr(decodeErrorResponse)
         case 409: return .requestErr(decodeErrorResponse)
         case 500...599: return .serverErr(decodeErrorResponse)
-        default: return .networkFail()
+        default: return .networkFail(decodeErrorResponse)
         }
     }
     

--- a/Offroad-iOS/Offroad-iOS/Network/Base/ErrorResponseDTO.swift
+++ b/Offroad-iOS/Offroad-iOS/Network/Base/ErrorResponseDTO.swift
@@ -8,6 +8,6 @@
 import Foundation
 
 struct ErrorResponseDTO: Codable {
-    let message: String
-    let code: String
+    let message: String?
+    let customErrorCode: String?
 }

--- a/Offroad-iOS/Offroad-iOS/Network/Base/NetworkResult.swift
+++ b/Offroad-iOS/Offroad-iOS/Network/Base/NetworkResult.swift
@@ -9,13 +9,13 @@ import Foundation
 
 enum NetworkResult<T> {
     case success(T?)                                  // 서버 통신 성공했을 때 (200, 201, 204)
-    case requestErr(ErrorResponseDTO?)          // 올바르지 않은 요청 에러 발생했을 때 (400)
-    case unAuthentication(ErrorResponseDTO?)    // 인증 실패 응답 받았을 때 (401)
-    case unAuthorization(ErrorResponseDTO?)     // 인가 실패 응답 받았을 때 (403)
-    case apiArr(ErrorResponseDTO?)              // 존재하지 않는 api를 호출했을 때 (404)
-    case pathErr(ErrorResponseDTO?)             // 경로 에러 발생했을 때 (405)
-    case registerErr(ErrorResponseDTO?)         // 데이터 등록 오류가 발생했을 때 (409)
-    case networkFail(ErrorResponseDTO?)         // 네트워크 연결 실패했을 때
-    case serverErr(ErrorResponseDTO?)           // 서버에서 에러가 발생했을 때 (500대)
-    case decodeErr           // 데이터는 받아왔으나 DTO 형식으로 decode가 되지 않을 때
+    case requestErr(ErrorResponseDTO? = nil)          // 올바르지 않은 요청 에러 발생했을 때 (400)
+    case unAuthentication(ErrorResponseDTO? = nil)    // 인증 실패 응답 받았을 때 (401)
+    case unAuthorization(ErrorResponseDTO? = nil)     // 인가 실패 응답 받았을 때 (403)
+    case apiArr(ErrorResponseDTO? = nil)              // 존재하지 않는 api를 호출했을 때 (404)
+    case pathErr(ErrorResponseDTO? = nil)             // 경로 에러 발생했을 때 (405)
+    case registerErr(ErrorResponseDTO? = nil)         // 데이터 등록 오류가 발생했을 때 (409)
+    case networkFail(ErrorResponseDTO? = nil)         // 네트워크 연결 실패했을 때
+    case serverErr(ErrorResponseDTO? = nil)           // 서버에서 에러가 발생했을 때 (500대)
+    case decodeErr                                    // 데이터는 받아왔으나 DTO 형식으로 decode가 되지 않을 때
 }

--- a/Offroad-iOS/Offroad-iOS/Network/Base/NetworkResult.swift
+++ b/Offroad-iOS/Offroad-iOS/Network/Base/NetworkResult.swift
@@ -9,13 +9,13 @@ import Foundation
 
 enum NetworkResult<T> {
     case success(T?)                                  // 서버 통신 성공했을 때 (200, 201, 204)
-    case requestErr(ErrorResponseDTO? = nil)          // 올바르지 않은 요청 에러 발생했을 때 (400)
-    case unAuthentication(ErrorResponseDTO? = nil)    // 인증 실패 응답 받았을 때 (401)
-    case unAuthorization(ErrorResponseDTO? = nil)     // 인가 실패 응답 받았을 때 (403)
-    case apiArr(ErrorResponseDTO? = nil)              // 존재하지 않는 api를 호출했을 때 (404)
-    case pathErr(ErrorResponseDTO? = nil)             // 경로 에러 발생했을 때 (405)
-    case registerErr(ErrorResponseDTO? = nil)         // 데이터 등록 오류가 발생했을 때 (409)
-    case networkFail(ErrorResponseDTO? = nil)         // 네트워크 연결 실패했을 때
-    case serverErr(ErrorResponseDTO? = nil)           // 서버에서 에러가 발생했을 때 (500대)
-    case decodeErr(ErrorResponseDTO? = nil)           // 데이터는 받아왔으나 DTO 형식으로 decode가 되지 않을 때
+    case requestErr(ErrorResponseDTO?)          // 올바르지 않은 요청 에러 발생했을 때 (400)
+    case unAuthentication(ErrorResponseDTO?)    // 인증 실패 응답 받았을 때 (401)
+    case unAuthorization(ErrorResponseDTO?)     // 인가 실패 응답 받았을 때 (403)
+    case apiArr(ErrorResponseDTO?)              // 존재하지 않는 api를 호출했을 때 (404)
+    case pathErr(ErrorResponseDTO?)             // 경로 에러 발생했을 때 (405)
+    case registerErr(ErrorResponseDTO?)         // 데이터 등록 오류가 발생했을 때 (409)
+    case networkFail(ErrorResponseDTO?)         // 네트워크 연결 실패했을 때
+    case serverErr(ErrorResponseDTO?)           // 서버에서 에러가 발생했을 때 (500대)
+    case decodeErr           // 데이터는 받아왔으나 DTO 형식으로 decode가 되지 않을 때
 }

--- a/Offroad-iOS/Offroad-iOS/Network/Base/NetworkResult.swift
+++ b/Offroad-iOS/Offroad-iOS/Network/Base/NetworkResult.swift
@@ -8,14 +8,14 @@
 import Foundation
 
 enum NetworkResult<T> {
-    case success(T?)                // 서버 통신 성공했을 때 (200, 201, 204)
-    case requestErr                 // 올바르지 않은 요청 에러 발생했을 때 (400)
-    case unAuthentication           // 인증 실패 응답 받았을 때 (401)
-    case unAuthorization            // 인가 실패 응답 받았을 때 (403)
-    case apiArr                     // 존재하지 않는 api를 호출했을 때 (404)
-    case pathErr                    // 경로 에러 발생했을 때 (405)
-    case registerErr                // 데이터 등록 오류가 발생했을 때 (409)
-    case networkFail                // 네트워크 연결 실패했을 때
-    case serverErr                // 서버에서 에러가 발생했을 때 (500대)
-    case decodeErr                  // 데이터는 받아왔으나 DTO 형식으로 decode가 되지 않을 때
+    case success(T?)                                  // 서버 통신 성공했을 때 (200, 201, 204)
+    case requestErr(ErrorResponseDTO? = nil)          // 올바르지 않은 요청 에러 발생했을 때 (400)
+    case unAuthentication(ErrorResponseDTO? = nil)    // 인증 실패 응답 받았을 때 (401)
+    case unAuthorization(ErrorResponseDTO? = nil)     // 인가 실패 응답 받았을 때 (403)
+    case apiArr(ErrorResponseDTO? = nil)              // 존재하지 않는 api를 호출했을 때 (404)
+    case pathErr(ErrorResponseDTO? = nil)             // 경로 에러 발생했을 때 (405)
+    case registerErr(ErrorResponseDTO? = nil)         // 데이터 등록 오류가 발생했을 때 (409)
+    case networkFail(ErrorResponseDTO? = nil)         // 네트워크 연결 실패했을 때
+    case serverErr(ErrorResponseDTO? = nil)           // 서버에서 에러가 발생했을 때 (500대)
+    case decodeErr(ErrorResponseDTO? = nil)           // 데이터는 받아왔으나 DTO 형식으로 decode가 되지 않을 때
 }

--- a/Offroad-iOS/Offroad-iOS/Network/Character/CharacterService.swift
+++ b/Offroad-iOS/Offroad-iOS/Network/Character/CharacterService.swift
@@ -50,7 +50,7 @@ final class CharacterService: BaseService, CharacterServiceProtocol {
                 case .underlying(let error, let response):
                     print(error.localizedDescription)
                     if response == nil {
-                        completion(.networkFail)
+                        completion(.networkFail())
                     }
                 default:
                     print(error.localizedDescription)
@@ -74,7 +74,7 @@ final class CharacterService: BaseService, CharacterServiceProtocol {
                 case .underlying(let error, let response):
                     print(error.localizedDescription)
                     if response == nil {
-                        completion(.networkFail)
+                        completion(.networkFail())
                     }
                 default:
                     print(error.localizedDescription)
@@ -99,7 +99,7 @@ final class CharacterService: BaseService, CharacterServiceProtocol {
                 case .underlying(let error, let response):
                     print(error.localizedDescription)
                     if response == nil {
-                        completion(.networkFail)
+                        completion(.networkFail())
                     }
                 default:
                     print(error.localizedDescription)
@@ -124,7 +124,7 @@ final class CharacterService: BaseService, CharacterServiceProtocol {
                 case .underlying(let error, let response):
                     print(error.localizedDescription)
                     if response == nil {
-                        completion(.networkFail)
+                        completion(.networkFail())
                     }
                 default:
                     print(error.localizedDescription)

--- a/Offroad-iOS/Offroad-iOS/Network/CharacterChat/CharacterChatService.swift
+++ b/Offroad-iOS/Offroad-iOS/Network/CharacterChat/CharacterChatService.swift
@@ -53,13 +53,22 @@ final class CharacterChatService: BaseService, CharacterChatServiceProtocol {
             case .failure(let error):
                 print(error.localizedDescription)
                 switch error {
-                case .underlying(let error, let response):
+                case .underlying(_, _ ):
                     print(error.localizedDescription)
-                    if response == nil {
-                        completion(.networkFail)
-                    }
+                    guard let response = error.response else { return }
+                    let networkResult: NetworkResult<CharacterChatGetResponseDTO> = self.fetchNetworkResult(
+                        statusCode: response.statusCode,
+                        data: response.data
+                    )
+                    completion(networkResult)
                 default:
                     print(error.localizedDescription)
+                    guard let response = error.response else { return }
+                    let networkResult: NetworkResult<CharacterChatGetResponseDTO> = self.fetchNetworkResult(
+                        statusCode: response.statusCode,
+                        data: response.data
+                    )
+                    completion(networkResult)
                 }
             }
         }

--- a/Offroad-iOS/Offroad-iOS/Network/CharacterChat/CharacterChatService.swift
+++ b/Offroad-iOS/Offroad-iOS/Network/CharacterChat/CharacterChatService.swift
@@ -52,27 +52,14 @@ final class CharacterChatService: BaseService, CharacterChatServiceProtocol {
                 completion(networkResult)
             case .failure(let error):
                 print(error.localizedDescription)
-                switch error {
-                case .underlying(_, _ ):
-                    print(error.localizedDescription)
-                    guard let response = error.response else { return }
-                    let networkResult: NetworkResult<CharacterChatGetResponseDTO> = self.fetchNetworkResult(
-                        statusCode: response.statusCode,
-                        data: response.data
-                    )
-                    completion(networkResult)
-                default:
-                    print(error.localizedDescription)
-                    guard let response = error.response else { return }
-                    let networkResult: NetworkResult<CharacterChatGetResponseDTO> = self.fetchNetworkResult(
-                        statusCode: response.statusCode,
-                        data: response.data
-                    )
-                    completion(networkResult)
-                }
+                guard let response = error.response else { return }
+                let networkResult: NetworkResult<CharacterChatGetResponseDTO> = self.fetchNetworkResult(
+                    statusCode: response.statusCode,
+                    data: response.data
+                )
+                completion(networkResult)
             }
         }
     }
-    
     
 }

--- a/Offroad-iOS/Offroad-iOS/Network/Coupon/CouponService.swift
+++ b/Offroad-iOS/Offroad-iOS/Network/Coupon/CouponService.swift
@@ -55,7 +55,7 @@ final class CouponService: BaseService, CouponServiceProtocol {
                 completion(networkResult)
             case .failure(let error):
                 print(error.localizedDescription)
-                let networkResult: NetworkResult<CouponRedemptionResponseDTO> = .networkFail
+                let networkResult: NetworkResult<CouponRedemptionResponseDTO> = .networkFail()
                 completion(networkResult)
             }
         })

--- a/Offroad-iOS/Offroad-iOS/Network/Notice/NoticeService.swift
+++ b/Offroad-iOS/Offroad-iOS/Network/Notice/NoticeService.swift
@@ -31,7 +31,7 @@ final class NoticeService: BaseService, NoticeServiceProtocol {
                 case .underlying(let error, let response):
                     print(error.localizedDescription)
                     if response == nil {
-                        completion(.networkFail)
+                        completion(.networkFail())
                     }
                 default:
                     print(error.localizedDescription)

--- a/Offroad-iOS/Offroad-iOS/Network/Place/PlaceService.swift
+++ b/Offroad-iOS/Offroad-iOS/Network/Place/PlaceService.swift
@@ -37,7 +37,7 @@ final class RegisteredPlaceService: BaseService, RegisteredPlaceServiceProtocol 
                 case .underlying(let error, let response):
                     print(error.localizedDescription)
                     if response == nil {
-                        completion(.networkFail)
+                        completion(.networkFail())
                     }
                 default:
                     print(error.localizedDescription)

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/ChatLog/ViewControllers/CharacterChatLogViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/ChatLog/ViewControllers/CharacterChatLogViewController.swift
@@ -199,10 +199,15 @@ extension CharacterChatLogViewController {
                 rootView.chatLogCollectionView.reloadData()
                 self.scrollToBottom(animated: false)
                 showChatButton()
-            case .networkFail:
+            case .networkFail(let errorResponseDTO):
+                print("message: \(errorResponseDTO?.message)")
+                print("customErrorCode: \(errorResponseDTO?.customErrorCode)")
                 showToast(message: ErrorMessages.networkError, inset: 66)
             case .decodeErr:
                 showToast(message: "디코딩 에러.", inset: 66)
+            case .serverErr(let errorResponseDTO):
+                print("message: \(errorResponseDTO?.message)")
+                print("customErrorCode: \(errorResponseDTO?.customErrorCode)")
             default:
                 self.showToast(message: "Something went wrong", inset: 60)
             }


### PR DESCRIPTION
### 🌴 작업한 브랜치
- #365 


### ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->
현재 서버 API 사용 시 200대 상태 코드, 즉 성공 시에 데이터를 받아오도록 구현되어 있습니다.
우리 프로젝트의 서버 통신 코드 중 상태 코드에 따라 특정 종류의 에러로 구분해주는 `fetchNetworkResult(statusCode:data:)` 메서드에서 이를 담당하는데, 이때 성공 시 Response Body 의 타입을 제네릭타입으로 decode하여 서버로부터 데이터를 가져올 수 있습니다. 

그러나 현재 코드는 400대, 500대 상태 코드에서는 Response Body를 받아올 수 없다는 한계점이 있습니다. 
현재 서버에서는 400대, 500대 상태에 대해서도 응답 데이터(Body)를 포함하며, 필요 시 이 때의 `message`와 `customErrorCode`를 사용해야 하는 경우도 발생합니다. 
<img src="https://github.com/user-attachments/assets/ee983087-9e4e-4210-88bb-b4dfddcdc905" width=500>
따라서 이를 받아올 수 있도록 하기 위해 코드를 수정하였습니다.
현재 우리 코드에는 ErrorResponseDTO 타입이 정의되어있으며, 200대 에러에서 연관값으로 제네릭 타입의 값을 반환하는 것처럼, 
400대, 500대 에러의 경우 ErrorResponseDTO 타입을 반환하도록 구현하였습니다. 

### 사용법
사용법은 다음과 같습니다. 채팅 로그를 받아오는 데이터를 예로 들겠습니다. 
서버 통신  API 메서드를 호출 후 콜백 함수의 매개변수가 `.success`나 `.decodeErr` 가 아닌 케이스일 경우에는 연관값으로 `ErrorResponsDTO` 타입의 값을 받아오게 됩니다. 

``` swift 
private func requestChatLogDataSource(characterId: Int? = nil) {
    // 서버 통신 API 호출
    NetworkService.shared.characterChatService.getChatLog(characterId: characterId) { [weak self] result in
        guard let self else { return }
        self.view.stopLoading()
        switch result {
        // 서버 통신 성공. 예) 200대 상태 코드일 경우
        case .success(let responseDTO):
            // 성공 시 responseDTO로 원하는 작업 실행
        
        // 서버 통신은 성공했으나 상태 코드가 400대, 500대일 경우
        // 연관값으로 ErrorResponseDTO 타입의 데이터를 받아올 수 있음.
        case .networkFail(let errorResponseDTO):
            // errorResponseDTO는 ErrorResponseDTO 타입이므로 message, customErrorCode 속성에 접근 가능
            print("message: \(errorResponseDTO?.message)")
            print("customErrorCode: \(errorResponseDTO?.customErrorCode)")
            // 네트워크 오류 시 적절한 처리 필요
        
        // 디코딩 에러 시에는 연관값 없음. (응답은 제대로 왔으나, 디코딩에 실패한 것이기 때문)
        case .decodeErr:
            showToast(message: "디코딩 에러.", inset: 66)
        case .serverErr(let errorResponseDTO):
            print("message: \(errorResponseDTO?.message)")
            print("customErrorCode: \(errorResponseDTO?.customErrorCode)")
        default:
            self.showToast(message: "Something went wrong", inset: 60)
        }
    }
}
```

<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### ❗️PR Point
<!-- 부족했던 점 혹은 개선하고 싶은 방향이 있다면 얘기해주세요 -->

<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->

|뷰|설명|
|:------:|:---:|
|        |     |


- Resolved: #365 
