### PR TITLE
[Feat] #370 - 채팅 로그 뷰 무한스크롤 구현

### DIFF
--- a/Offroad-iOS/Offroad-iOS/Network/CharacterChat/CharacterChatAPI.swift
+++ b/Offroad-iOS/Offroad-iOS/Network/CharacterChat/CharacterChatAPI.swift
@@ -11,7 +11,7 @@ import Moya
 
 enum CharacterChatAPI {
     case postChat(characterId: Int? = nil, body: CharacterChatPostRequestDTO)
-    case getChatLog(characterId: Int? = nil)
+    case getChatLog(characterId: Int? = nil, limit: Int, cursor: Int? = nil)
 }
 
 extension CharacterChatAPI: BaseTargetType {
@@ -39,9 +39,16 @@ extension CharacterChatAPI: BaseTargetType {
                 bodyEncoding: JSONEncoding.default,
                 urlParameters: ["characterId" : characterId]
             )
-        case .getChatLog(characterId: let characterId):
-            guard let characterId else { return .requestPlain }
-            return .requestParameters(parameters: ["characterId" : characterId], encoding: URLEncoding.queryString)
+        case .getChatLog(characterId: let characterId, limit: let limit, cursor: let cursor):
+            
+            // parameter로 들어갈 빈 딕셔너리 만든 후 각 항목이 nil이 아닐 경우 딕셔너리에 넣어 보내기
+            var queryParameters: [String: Any] = [:]
+            if let characterId { queryParameters["characterId"] = characterId }
+            queryParameters["limit"] = limit
+            if let cursor { queryParameters["cursor"] = cursor }
+            return .requestParameters(parameters: queryParameters, encoding: URLEncoding.queryString)
+//            guard let characterId else { return .requestPlain }
+//            return .requestParameters(parameters: ["characterId" : characterId], encoding: URLEncoding.queryString)
         }
     }
     

--- a/Offroad-iOS/Offroad-iOS/Network/CharacterChat/CharacterChatAPI.swift
+++ b/Offroad-iOS/Offroad-iOS/Network/CharacterChat/CharacterChatAPI.swift
@@ -40,15 +40,11 @@ extension CharacterChatAPI: BaseTargetType {
                 urlParameters: ["characterId" : characterId]
             )
         case .getChatLog(characterId: let characterId, limit: let limit, cursor: let cursor):
-            
-            // parameter로 들어갈 빈 딕셔너리 만든 후 각 항목이 nil이 아닐 경우 딕셔너리에 넣어 보내기
             var queryParameters: [String: Any] = [:]
             if let characterId { queryParameters["characterId"] = characterId }
             queryParameters["limit"] = limit
             if let cursor { queryParameters["cursor"] = cursor }
             return .requestParameters(parameters: queryParameters, encoding: URLEncoding.queryString)
-//            guard let characterId else { return .requestPlain }
-//            return .requestParameters(parameters: ["characterId" : characterId], encoding: URLEncoding.queryString)
         }
     }
     

--- a/Offroad-iOS/Offroad-iOS/Network/CharacterChat/CharacterChatService.swift
+++ b/Offroad-iOS/Offroad-iOS/Network/CharacterChat/CharacterChatService.swift
@@ -15,7 +15,7 @@ protocol CharacterChatServiceProtocol {
         body: CharacterChatPostRequestDTO,
         completion: @escaping (NetworkResult<CharacterChatPostResponseDTO>) -> Void
     )
-    func getChatLog(characterId: Int?, completion: @escaping (NetworkResult<CharacterChatGetResponseDTO>) -> Void)
+    func getChatLog(characterId: Int?, limit: Int, cursor: Int?, completion: @escaping (NetworkResult<CharacterChatGetResponseDTO>) -> Void)
 }
 
 final class CharacterChatService: BaseService, CharacterChatServiceProtocol {
@@ -41,8 +41,10 @@ final class CharacterChatService: BaseService, CharacterChatServiceProtocol {
         }
     }
     
-    func getChatLog(characterId: Int? = nil, completion: @escaping (NetworkResult<CharacterChatGetResponseDTO>) -> Void) {
-        provider.request(.getChatLog(characterId: characterId)) { result in
+    func getChatLog(characterId: Int? = nil, limit: Int, cursor: Int? = nil, completion: @escaping (NetworkResult<CharacterChatGetResponseDTO>) -> Void) {
+        provider.request(
+            CharacterChatAPI.getChatLog(characterId: characterId, limit: limit, cursor: cursor)
+        ) { result in
             switch result {
             case .success(let response):
                 let networkResult: NetworkResult<CharacterChatGetResponseDTO> = self.fetchNetworkResult(

--- a/Offroad-iOS/Offroad-iOS/Network/CharacterChat/DTO/Response/CharacterChatPostResponseDTO.swift
+++ b/Offroad-iOS/Offroad-iOS/Network/CharacterChat/DTO/Response/CharacterChatPostResponseDTO.swift
@@ -16,12 +16,14 @@ struct ChatData: Codable {
     var role: String // "USER" 또는 "ORB_CHARACTER"
     var content: String
     var createdAt: String
+    var id: Int
 }
 
 struct ChatDataModel {
     var role: String
     var content: String
     var createdDate: Date?
+    var id: Int
     var isLoading: Bool = false
     
     var formattedTimeString: String {
@@ -39,10 +41,11 @@ struct ChatDataModel {
         return dateFormatter.string(from: createdDate)
     }
     
-    init(role: String, content: String, createdData: Date?, isLoading: Bool = false) {
+    init(role: String, content: String, createdData: Date?, id: Int, isLoading: Bool = false) {
         self.role = role
         self.content = content
         self.createdDate = createdData
+        self.id = id
         self.isLoading = isLoading
     }
     
@@ -51,6 +54,7 @@ struct ChatDataModel {
         
         self.role = data.role
         self.content = data.content
+        self.id = data.id
         formatter.formatOptions = [.withFullDate, .withTime, .withDashSeparatorInDate, .withColonSeparatorInTime]
         formatter.timeZone = TimeZone(identifier: "Asia/Seoul")
         if let date = formatter.date(from: data.createdAt) {

--- a/Offroad-iOS/Offroad-iOS/Network/CharacterChat/DTO/Response/CharacterChatPostResponseDTO.swift
+++ b/Offroad-iOS/Offroad-iOS/Network/CharacterChat/DTO/Response/CharacterChatPostResponseDTO.swift
@@ -23,7 +23,8 @@ struct ChatDataModel {
     var role: String
     var content: String
     var createdDate: Date?
-    var id: Int
+    // id가 옵셔널 타입인 이유는 사용자가 채팅을 보낸 직후의 채팅 말풍선은 아직 서버에 저장되기 전이므로 id를 알 수 없기 때문
+    var id: Int?
     var isLoading: Bool = false
     
     var formattedTimeString: String {
@@ -41,7 +42,7 @@ struct ChatDataModel {
         return dateFormatter.string(from: createdDate)
     }
     
-    init(role: String, content: String, createdData: Date?, id: Int, isLoading: Bool = false) {
+    init(role: String, content: String, createdData: Date?, id: Int? = nil, isLoading: Bool = false) {
         self.role = role
         self.content = content
         self.createdDate = createdData

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/ChatLog/ViewControllers/CharacterChatLogViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/ChatLog/ViewControllers/CharacterChatLogViewController.swift
@@ -210,7 +210,12 @@ extension CharacterChatLogViewController {
                 }
                 
                 if responseDTO.data.count == 0 { self.didGetAllChatLog = true }
-                self.chatLogDataList.append(contentsOf: responseDTO.data.map({ ChatDataModel(data: $0) }))
+                if let cursor {
+                    self.chatLogDataList.append(contentsOf: responseDTO.data.map({ ChatDataModel(data: $0) }))
+                } else {
+                    self.chatLogDataList = responseDTO.data.map({ ChatDataModel(data: $0) })
+                }
+                
                 guard chatLogDataList.count > 0 else { return }
                 self.lastCursor = chatLogDataList.last!.id
                 completion?()
@@ -317,6 +322,7 @@ extension CharacterChatLogViewController {
                         self.didGetAllChatLog = false
                         self.rootView.chatLogCollectionView.reloadData()
                         self.scrollToBottom(animated: false)
+                        self.isScrollLoading = false
                     }
                 } else {
                     showToast(message: ErrorMessages.networkError, inset: 66)

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/ChatLog/ViewControllers/CharacterChatLogViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/ChatLog/ViewControllers/CharacterChatLogViewController.swift
@@ -17,10 +17,10 @@ class CharacterChatLogViewController: OffroadTabBarViewController {
     private let viewModel = CharacterChatLogViewModel()
     private let chatButtonHidingAnimator = UIViewPropertyAnimator(duration: 0.5, dampingRatio: 1)
     private var rootView: CharacterChatLogView!
-    private var chatLogDataList: [ChatDataModel] = []
-    private var chatLogDataSource: [[ChatDataModel]] {
-        return viewModel.groupChatsByDate(chats: chatLogDataList)
+    private var chatLogDataList: [ChatDataModel] = [] {
+        didSet { chatLogDataSource = viewModel.groupChatsByDate(chats: chatLogDataList) }
     }
+    private var chatLogDataSource: [[ChatDataModel]] = [[]]
     private var isChatButtonHidden: Bool = true
     /// 채팅 중에 채팅 로그 뷰 진입 시 키보드가 내려가는데, 이때 keyboardWillHide() 메서드가 불리지 않게 하기 위해 사용하는 flag.
     ///
@@ -202,9 +202,9 @@ extension CharacterChatLogViewController {
                 }
                 
                 if cursor == nil {
-                    chatLogDataList = responseDTO.data.map({ ChatDataModel(data: $0) })
+                    self.chatLogDataList = responseDTO.data.map({ ChatDataModel(data: $0) })
                 } else {
-                    chatLogDataList.append(contentsOf: responseDTO.data.map({ ChatDataModel(data: $0) }))
+                    self.chatLogDataList.append(contentsOf: responseDTO.data.map({ ChatDataModel(data: $0) }))
                 }
                 
                 guard chatLogDataList.count > 0 else { return }

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/ChatLog/ViewControllers/CharacterChatLogViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/ChatLog/ViewControllers/CharacterChatLogViewController.swift
@@ -316,15 +316,7 @@ extension CharacterChatLogViewController {
         NetworkMonitoringManager.shared.networkConnectionChanged
             .subscribe(onNext: { [weak self] isConnected in
                 guard let self else { return }
-                if isConnected {
-                    self.updateChatLogDataSource(characterId: characterId, limit: 14, cursor: nil) { [weak self] in
-                        guard let self else { return }
-                        self.didGetAllChatLog = false
-                        self.rootView.chatLogCollectionView.reloadData()
-                        self.scrollToBottom(animated: false)
-                        self.isScrollLoading = false
-                    }
-                } else {
+                if !isConnected {
                     showToast(message: ErrorMessages.networkError, inset: 66)
                 }
             }).disposed(by: disposeBag)

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/ChatLog/ViewControllers/CharacterChatLogViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/ChatLog/ViewControllers/CharacterChatLogViewController.swift
@@ -215,7 +215,7 @@ extension CharacterChatLogViewController {
                 self.lastCursor = chatLogDataList.last!.id
                 completion?()
             case .networkFail:
-                showToast(message: ErrorMessages.networkError, inset: 66)
+                return
             case .decodeErr:
                 showToast(message: "디코딩 에러.", inset: 66)
             case .serverErr:

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/ChatLog/ViewControllers/CharacterChatLogViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/ChatLog/ViewControllers/CharacterChatLogViewController.swift
@@ -545,22 +545,18 @@ extension CharacterChatLogViewController: UIScrollViewDelegate {
         let triggerOffset: CGFloat = 200
         if scrollView.contentOffset.y < triggerOffset && !isScrollLoading {
             isScrollLoading = true
-            DispatchQueue.global().async { [weak self] in
+            self.requestChatLogDataSource(characterId: characterId, limit: 14, cursor: lastCursor) { [weak self] in
                 guard let self else { return }
-                self.requestChatLogDataSource(characterId: characterId, limit: 14, cursor: lastCursor) { [weak self] in
-                    guard let self else { return }
-                    self.rootView.chatLogCollectionView.reloadData()
-                    let previousContentHeight = scrollView.contentSize.height
-                    scrollView.layoutIfNeeded()
-                    let updatedContentHeight = scrollView.contentSize.height
-                    scrollView.contentOffset = CGPoint(
-                        x: 0,
-                        y: updatedContentHeight - previousContentHeight + self.rootView.chatLogCollectionView.contentOffset.y
-                    )
-                    self.isScrollLoading = false
-                }
+                self.rootView.chatLogCollectionView.reloadData()
+                let previousContentHeight = scrollView.contentSize.height
+                scrollView.layoutIfNeeded()
+                let updatedContentHeight = scrollView.contentSize.height
+                scrollView.contentOffset = CGPoint(
+                    x: 0,
+                    y: updatedContentHeight - previousContentHeight + self.rootView.chatLogCollectionView.contentOffset.y
+                )
+                self.isScrollLoading = false
             }
-            
         }
         
         guard scrollView.contentSize.height > 0 else { return }

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/ChatLog/ViewControllers/CharacterChatLogViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/ChatLog/ViewControllers/CharacterChatLogViewController.swift
@@ -261,13 +261,16 @@ extension CharacterChatLogViewController {
         rootView.sendButton.rx.tap.bind(
             onNext: { [weak self] in
                 guard let self else { return }
-                self.postCharacterChat(characterId: characterId, message: self.rootView.userChatInputView.text)
+                let userMessage = self.rootView.userChatInputView.text
                 self.rootView.sendButton.isEnabled = false
                 // 사용자 채팅 버블 추가
                 self.sendChatBubble(isUserChat: true, text: self.rootView.userChatInputView.text, isLoading: false) { [weak self] isFinished in
                     guard let self else { return }
                     // 캐릭터 셀 추가
-                    self.sendChatBubble(isUserChat: false, text: "", isLoading: true)
+                    self.sendChatBubble(isUserChat: false, text: "", isLoading: true) { [weak self] isFinished in
+                        guard let self else { return }
+                        self.postCharacterChat(characterId: characterId, message: userMessage!)
+                    }
                 }
                 self.rootView.userChatInputView.text = ""
                 

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/ChatLog/ViewModel/CharacterChatLogViewModel.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/ChatLog/ViewModel/CharacterChatLogViewModel.swift
@@ -20,7 +20,7 @@ final class CharacterChatLogViewModel {
             if groupedChats[dateKey] == nil {
                 groupedChats[dateKey] = []
             }
-            groupedChats[dateKey]?.append(chat)
+            groupedChats[dateKey]?.insert(chat, at: 0)
         }
         let sortedKeys = groupedChats.keys.sorted()
         return sortedKeys.compactMap { groupedChats[$0] }

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/ChatLog/Views/CharacterChatLogView.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/ChatLog/Views/CharacterChatLogView.swift
@@ -162,7 +162,6 @@ extension CharacterChatLogView {
             )
             collectionView.contentInsetAdjustmentBehavior = .automatic
             collectionView.contentInset.bottom = 135
-            collectionView.showsVerticalScrollIndicator = false
             collectionView.keyboardDismissMode = .onDrag
         }
         


### PR DESCRIPTION
### 🌴 작업한 브랜치
- #370 


### ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->
채팅 로그 뷰의 무한스크롤을 구현하였습니다. 
- 추가적인 채팅 내역(초깃값 포함)을 요청하는 메서드는
 `updateChatLogDataSource(characterId:limit:cursor:completion:)` 입니다. 
처음에는 28개의 채팅을 불러오고, 이후부터는 한 번에 14개씩 불러오게 됩니다. 
- 서버에 요청하여 받아온 추가적인 채팅 내역을 바탕으로 컬렉션뷰를 업데이트하는 메서드는 `expandChatLogCollectionView()` 입니다. 이 메서드는 변경된 dataSource를 바탕으로 추가된 `Section`과 `Item`들을 계산하여 컬렉션뷰에 추가합니다. 
- 무한스크롤을 통해서 모든 채팅 내역을 불러올 경우 (서버의 응답 값이 비어있을 경우) 더 이상 서버에 요청하지 않도록 구현하였습니다.
(`didGetAllChatLog` 플래그의 역할)

<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### ❗️PR Point
<!-- 부족했던 점 혹은 개선하고 싶은 방향이 있다면 얘기해주세요 -->
- 무한스크롤로 인해 추가적인 데이터를 받아올 때 스크롤이 부자연스럽게 잠깐 끊기는 현상이 있습니다. 참고해주세요
(이걸 해결해보려고 했는데, 도저히 지금 상황에서는 시간 내에 못할 것 같아서 일단 후순위로 미뤄둔 상태입니다.)
- 현재 채팅 로그에서 이전 채팅 내역을 요청하는 조건은 scrollView의 `contentOffset`입니다.
추후 UX 개선 시 해당 조건이 추가되거나 변경될 수 있습니다.
- 현재 무한 스크롤 기능은 구현되어있으나, 로딩 로티는 적용되지 않은 상황입니다. 
이전 작업에서 제가 `UIScrollView`를 확장하여 로딩 로티를 표시하는 메서드를 구현한 적이 있는데, 
해당 메서드의 개선이 필요하다고 판단되어 다른 브랜치에서 이를 수정 후에 적용할 예정입니다. 
- 빠르게 스크롤하거나, 화면 상단 상태바를 눌러 맨 위로 스크롤하는 경우, 연속적으로 데이터가 불러와 이상하게 보이는 현상이 있습니다. 
이 역시 로딩 로티를 구현하는 브랜치에서 같이 개선할 예정입니다. 
<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->

|뷰|설명|
|:------:|:---:|
|  <img src="https://github.com/user-attachments/assets/95bc6410-689a-4414-9faa-c47ec9b22a09" width=200>  |     |


- Resolved: #370 
