### PR TITLE
[Chore] #376 - 바뀐 MoyaPlugin 대응

### DIFF
--- a/Offroad-iOS/Offroad-iOS/Presentation/MyPage/CharacterList/ViewController/CharacterDetailViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/MyPage/CharacterList/ViewController/CharacterDetailViewController.swift
@@ -96,14 +96,6 @@ extension CharacterDetailViewController {
             self.rootView.collectionView.reloadData()
         }).disposed(by: disposeBag)
         
-        Observable.combineLatest(
-            viewModel.networkingFailure,
-            viewDidAppear.take(1)
-        ).subscribe(onNext: { [weak self] _, _ in
-            guard let self else { return }
-            self.showToast(message: ErrorMessages.networkError, inset: 66)
-        }).disposed(by: disposeBag)
-        
         rootView.customBackButton.rx.tap.bind(onNext: { [weak self] in
             guard let self else { return }
             self.navigationController?.popViewController(animated: true)

--- a/Offroad-iOS/Offroad-iOS/Presentation/MyPage/CharacterList/ViewModel/CharacterDetailViewModel.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/MyPage/CharacterList/ViewModel/CharacterDetailViewModel.swift
@@ -47,15 +47,15 @@ final class CharacterDetailViewModel {
         Observable.combineLatest(
             self.characterDetailInfoSubject,
             self.characterMotionListDataSourceSubject
-        ).do(onNext: { [weak self] in
-            guard let self else { return }
-            /// 네트워크 종류를 구분하지 않아서, 로컬 네트워크(loopback 등)일 경우 문제 생길 수 있음.
-            /// 일반적인 상황에서는 큰 문제 없을 것으로 예상
-            let isNetworkConnected = NetworkMonitoringManager.shared.networkMonitor.currentPath.status == .satisfied
-            if !isNetworkConnected && ((($0 == nil) || ($1 == nil))) {
-                self.networkingFailure.onNext(())
-            }
-        }).filter({ $0 != nil && $1 != nil })
+//        ).do(onNext: { [weak self] in
+//            guard let self else { return }
+//            /// 네트워크 종류를 구분하지 않아서, 로컬 네트워크(loopback 등)일 경우 문제 생길 수 있음.
+//            /// 일반적인 상황에서는 큰 문제 없을 것으로 예상
+//            let isNetworkConnected = NetworkMonitoringManager.shared.networkMonitor.currentPath.status == .satisfied
+//            if !isNetworkConnected && ((($0 == nil) || ($1 == nil))) {
+//                self.networkingFailure.onNext(())
+//            }
+        /*}*/).filter({ $0 != nil && $1 != nil })
         .subscribe(onNext: { [weak self] _ in
             guard let self else { return }
             self.networkingSuccess.onNext(())
@@ -93,7 +93,7 @@ extension CharacterDetailViewModel {
                 MyInfoManager.shared.didChangeRepresentativeCharacter.accept(())
                 representativeCharacterChanged.onNext(())
             case .networkFail:
-                self.networkingFailure.onNext(())
+                return
             default:
                 break
             }

--- a/Offroad-iOS/Offroad-iOS/Presentation/MyPage/CharacterList/ViewModel/CharacterDetailViewModel.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/MyPage/CharacterList/ViewModel/CharacterDetailViewModel.swift
@@ -30,7 +30,6 @@ final class CharacterDetailViewModel {
     
     var disposeBag = DisposeBag()
     
-    var representativeCharacterChanged = PublishSubject<Void>()
     var characterDetailInfoSubject = PublishSubject<CharacterDetailInfo?>()
     var characterMotionListDataSourceSubject = PublishSubject<[CharacterMotionInfoData]?>()
     
@@ -46,16 +45,8 @@ final class CharacterDetailViewModel {
         
         Observable.combineLatest(
             self.characterDetailInfoSubject,
-            self.characterMotionListDataSourceSubject
-//        ).do(onNext: { [weak self] in
-//            guard let self else { return }
-//            /// 네트워크 종류를 구분하지 않아서, 로컬 네트워크(loopback 등)일 경우 문제 생길 수 있음.
-//            /// 일반적인 상황에서는 큰 문제 없을 것으로 예상
-//            let isNetworkConnected = NetworkMonitoringManager.shared.networkMonitor.currentPath.status == .satisfied
-//            if !isNetworkConnected && ((($0 == nil) || ($1 == nil))) {
-//                self.networkingFailure.onNext(())
-//            }
-        /*}*/).filter({ $0 != nil && $1 != nil })
+            self.characterMotionListDataSourceSubject)
+        .filter({ $0 != nil && $1 != nil })
         .subscribe(onNext: { [weak self] _ in
             guard let self else { return }
             self.networkingSuccess.onNext(())
@@ -70,7 +61,7 @@ final class CharacterDetailViewModel {
         
         Observable.combineLatest(
             characterDetailInfoSubject,
-            representativeCharacterChanged
+            MyInfoManager.shared.didChangeRepresentativeCharacter
         )
         .filter({ $0.0 != nil })
         .map({ ($0.0!, $0.1) })
@@ -91,7 +82,6 @@ extension CharacterDetailViewModel {
                 representativeCharacterId = characterId
                 MyInfoManager.shared.representativeCharacterID = characterId
                 MyInfoManager.shared.didChangeRepresentativeCharacter.accept(())
-                representativeCharacterChanged.onNext(())
             case .networkFail:
                 return
             default:

--- a/Offroad-iOS/Offroad-iOS/Presentation/MyPage/Coupon/ViewController/CouponDetailViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/MyPage/Coupon/ViewController/CouponDetailViewController.swift
@@ -120,7 +120,6 @@ class CouponDetailViewController: UIViewController {
                 self.afterCouponRedemptionRelay.accept(response.data.success)
             default:
                 self.afterCouponRedemptionRelay.accept(false)
-                self.showToast(message: ErrorMessages.networkError, inset: 66)
                 return
             }
         }

--- a/Offroad-iOS/Offroad-iOS/Presentation/PlaceList/ViewControllers/PlaceListViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/PlaceList/ViewControllers/PlaceListViewController.swift
@@ -8,17 +8,10 @@
 import UIKit
 
 import CoreLocation
-import RxSwift
-import RxCocoa
 
 class PlaceListViewController: UIViewController {
     
     //MARK: - Properties
-    
-    var disposeBag = DisposeBag()
-    
-    let netWorkdDidFail = PublishRelay<Void>()
-    let viewDidAppear = PublishRelay<Void>()
     
     let locationManager = CLLocationManager()
     let placeService = RegisteredPlaceService()
@@ -48,8 +41,6 @@ class PlaceListViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        bindData()
-        
         setupButtonsActions()
         setupCollectionView()
         setupDelegates()
@@ -66,12 +57,6 @@ class PlaceListViewController: UIViewController {
         offroadTabBarController.hideTabBarAnimation()
     }
     
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-        
-        viewDidAppear.accept(())
-    }
-        
 }
 
 extension PlaceListViewController {
@@ -87,15 +72,6 @@ extension PlaceListViewController {
     }
     
     //MARK: - Private Func
-    
-    private func bindData() {
-        Observable.combineLatest(netWorkdDidFail, viewDidAppear)
-            .subscribe { [weak self] _ in
-                guard let self else { return }
-                self.showToast(message: ErrorMessages.networkError, inset: 66)
-            }
-            .disposed(by: disposeBag)
-    }
         
     private func setupButtonsActions() {
         rootView.customBackButton.addTarget(self, action: #selector(customBackButtonTapped), for: .touchUpInside)
@@ -155,9 +131,8 @@ extension PlaceListViewController {
                 self.rootView.segmentedControl.isUserInteractionEnabled = true
                 self.rootView.pageViewController.view.isUserInteractionEnabled = true
                 
-            case .networkFail:
-                netWorkdDidFail.accept(())
             default:
+                rootView.pageViewController.view.stopLoading()
                 return
             }
         }

--- a/Offroad-iOS/Offroad-iOS/Presentation/QuestMap/ViewControllers/QuestMapViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/QuestMap/ViewControllers/QuestMapViewController.swift
@@ -180,7 +180,6 @@ extension QuestMapViewController {
             .subscribe(onNext: { [weak self] in
                 guard let self else { return }
                 self.tabBarController?.view.stopLoading()
-                self.showToast(message: ErrorMessages.networkError, inset: 66)
             }).disposed(by: disposeBag)
         
         viewModel.locationServiceDisabledRelay

--- a/Offroad-iOS/Offroad-iOS/Presentation/QuestMap/ViewModel/QuestMapViewModel.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/QuestMap/ViewModel/QuestMapViewModel.swift
@@ -110,9 +110,8 @@ extension QuestMapViewModel {
                 }
                 
                 self.markersSubject.onNext(markers)
-            case .networkFail:
-                self.networkFailureSubject.onNext(())
             default:
+                self.networkFailureSubject.onNext(())
                 return
             }
         }
@@ -146,9 +145,8 @@ extension QuestMapViewModel {
                     self.isLocationAdventureAuthenticated.onNext(data.data.isValidPosition)
                     self.successCharacterImageUrl.onNext(data.data.successCharacterImageUrl)
                     self.completeQuestList.onNext(data.data.completeQuestList)
-                case .networkFail:
-                    self.networkFailureSubject.onNext(())
                 default:
+                    self.networkFailureSubject.onNext(())
                     return
                 }
             })


### PR DESCRIPTION
### 🌴 작업한 브랜치
- #376 


### ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->
인터넷 연결이 끊겨 서버로부터 아무런 데이터도 받지 못하는 경우, 네트워크 에러 관련 토스트를 띄워야 합니다. 
이때, MoyaPlugin에서 해당 케이스에서 토스트를 띄우도록 구현함에 따라, 
제가 작업한 뷰컨트롤러들에서 서버 통신 실패 시 토스트를 띄우는 메서드를 지움으로써 해당 메서드가 중복으로 호출되는 것을 방지하였습니다. 

관련 뷰 혹은 서버 통신은 다음과 같습니다. 
- 지도에서 장소 목록 조회, 장소 목록 뷰
- 탐험 (위치)인증
- 캐릭터 상세 뷰
- 캐릭터 상세 뷰
- 대표 캐릭터로 선택하는 API
<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### ❗️PR Point
<!-- 부족했던 점 혹은 개선하고 싶은 방향이 있다면 얘기해주세요 -->

<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->

|뷰|설명|
|:------:|:---:|
|        |     |


- Resolved: #376 
