### PR TITLE
[Fix] #367 - 온보딩 약관동의 뷰 개선

### DIFF
--- a/Offroad-iOS/Offroad-iOS/Network/Base/MoyaPlugin.swift
+++ b/Offroad-iOS/Offroad-iOS/Network/Base/MoyaPlugin.swift
@@ -68,5 +68,7 @@ final class MoyaPlugin: PluginType {
         log.append("\(error.failureReason ?? error.errorDescription ?? "unknown error")\n")
         log.append("<-- END HTTP")
         print(log)
+        
+        ORBToastManager.shared.showToast(message: ErrorMessages.networkError, inset: 54)
     }
 }

--- a/Offroad-iOS/Offroad-iOS/Presentation/Login/ViewController/LoginViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Login/ViewController/LoginViewController.swift
@@ -116,22 +116,14 @@ extension LoginViewController {
         NetworkService.shared.adventureService.getAdventureInfo(category: "NONE") { response in
             switch response {
             case .success(let data):
-                let userNickname = data?.data.nickname ?? ""
                 let characterName = data?.data.characterName ?? ""
                                                 
-                if userNickname == "" {
+                if characterName == "" {
                     let termsConsentViewController = TermsConsentViewController()
                     termsConsentViewController.modalPresentationStyle = .fullScreen
                     termsConsentViewController.modalTransitionStyle = .crossDissolve
 
                     self.present(termsConsentViewController, animated: true)
-                } else if characterName == "" {
-                    let choosingCharacterViewController = ChoosingCharacterViewController()
-                    
-                    choosingCharacterViewController.modalPresentationStyle = .fullScreen
-                    choosingCharacterViewController.modalTransitionStyle = .crossDissolve
-                    
-                    self.present(choosingCharacterViewController, animated: true)
                 } else {
                     let offroadTabBarViewController = OffroadTabBarController()
                     

--- a/Offroad-iOS/Offroad-iOS/Presentation/MyPage/Settings/MarketingConsent/ViewController/MarketingConsentViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/MyPage/Settings/MarketingConsent/ViewController/MarketingConsentViewController.swift
@@ -49,7 +49,11 @@ extension MarketingConsentViewController {
         NetworkService.shared.profileService.patchMarketingConsent(body: isAgreed) { response in
             switch response {
             case .success:
-                print("마케팅 수신 여부 변경 성공!\n요청 성공 값: \(isAgreed.marketing)")
+                let isAgreedString = isAgreed.marketing ? "동의" : "비동의"
+                let dateFormatter = DateFormatter()
+                dateFormatter.dateFormat = "yyyy년 M월 d일 HH:mm"
+                
+                self.showToast(message: "\(dateFormatter.string(from: Date()))부로\n마케팅 정보 수신 \(isAgreedString) 처리되었습니다.", inset: 54)
             default:
                 break
             }

--- a/Offroad-iOS/Offroad-iOS/Presentation/Onboarding/ViewController/TermsConsentPopupViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Onboarding/ViewController/TermsConsentPopupViewController.swift
@@ -46,14 +46,14 @@ final class TermsConsentPopupViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        rootView.configurePopupView(titleString: popupTitleString, 
-                                    descriptionString: popupDescriptionString,
-                                    contentString: popupContentString)
         setupAddTarget()
     }
     
     override func viewDidAppear(_ animated: Bool) {
         rootView.presentPopupView()
+        rootView.configurePopupView(titleString: popupTitleString,
+                                    descriptionString: popupDescriptionString,
+                                    contentString: popupContentString)
     }
 }
 

--- a/Offroad-iOS/Offroad-iOS/Presentation/Onboarding/ViewController/TermsConsentViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Onboarding/ViewController/TermsConsentViewController.swift
@@ -97,6 +97,11 @@ extension TermsConsentViewController {
                 dateFormatter.dateFormat = "yyyy년 M월 d일 HH:mm"
                 
                 self.showToast(message: "\(dateFormatter.string(from: Date()))부로\n마케팅 정보 수신 \(isAgreedString) 처리되었습니다.", inset: 54)
+                
+                let nicknameViewController = NicknameViewController()
+                let navigationController = UINavigationController(rootViewController: nicknameViewController)
+                
+                self.presentNavigationController(navigationController: navigationController)
             default:
                 break
             }
@@ -113,11 +118,6 @@ extension TermsConsentViewController {
     
     @objc private func nextButtonTapped() {
         patchMarketingConsent(isAgreed: MarketingConsentRequestDTO(marketing: termsModelData[3].isSelected))
-        
-        let nicknameViewController = NicknameViewController()
-        let navigationController = UINavigationController(rootViewController: nicknameViewController)
-        
-        self.presentNavigationController(navigationController: navigationController)
     }
 }
 

--- a/Offroad-iOS/Offroad-iOS/Presentation/Onboarding/ViewController/TermsConsentViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Onboarding/ViewController/TermsConsentViewController.swift
@@ -92,7 +92,11 @@ extension TermsConsentViewController {
         NetworkService.shared.profileService.patchMarketingConsent(body: isAgreed) { response in
             switch response {
             case .success:
-                print("마케팅 수신 여부 변경 성공!\n요청 성공 값: \(isAgreed.marketing)")
+                let isAgreedString = isAgreed.marketing ? "동의" : "비동의"
+                let dateFormatter = DateFormatter()
+                dateFormatter.dateFormat = "yyyy년 M월 d일 HH:mm"
+                
+                self.showToast(message: "\(dateFormatter.string(from: Date()))부로\n마케팅 정보 수신 \(isAgreedString) 처리되었습니다.", inset: 54)
             default:
                 break
             }

--- a/Offroad-iOS/Offroad-iOS/Presentation/Splash/ViewController/SplashViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Splash/ViewController/SplashViewController.swift
@@ -70,13 +70,10 @@ extension SplashViewController {
             guard let self else { return }
             switch response {
             case .success(let data):
-                let userNickname = data?.data.nickname ?? ""
                 let characterName = data?.data.characterName ?? ""
                                                 
-                if userNickname == "" {
-                    self.presentViewController(viewController: TermsConsentViewController())
-                } else if characterName == "" {
-                    self.presentViewController(viewController: ChoosingCharacterViewController())
+                if characterName == "" {
+                    self.presentViewController(viewController: LoginViewController())
                 } else {
                     self.getCharacterListInfo()
                     self.presentViewController(viewController: OffroadTabBarController(pushType: pushType))


### PR DESCRIPTION
### 🌴 작업한 브랜치
- #367


### ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->
- 온보딩 도중 이탈 시, 무조건 스플래시 이후 로그인뷰로 이동
  - 현재 서버 API가 수정되지 않아 닉네임을 설정한 이후에 이탈하고, 이전에 설정했던 닉네임을 다시 입력하면 중복된 닉네임으로 뜨는 버그가 있습니다! 서버 수정 후 반영되면 해결될 문제로 보여집니다.
- 온보딩 약관 동의 뷰 팝업 로딩 시점 변경
- 마케팅 수신 동의 시 토스트 구현
  - 따로 디자인이 지정되어있지 않아, 기존에 구현되어있던 토스트를 사용하였습니다.


### 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->
|온보딩 이탈 시 재로그인|온보딩 팝업 로딩|
|:------:|:---:|
|<img src = "https://github.com/user-attachments/assets/5a686efe-835b-4236-afc4-213eefcc7e64" width ="250">|<img src = "https://github.com/user-attachments/assets/4ac31f02-b1b7-492e-b227-b4acc2ec31e4" width ="250">|

|마케팅 수신 동의 토스트((온보딩 뷰)|마케팅 수신 동의 토스트(설정 뷰)|
|:------:|:---:|
|<img src = "https://github.com/user-attachments/assets/9cc150a2-1276-4033-89b7-1f58b5552638" width ="250">|<img src = "https://github.com/user-attachments/assets/ad83fb1a-e251-4e61-969a-e61e43debdaf" width ="250">|


- Resolved: #367
