### PR TITLE
[Feat] #372 - 캐릭터 채팅 읽음 여부 

### DIFF
--- a/Offroad-iOS/Offroad-iOS.xcodeproj/project.pbxproj
+++ b/Offroad-iOS/Offroad-iOS.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		4E1E94172C3AC27000A7B08A /* QuestMapViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E1E94162C3AC27000A7B08A /* QuestMapViewController.swift */; };
 		4E1E94192C3AC27C00A7B08A /* QuestMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E1E94182C3AC27C00A7B08A /* QuestMapView.swift */; };
 		4E23776E2CC81B2000716AFF /* NetworkMonitoringManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E23776D2CC81B2000716AFF /* NetworkMonitoringManager.swift */; };
+		4E3120F82D0FECD80055F0B0 /* CharacterChatReadGetResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E3120F72D0FECD80055F0B0 /* CharacterChatReadGetResponseDTO.swift */; };
 		4E37B6CF2C456FBF007358DA /* UITabBar+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E37B6CE2C456FBF007358DA /* UITabBar+.swift */; };
 		4E37B6D12C4594CE007358DA /* CompleteChoosingCharacterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E37B6D02C4594CE007358DA /* CompleteChoosingCharacterView.swift */; };
 		4E37B6D32C4594D9007358DA /* CompleteChoosingCharacterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E37B6D22C4594D9007358DA /* CompleteChoosingCharacterViewController.swift */; };
@@ -339,6 +340,7 @@
 		4E1E94162C3AC27000A7B08A /* QuestMapViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestMapViewController.swift; sourceTree = "<group>"; };
 		4E1E94182C3AC27C00A7B08A /* QuestMapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestMapView.swift; sourceTree = "<group>"; };
 		4E23776D2CC81B2000716AFF /* NetworkMonitoringManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkMonitoringManager.swift; sourceTree = "<group>"; };
+		4E3120F72D0FECD80055F0B0 /* CharacterChatReadGetResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CharacterChatReadGetResponseDTO.swift; sourceTree = "<group>"; };
 		4E37B6CE2C456FBF007358DA /* UITabBar+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITabBar+.swift"; sourceTree = "<group>"; };
 		4E37B6D02C4594CE007358DA /* CompleteChoosingCharacterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = CompleteChoosingCharacterView.swift; path = "Offroad-iOS/Presentation/Character/CompleteChoosingCharacter/View/CompleteChoosingCharacterView.swift"; sourceTree = SOURCE_ROOT; };
 		4E37B6D22C4594D9007358DA /* CompleteChoosingCharacterViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = CompleteChoosingCharacterViewController.swift; path = "Offroad-iOS/Presentation/Character/CompleteChoosingCharacter/ViewController/CompleteChoosingCharacterViewController.swift"; sourceTree = SOURCE_ROOT; };
@@ -1202,6 +1204,7 @@
 			children = (
 				4E3A32702CE51176007228D0 /* CharacterChatPostResponseDTO.swift */,
 				4E3A32722CE51185007228D0 /* CharacterChatGetResponseDTO.swift */,
+				4E3120F72D0FECD80055F0B0 /* CharacterChatReadGetResponseDTO.swift */,
 			);
 			path = Response;
 			sourceTree = "<group>";
@@ -2754,6 +2757,7 @@
 				4E4E2C0C2CCF6518000A634D /* QuestMapViewModel.swift in Sources */,
 				D004F8582CA12B1500D5A2CD /* NoticeAPI.swift in Sources */,
 				872F4BB72C6B809800284DE0 /* CharacterDetailViewController.swift in Sources */,
+				4E3120F82D0FECD80055F0B0 /* CharacterChatReadGetResponseDTO.swift in Sources */,
 				D06466A12C89CB5200CF10FD /* UserInfoResponseDTO.swift in Sources */,
 				872F4BBB2C6B917800284DE0 /* CharacterDetailCell.swift in Sources */,
 				D0E7963D2C453787005B47A5 /* QuestService.swift in Sources */,

--- a/Offroad-iOS/Offroad-iOS/Network/CharacterChat/CharacterChatAPI.swift
+++ b/Offroad-iOS/Offroad-iOS/Network/CharacterChat/CharacterChatAPI.swift
@@ -12,6 +12,8 @@ import Moya
 enum CharacterChatAPI {
     case postChat(characterId: Int? = nil, body: CharacterChatPostRequestDTO)
     case getChatLog(characterId: Int? = nil, limit: Int, cursor: Int? = nil)
+    case patchChatRead(characterId: Int? = nil)
+    case getLastChatInfo
 }
 
 extension CharacterChatAPI: BaseTargetType {
@@ -20,13 +22,21 @@ extension CharacterChatAPI: BaseTargetType {
     }
     
     var path: String {
-        "/chats"
+        switch self {
+        case .postChat, .getChatLog:
+           return  "/chats"
+        case .patchChatRead:
+            return "/chats/read"
+        case .getLastChatInfo:
+            return "/chats/last-unread"
+        }
     }
     
     var method: Moya.Method {
         switch self {
         case .postChat: .post
-        case .getChatLog: .get
+        case .patchChatRead: .patch
+        case .getChatLog, .getLastChatInfo: .get
         }
     }
     
@@ -45,6 +55,12 @@ extension CharacterChatAPI: BaseTargetType {
             queryParameters["limit"] = limit
             if let cursor { queryParameters["cursor"] = cursor }
             return .requestParameters(parameters: queryParameters, encoding: URLEncoding.queryString)
+        case .patchChatRead(characterId: let characterId):
+            var queryParameters: [String: Any] = [:]
+            if let characterId { queryParameters["characterId"] = characterId }
+            return .requestParameters(parameters: queryParameters, encoding: URLEncoding.queryString)
+        case .getLastChatInfo:
+            return .requestPlain
         }
     }
     

--- a/Offroad-iOS/Offroad-iOS/Network/CharacterChat/CharacterChatService.swift
+++ b/Offroad-iOS/Offroad-iOS/Network/CharacterChat/CharacterChatService.swift
@@ -15,7 +15,14 @@ protocol CharacterChatServiceProtocol {
         body: CharacterChatPostRequestDTO,
         completion: @escaping (NetworkResult<CharacterChatPostResponseDTO>) -> Void
     )
-    func getChatLog(characterId: Int?, limit: Int, cursor: Int?, completion: @escaping (NetworkResult<CharacterChatGetResponseDTO>) -> Void)
+    func getChatLog(
+        characterId: Int?,
+        limit: Int,
+        cursor: Int?,
+        completion: @escaping (NetworkResult<CharacterChatGetResponseDTO>) -> Void
+    )
+    func patchChatRead(characterId: Int?, completion: @escaping (NetworkResult<Any>) -> Void)
+    func getLastChatInfo(completion: @escaping (NetworkResult<CharacterChatReadGetResponseDTO>) -> Void)
 }
 
 final class CharacterChatService: BaseService, CharacterChatServiceProtocol {
@@ -64,4 +71,43 @@ final class CharacterChatService: BaseService, CharacterChatServiceProtocol {
         }
     }
     
+    func patchChatRead(characterId: Int? = nil, completion: @escaping (NetworkResult<Any>) -> Void) {
+        provider.request(.patchChatRead(characterId: characterId)) { result in
+            switch result {
+            case .success(let response):
+                let networkResult: NetworkResult<Any> = self.fetchNetworkResult(
+                    statusCode: response.statusCode,
+                    data: response.data
+                )
+                completion(networkResult)
+            case .failure(let error):
+                guard let response = error.response else { return }
+                let networkResult: NetworkResult<Any> = self.fetchNetworkResult(
+                    statusCode: response.statusCode,
+                    data: response.data
+                )
+                completion(networkResult)
+            }
+        }
+    }
+    
+    func getLastChatInfo(completion: @escaping (NetworkResult<CharacterChatReadGetResponseDTO>) -> Void) {
+        provider.request(.getLastChatInfo) { result in
+            switch result {
+            case .success(let response):
+                let networkResult: NetworkResult<CharacterChatReadGetResponseDTO> = self.fetchNetworkResult<CharacterChatReadGetResponseDTO>(
+                    statusCode: response.statusCode,
+                    data: response.data
+                )
+                completion(networkResult)
+            case .failure(let error):
+                guard let response = error.response else { return }
+                let networkResult: NetworkResult<CharacterChatReadGetResponseDTO> = self.fetchNetworkResult(
+                    statusCode: response.statusCode,
+                    data: response.data
+                )
+                completion(networkResult)
+            }
+        }
+    }
 }

--- a/Offroad-iOS/Offroad-iOS/Network/CharacterChat/DTO/Response/CharacterChatReadGetResponseDTO.swift
+++ b/Offroad-iOS/Offroad-iOS/Network/CharacterChat/DTO/Response/CharacterChatReadGetResponseDTO.swift
@@ -1,0 +1,19 @@
+//
+//  CharacterChatReadGetResponseDTO.swift
+//  Offroad-iOS
+//
+//  Created by 김민성 on 12/16/24.
+//
+
+import Foundation
+
+struct CharacterChatReadGetResponseDTO: Codable {
+    var message: String
+    var data: CharacterChatReadGetResponseData
+}
+
+struct CharacterChatReadGetResponseData: Codable {
+    var doesAllRead: Bool
+    var characterName: String?
+    var content: String?
+}

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/ORBCharacterChatManager.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/ORBCharacterChatManager.swift
@@ -48,17 +48,6 @@ extension ORBCharacterChatManager {
     
     func startChat() {
         chatWindow.makeKeyAndVisible()
-        if chatViewController.isCharacterChatBoxShown {
-            chatViewController.showCharacterChatBox()
-            chatViewController.changeChatBoxMode(to: .withoutReplyButtonExpanded, animated: true)
-        } else {
-            chatViewController.configureCharacterChatBox(
-                character: "", message: "",
-                mode: .withoutReplyButtonShrinked,
-                animated: false
-            )
-            chatViewController.hideCharacterChatBox()
-        }
         self.chatViewController.rootView.userChatInputView.becomeFirstResponder()
     }
     

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/ViewControllers/ORBCharacterChatViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/ViewControllers/ORBCharacterChatViewController.swift
@@ -92,8 +92,6 @@ extension ORBCharacterChatViewController {
     }
     
     @objc private func tapGestureHandler(sender: UITapGestureRecognizer) {
-        guard rootView.characterChatBox.mode == .withReplyButtonShrinked
-                || rootView.characterChatBox.mode == .withReplyButtonExpanded else { return }
         NetworkService.shared.characterChatService.patchChatRead { [weak self] networkResult in
             guard let self else { return }
             switch networkResult {

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/ViewControllers/ORBCharacterChatViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/ViewControllers/ORBCharacterChatViewController.swift
@@ -94,6 +94,13 @@ extension ORBCharacterChatViewController {
     @objc private func tapGestureHandler(sender: UITapGestureRecognizer) {
         guard rootView.characterChatBox.mode == .withReplyButtonShrinked
                 || rootView.characterChatBox.mode == .withReplyButtonExpanded else { return }
+        NetworkService.shared.characterChatService.patchChatRead { [weak self] networkResult in
+            guard let self else { return }
+            switch networkResult {
+            case .success: return
+            default: self.showToast(message: ErrorMessages.networkError, inset: 66)
+            }
+        }
         ORBCharacterChatManager.shared.shouldPushCharacterChatLogViewController.onNext(MyInfoManager.shared.representativeCharacterID ?? 1)
     }
     

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/ViewControllers/ORBCharacterChatViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/ViewControllers/ORBCharacterChatViewController.swift
@@ -293,6 +293,7 @@ extension ORBCharacterChatViewController {
         characterChatBoxPositionAnimator.stopAnimation(true)
         characterChatBoxPositionAnimator.addAnimations { [weak self] in
             guard let self else { return }
+            // pagGesture로 변경된 (세로)위치 원상복구
             self.rootView.characterChatBox.transform = CGAffineTransform.identity
             self.rootView.characterChatBoxTopConstraint.constant = view.safeAreaInsets.top + 27
             self.rootView.layoutIfNeeded()
@@ -305,6 +306,7 @@ extension ORBCharacterChatViewController {
         characterChatBoxPositionAnimator.stopAnimation(true)
         characterChatBoxPositionAnimator.addAnimations { [weak self] in
             guard let self else { return }
+            // pagGesture로 변경된 (세로)위치 원상복구
             self.rootView.characterChatBox.transform = CGAffineTransform.identity
             self.rootView.characterChatBoxTopConstraint.constant
             = -self.rootView.characterChatBox.frame.height
@@ -355,22 +357,12 @@ extension ORBCharacterChatViewController {
         rootView.characterChatBox.characterNameLabel.text = name + " :"
         rootView.characterChatBox.messageLabel.text = message
         changeChatBoxMode(to: mode, animated: animated)
-        let labelFrameWidth = rootView.characterChatBox.messageLabel.frame.width
-        let labelFrameHeight = rootView.characterChatBox.messageLabel.frame.height
-        let calculatedLabelSize = calculateLabelSize(
-            text: message,
-            font: rootView.characterChatBox.messageLabel.font,
-            maxSize: .init(width: labelFrameWidth, height: CGFloat.greatestFiniteMagnitude)
-        )
-        rootView.characterChatBox.chevronImageButton.isHidden
-        = (calculatedLabelSize.height > labelFrameHeight) ? false : true
     }
     
     func changeChatBoxMode(to mode: ChatBoxMode, animated: Bool) {
         characterChatBoxModeChangingAnimator.stopAnimation(true)
         rootView.characterChatBox.mode = mode
-        rootView.characterChatBox.chevronImageButton.isHidden =
-        (mode == .loading) ? true : false
+        rootView.characterChatBox.chevronImageButton.isHidden = (mode == .loading)
         if animated {
             characterChatBoxModeChangingAnimator.addAnimations { [weak self] in
                 guard let self else { return }

--- a/Offroad-iOS/Offroad-iOS/Presentation/Home/View/HomeView.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Home/View/HomeView.swift
@@ -87,6 +87,7 @@ extension HomeView {
         chatUnreadDotView.do { view in
             view.backgroundColor = .primary(.errorNew)
             view.roundCorners(cornerRadius: 4)
+            view.isHidden = true
         }
         
         shareButton.do {

--- a/Offroad-iOS/Offroad-iOS/Presentation/Home/View/HomeView.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Home/View/HomeView.swift
@@ -22,7 +22,7 @@ final class HomeView: UIView {
     private let characterNameLabel = UILabel()
     private let backgroundImageView = UIImageView(image: UIImage(resource: .imgHomeBackground))
     let chatButton = UIButton()
-    private let chatUnreadDotView = UIView()
+    let chatUnreadDotView = UIView()
     let shareButton = UIButton()
     let changeCharacterButton = UIButton()
     private let buttonStackView = UIStackView()

--- a/Offroad-iOS/Offroad-iOS/Presentation/Home/View/HomeView.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Home/View/HomeView.swift
@@ -22,6 +22,7 @@ final class HomeView: UIView {
     private let characterNameLabel = UILabel()
     private let backgroundImageView = UIImageView(image: UIImage(resource: .imgHomeBackground))
     let chatButton = UIButton()
+    private let chatUnreadDotView = UIView()
     let shareButton = UIButton()
     let changeCharacterButton = UIButton()
     private let buttonStackView = UIStackView()
@@ -81,6 +82,11 @@ extension HomeView {
         
         chatButton.do {
             $0.setImage(.btnChat, for: .normal)
+        }
+        
+        chatUnreadDotView.do { view in
+            view.backgroundColor = .primary(.errorNew)
+            view.roundCorners(cornerRadius: 4)
         }
         
         shareButton.do {
@@ -175,6 +181,7 @@ extension HomeView {
             shareButton,
             changeCharacterButton
         )
+        chatButton.addSubview(chatUnreadDotView)
         titleView.addSubviews(titleLabel, changeTitleButton)
         questStackView.addArrangedSubviews(recentQuestView, almostDoneQuestView)
         recentQuestView.addSubviews(recentQuestProgressView, recentQuestProgressLabel)
@@ -207,6 +214,12 @@ extension HomeView {
         buttonStackView.snp.makeConstraints {
             $0.top.equalTo(characterNameView.snp.top)
             $0.trailing.equalToSuperview().inset(24)
+        }
+        
+        chatUnreadDotView.snp.makeConstraints { make in
+            make.top.equalToSuperview().inset(2)
+            make.trailing.equalToSuperview().inset(4)
+            make.size.equalTo(8)
         }
         
         characterBaseImageView.snp.makeConstraints {

--- a/Offroad-iOS/Offroad-iOS/Presentation/Home/ViewController/HomeViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Home/ViewController/HomeViewController.swift
@@ -55,7 +55,6 @@ final class HomeViewController: OffroadTabBarViewController {
         setupTarget()
         getUserAdventureInfo()
         getUserQuestInfo()
-        getLastChatInfo()
         bindData()
         
         requestPushNotificationPermission()
@@ -69,7 +68,7 @@ final class HomeViewController: OffroadTabBarViewController {
         offroadTabBarController.showTabBarAnimation()
         
         self.navigationController?.navigationBar.isHidden = true
-        
+        getLastChatInfo()
     }
 }
 
@@ -136,8 +135,10 @@ extension HomeViewController {
     }
     
     private func getLastChatInfo() {
+        rootView.chatButton.isEnabled = false
         NetworkService.shared.characterChatService.getLastChatInfo { [weak self] networkResult in
             guard let self else { return }
+            self.rootView.chatButton.isEnabled = true
             switch networkResult {
             case .success(let dto):
                 guard let dto else { return }


### PR DESCRIPTION
### 🌴 작업한 브랜치
- #372 


### ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->
캐릭터 채팅 읽음 기능을 구현하였습니다. 
캐릭터로부터 선톡이 왔을 때 사용자가 채팅을 읽지 않으면 이를 사용자에게 알려주어야 합니다.
또한 사용자가 최신 채팅을 읽으면 읽었음을 확인하여 서버에 알려주어야 합니다.

추가된 주요 기능들은 다음과 같습니다. 
- 홈 화면의 메시지 버튼(채팅 버튼) 옆의 빨간 점
홈 화면에 있는 메시지 버튼(채팅 버튼) 옆에 뜨는 빨간 점은 캐릭터의 가장 최근 채팅을 읽지 않은 상태인지 여부를 알려줍니다. 
즉, 현재 홈 화면에 뜨는 캐릭터(==대표 캐릭터)의 최근 메시지 읽음 여부를 확인해야 하며, `~/api/chats/read(PATCH)`API를 통해 확인합니다.
현재는 채팅 읽음 여부를 `viewWillAppear` 에서 확인하고 있는데요, 호출 위치나 방식은 추후 개선될 필요가 있어 보입니다. (캐릭터 선톡이 올 때 최신 채팅 읽음 여부를 업데이트해야 할 듯 합니다.)
홈 화면의 메시지 버튼 옆에 빨간 점이 있을 경우, 메시지 버튼(채팅 버튼)을 누르면 키보드가 올라오는것 뿐만 아니라 가장 최근의 메시지가 같이 보이게 됩니다. 

- 채팅 읽음 여부 확인
캐릭터의 최신 채팅을 읽었는지 여부를 확인하여 서버에 이를 알려야 합니다. 
현재('24.12.17 오후 12:05) 화면설계서 기준 캐릭터의 선톡 채팅의 읽음 기준은 다음과 같습니다.
  1) 캐릭터 선톡이 푸시 알림으로 왔을 때 해당 알림을 탭하여 앱에 접속한 경우
  2) 앱 접속 후 플레이 중 캐릭터 선톡이 상단에 띄워졌을 때 답장하기를 탭하여 키보드가 올라온 경우
  3) 앱 접속 후 플레이 중 캐릭터 선톡이 상단에 띄워졌을 때 탭하여 채팅 로그 뷰를 켠 경우

  위 중 두, 세번째에 해당하는 경우는 캐릭터 채팅을 읽었음을 서버에 전송하도록 하였으며, 첫 번째의 경우는 추후 적용 예정입니다. 
  또한 캐릭터 채팅 로그에서 채팅을 보내고 캐릭터로부터 답장이 왔을 때에도 채팅을 읽었음을 서버에 전송하도록 하였습니다. 
<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### ❗️PR Point
<!-- 부족했던 점 혹은 개선하고 싶은 방향이 있다면 얘기해주세요 -->
- 캐릭터의 최신 채팅을 읽었음을 서버에 알리는 API(PATCH) 인 경우, 정상적인 응답 시 상태 코드가 204로, 별도 응답 값이 없습니다. 참고 바랍니다. (스웨거에도 204로 적혀있긴 한데..응답 값의 형식 예시가 표현되어있어서 헷갈릴까 하여 적어둡니다.)
- 현재 서버에서 선톡이 올 경우, 이를 채팅 로그에 반영하는 로직은 구현되어있지 않은 것으로 알고 있습니다. 
따라서 선톡이 왔을 때 최신 채팅이 쌓이지 않으므로, 현재는 최신 채팅을 읽었는지 여부가 항상 true로 옵니다. (빨간 점이 보일 일이 없습니다.)
이 점 참고하여 리뷰 부탁드립니다. 
<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->

|뷰|설명|
|:------:|:---:|
|        |     |


- Resolved: #372 
