### PR TITLE
[Fix] #385 - 캐릭터 채팅 동작 개선

### DIFF
--- a/Offroad-iOS/Offroad-iOS/Application/AppDelegate.swift
+++ b/Offroad-iOS/Offroad-iOS/Application/AppDelegate.swift
@@ -67,9 +67,13 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
                 completionHandler([])
                 if let characterName = data["characterName"] as? String,
                    let message = data["message"] as? String {
-                    ORBCharacterChatManager.shared.shouldUpdateLastChatInfo.accept(())
-                    ORBCharacterChatManager.shared.showCharacterChatBox(character: characterName, message: message, mode: .withReplyButtonShrinked)
-                    ORBCharacterChatManager.shared.chatViewController.rootView.setNeedsLayout()
+                    if let chatLogViewController = ORBCharacterChatManager.shared.currentChatLogViewController {
+                        chatLogViewController.characterChatPushedRelay.accept(message)
+                    } else {
+                        ORBCharacterChatManager.shared.shouldUpdateLastChatInfo.accept(())
+                        ORBCharacterChatManager.shared.showCharacterChatBox(character: characterName, message: message, mode: .withReplyButtonShrinked)
+                        ORBCharacterChatManager.shared.chatViewController.rootView.setNeedsLayout()
+                    }
                 }
             } else if category == "ANNOUNCEMENT_REDIRECT" {
                 completionHandler([.list, .banner])

--- a/Offroad-iOS/Offroad-iOS/Application/AppDelegate.swift
+++ b/Offroad-iOS/Offroad-iOS/Application/AppDelegate.swift
@@ -67,6 +67,7 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
                 completionHandler([])
                 if let characterName = data["characterName"] as? String,
                    let message = data["message"] as? String {
+                    ORBCharacterChatManager.shared.shouldUpdateLastChatInfo.accept(())
                     ORBCharacterChatManager.shared.showCharacterChatBox(character: characterName, message: message, mode: .withReplyButtonShrinked)
                     ORBCharacterChatManager.shared.chatViewController.rootView.setNeedsLayout()
                 }

--- a/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/Alert/ORBAlertController.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/Alert/ORBAlertController.swift
@@ -232,6 +232,7 @@ extension ORBAlertController {
             })
             .bind { [weak self] recognizer in
                 print("tapped in view")
+                guard !ORBCharacterChatManager.shared.chatViewController.isUserChatInputViewShown else { return }
                 self?.rootView.endEditing(true)
             }.disposed(by: disposeBag)
         

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/ORBCharacterChatManager.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/ORBCharacterChatManager.swift
@@ -63,6 +63,7 @@ extension ORBCharacterChatManager {
     }
     
     func endChat() {
+        chatViewController.hideUserChatInputView()
         chatViewController.rootView.userChatInputView.resignFirstResponder()
         chatViewController.rootView.userChatInputView.text = ""
         chatViewController.rootView.userChatDisplayView.text = ""

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/ORBCharacterChatManager.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/ORBCharacterChatManager.swift
@@ -22,6 +22,7 @@ final class ORBCharacterChatManager {
     let shouldMakeKeyboardBackgroundTransparent = PublishRelay<Bool>()
     let shouldUpdateLastChatInfo = PublishRelay<Void>()
     let didReadLastChat = PublishRelay<Void>()
+    weak var currentChatLogViewController: CharacterChatLogViewController? = nil
     
     //MARK: - UI Properties
     

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/ORBCharacterChatManager.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/ORBCharacterChatManager.swift
@@ -27,18 +27,26 @@ final class ORBCharacterChatManager {
     var chatViewController: ORBCharacterChatViewController {
         chatWindow.rootViewController as! ORBCharacterChatViewController
     }
+    var characterChatBox: ORBCharacterChatBox { chatViewController.rootView.characterChatBox }
+    var userChatView: UIView { chatViewController.rootView.userChatView }
+    var endChatButton: UIButton { chatViewController.rootView.endChatButton }
     
     //MARK: - Life Cycle
     
-    private init() { }
+    private init() {
+        characterChatBox.isHidden = true
+        userChatView.isHidden = true
+        endChatButton.isHidden = true
+    }
     
 }
-    
+
 extension ORBCharacterChatManager {
     
     func showCharacterChatBox(character name: String, message: String, mode: ChatBoxMode) {
         chatWindow.makeKeyAndVisible()
         chatViewController.configureCharacterChatBox(character: name, message: message, mode: mode, animated: false)
+        characterChatBox.isHidden = false
         chatViewController.showCharacterChatBox()
     }
     
@@ -59,6 +67,8 @@ extension ORBCharacterChatManager {
             )
             chatViewController.hideCharacterChatBox()
         }
+        userChatView.isHidden = false
+        endChatButton.isHidden = false
         self.chatViewController.rootView.userChatInputView.becomeFirstResponder()
     }
     

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/ORBCharacterChatManager.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/ORBCharacterChatManager.swift
@@ -20,6 +20,8 @@ final class ORBCharacterChatManager {
     
     let shouldPushCharacterChatLogViewController = PublishSubject<Int>()
     let shouldMakeKeyboardBackgroundTransparent = PublishRelay<Bool>()
+    let shouldUpdateLastChatInfo = PublishRelay<Void>()
+    let didReadLastChat = PublishRelay<Void>()
     
     //MARK: - UI Properties
     

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/ORBCharacterChatManager.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/ORBCharacterChatManager.swift
@@ -46,7 +46,6 @@ extension ORBCharacterChatManager {
     func showCharacterChatBox(character name: String, message: String, mode: ChatBoxMode) {
         chatWindow.makeKeyAndVisible()
         chatViewController.configureCharacterChatBox(character: name, message: message, mode: mode, animated: false)
-        characterChatBox.isHidden = false
         chatViewController.showCharacterChatBox()
     }
     

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/ORBCharacterChatManager.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/ORBCharacterChatManager.swift
@@ -46,10 +46,10 @@ final class ORBCharacterChatManager {
 
 extension ORBCharacterChatManager {
     
-    func showCharacterChatBox(character name: String, message: String, mode: ChatBoxMode) {
+    func showCharacterChatBox(character name: String, message: String, mode: ChatBoxMode, isAutoDismiss: Bool = true) {
         chatWindow.makeKeyAndVisible()
         chatViewController.configureCharacterChatBox(character: name, message: message, mode: mode, animated: false)
-        chatViewController.showCharacterChatBox()
+        chatViewController.showCharacterChatBox(isAutoDismiss: isAutoDismiss)
     }
     
     func hideCharacterChatBox() {

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/ViewControllers/ORBCharacterChatViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/ViewControllers/ORBCharacterChatViewController.swift
@@ -392,31 +392,31 @@ extension ORBCharacterChatViewController {
                 case .withReplyButtonShrinked:
                     self.rootView.characterChatBox.messageLabel.isHidden = false
                     self.rootView.characterChatBox.replyButton.isHidden = false
-                    self.rootView.characterChatBox.chevronImageButton.transform = .identity
+                    self.rootView.characterChatBox.chevronImageButton.imageView?.transform = .identity
                     self.rootView.characterChatBox.loadingAnimationView.isHidden = true
                     self.rootView.characterChatBox.loadingAnimationView.stop()
                 case .withReplyButtonExpanded:
                     self.rootView.characterChatBox.messageLabel.isHidden = false
                     self.rootView.characterChatBox.replyButton.isHidden = false
-                    self.rootView.characterChatBox.chevronImageButton.transform = .init(rotationAngle: .pi * 0.9999)
+                    self.rootView.characterChatBox.chevronImageButton.imageView?.transform = .init(rotationAngle: .pi * 0.9999)
                     self.rootView.characterChatBox.loadingAnimationView.isHidden = true
                     self.rootView.characterChatBox.loadingAnimationView.stop()
                 case .withoutReplyButtonShrinked:
                     self.rootView.characterChatBox.messageLabel.isHidden = false
                     self.rootView.characterChatBox.replyButton.isHidden = true
-                    self.rootView.characterChatBox.chevronImageButton.transform = .identity
+                    self.rootView.characterChatBox.chevronImageButton.imageView?.transform = .identity
                     self.rootView.characterChatBox.loadingAnimationView.isHidden = true
                     self.rootView.characterChatBox.loadingAnimationView.stop()
                 case .withoutReplyButtonExpanded:
                     self.rootView.characterChatBox.messageLabel.isHidden = false
                     self.rootView.characterChatBox.replyButton.isHidden = true
-                    self.rootView.characterChatBox.chevronImageButton.transform = .init(rotationAngle: .pi * 0.9999)
+                    self.rootView.characterChatBox.chevronImageButton.imageView?.transform = .init(rotationAngle: .pi * 0.9999)
                     self.rootView.characterChatBox.loadingAnimationView.isHidden = true
                     self.rootView.characterChatBox.loadingAnimationView.stop()
                 case .loading:
                     self.rootView.characterChatBox.messageLabel.isHidden = true
                     self.rootView.characterChatBox.replyButton.isHidden = true
-                    self.rootView.characterChatBox.chevronImageButton.transform = .identity
+                    self.rootView.characterChatBox.chevronImageButton.imageView?.transform = .identity
                     self.rootView.characterChatBox.loadingAnimationView.isHidden = false
                     self.rootView.characterChatBox.loadingAnimationView.play()
                 }
@@ -429,31 +429,31 @@ extension ORBCharacterChatViewController {
             case .withReplyButtonShrinked:
                 self.rootView.characterChatBox.messageLabel.isHidden = false
                 self.rootView.characterChatBox.replyButton.isHidden = false
-                self.rootView.characterChatBox.chevronImageButton.transform = .identity
+                self.rootView.characterChatBox.chevronImageButton.imageView?.transform = .identity
                 self.rootView.characterChatBox.loadingAnimationView.isHidden = true
                 self.rootView.characterChatBox.loadingAnimationView.stop()
             case .withReplyButtonExpanded:
                 self.rootView.characterChatBox.messageLabel.isHidden = false
                 self.rootView.characterChatBox.replyButton.isHidden = false
-                self.rootView.characterChatBox.chevronImageButton.transform = .init(rotationAngle: .pi * 0.99)
+                self.rootView.characterChatBox.chevronImageButton.imageView?.transform = .init(rotationAngle: .pi * 0.99)
                 self.rootView.characterChatBox.loadingAnimationView.isHidden = true
                 self.rootView.characterChatBox.loadingAnimationView.stop()
             case .withoutReplyButtonShrinked:
                 self.rootView.characterChatBox.messageLabel.isHidden = false
                 self.rootView.characterChatBox.replyButton.isHidden = true
-                self.rootView.characterChatBox.chevronImageButton.transform = .identity
+                self.rootView.characterChatBox.chevronImageButton.imageView?.transform = .identity
                 self.rootView.characterChatBox.loadingAnimationView.isHidden = true
                 self.rootView.characterChatBox.loadingAnimationView.stop()
             case .withoutReplyButtonExpanded:
                 self.rootView.characterChatBox.messageLabel.isHidden = false
                 self.rootView.characterChatBox.replyButton.isHidden = true
-                self.rootView.characterChatBox.chevronImageButton.transform = .init(rotationAngle: .pi * 0.99)
+                self.rootView.characterChatBox.chevronImageButton.imageView?.transform = .init(rotationAngle: .pi * 0.99)
                 self.rootView.characterChatBox.loadingAnimationView.isHidden = true
                 self.rootView.characterChatBox.loadingAnimationView.stop()
             case .loading:
                 self.rootView.characterChatBox.messageLabel.isHidden = true
                 self.rootView.characterChatBox.replyButton.isHidden = true
-                self.rootView.characterChatBox.chevronImageButton.transform = .identity
+                self.rootView.characterChatBox.chevronImageButton.imageView?.transform = .identity
                 self.rootView.characterChatBox.loadingAnimationView.isHidden = false
                 self.rootView.characterChatBox.loadingAnimationView.play()
             }

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/ViewControllers/ORBCharacterChatViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/ViewControllers/ORBCharacterChatViewController.swift
@@ -150,6 +150,10 @@ extension ORBCharacterChatViewController {
             guard let self else { return }
             self.rootView.window?.makeKeyAndVisible()
             self.rootView.userChatInputView.becomeFirstResponder()
+            
+            self.rootView.characterChatBox.isHidden = false
+            self.rootView.userChatView.isHidden = false
+            self.rootView.endChatButton.isHidden = false
             self.changeChatBoxMode(to: .withoutReplyButtonExpanded, animated: true)
         }.disposed(by: disposeBag)
         
@@ -327,6 +331,7 @@ extension ORBCharacterChatViewController {
         guard isUserChatInputViewShown else { return }
         let inputViewHeight = rootView.userChatView.frame.height
         isUserChatInputViewShown = false
+        // 48: 채팅 종료 버튼과 그 아래의 padding 값의 합
         updateChatInputViewPosition(bottomInset: -(48 + inputViewHeight))
     }
     

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/ViewControllers/ORBCharacterChatViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/ViewControllers/ORBCharacterChatViewController.swift
@@ -202,6 +202,7 @@ extension ORBCharacterChatViewController {
             self.hideUserChatInputView()
             self.rootView.userChatInputView.text = ""
             self.rootView.userChatDisplayView.text = ""
+            panGesture.isEnabled = false
             hideCharacterChatBox()
         }.disposed(by: disposeBag)
         
@@ -334,6 +335,7 @@ extension ORBCharacterChatViewController {
     func showCharacterChatBox() {
         isCharacterChatBoxShown = true
         rootView.characterChatBox.isHidden = false
+        panGesture.isEnabled = true
         rootView.layoutIfNeeded()
         characterChatBoxPositionAnimator.stopAnimation(true)
         characterChatBoxPositionAnimator.addAnimations { [weak self] in

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/ViewControllers/ORBCharacterChatViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/ViewControllers/ORBCharacterChatViewController.swift
@@ -257,7 +257,8 @@ extension ORBCharacterChatViewController {
             self.rootView.layoutIfNeeded()
         }).disposed(by: disposeBag)
         
-        patchChatReadRelay.subscribe(onNext: {
+        patchChatReadRelay.subscribe(onNext: { [weak self] in
+            guard let self else { return }
             NetworkService.shared.characterChatService.patchChatRead { [weak self] networkResult in
                 guard let self else { return }
                 switch networkResult {

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/ViewControllers/ORBCharacterChatViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/ViewControllers/ORBCharacterChatViewController.swift
@@ -92,8 +92,7 @@ extension ORBCharacterChatViewController {
     }
     
     @objc private func tapGestureHandler(sender: UITapGestureRecognizer) {
-        guard rootView.characterChatBox.mode == .withReplyButtonShrinked
-                || rootView.characterChatBox.mode == .withReplyButtonExpanded else { return }
+        guard rootView.characterChatBox.mode != .loading else { return }
         ORBCharacterChatManager.shared.shouldPushCharacterChatLogViewController.onNext(MyInfoManager.shared.representativeCharacterID ?? 1)
     }
     

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/ViewControllers/ORBCharacterChatViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/ViewControllers/ORBCharacterChatViewController.swift
@@ -82,12 +82,12 @@ extension ORBCharacterChatViewController {
                 rootView.characterChatBox.transform = transform
                 
             } else if verticalPosition < 0, !hasReplyButton {
-                let maximumDragDistance: CGFloat = 60
+                let maximumDragDistance: CGFloat = 15
                 let transform = CGAffineTransform(translationX: 0, y: -maximumDragDistance * (1 - exp(-0.5 * -verticalPosition / maximumDragDistance)))
                 rootView.characterChatBox.transform = transform
                 
             } else if verticalPosition > 0 {
-                let maximumDragDistance: CGFloat = 60
+                let maximumDragDistance: CGFloat = hasReplyButton ? 60 : 15
                 let transform = CGAffineTransform(translationX: 0, y: maximumDragDistance * (1 - exp(-0.5 * verticalPosition / maximumDragDistance)))
                 rootView.characterChatBox.transform = transform
                 

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/ViewControllers/ORBCharacterChatViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/ViewControllers/ORBCharacterChatViewController.swift
@@ -384,7 +384,7 @@ extension ORBCharacterChatViewController {
                 case .withReplyButtonExpanded:
                     self.rootView.characterChatBox.messageLabel.isHidden = false
                     self.rootView.characterChatBox.replyButton.isHidden = false
-                    self.rootView.characterChatBox.chevronImageButton.transform = .init(rotationAngle: .pi * 0.99)
+                    self.rootView.characterChatBox.chevronImageButton.transform = .init(rotationAngle: .pi * 0.9999)
                     self.rootView.characterChatBox.loadingAnimationView.isHidden = true
                     self.rootView.characterChatBox.loadingAnimationView.stop()
                 case .withoutReplyButtonShrinked:
@@ -396,7 +396,7 @@ extension ORBCharacterChatViewController {
                 case .withoutReplyButtonExpanded:
                     self.rootView.characterChatBox.messageLabel.isHidden = false
                     self.rootView.characterChatBox.replyButton.isHidden = true
-                    self.rootView.characterChatBox.chevronImageButton.transform = .init(rotationAngle: .pi * 0.99)
+                    self.rootView.characterChatBox.chevronImageButton.transform = .init(rotationAngle: .pi * 0.9999)
                     self.rootView.characterChatBox.loadingAnimationView.isHidden = true
                     self.rootView.characterChatBox.loadingAnimationView.stop()
                 case .loading:

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/ViewControllers/ORBCharacterChatViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/ViewControllers/ORBCharacterChatViewController.swift
@@ -427,13 +427,13 @@ extension ORBCharacterChatViewController {
             characterChatBoxModeChangingAnimator.addAnimations { [weak self] in
                 guard let self else { return }
                 self.rootView.characterChatBox.setupHiddenState(mode: mode)
-                self.rootView.characterChatBox.setupAdditionalLayout()
+                self.rootView.characterChatBox.setupAdditionalLayout(mode: mode)
                 self.rootView.layoutIfNeeded()
             }
             characterChatBoxModeChangingAnimator.startAnimation()
         } else {
             rootView.characterChatBox.setupHiddenState(mode: mode)
-            rootView.characterChatBox.setupAdditionalLayout()
+            rootView.characterChatBox.setupAdditionalLayout(mode: mode)
             rootView.layoutIfNeeded()
         }
     }

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/ViewControllers/ORBCharacterChatViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/ViewControllers/ORBCharacterChatViewController.swift
@@ -333,6 +333,7 @@ extension ORBCharacterChatViewController {
     
     func showCharacterChatBox() {
         isCharacterChatBoxShown = true
+        rootView.characterChatBox.isHidden = false
         rootView.layoutIfNeeded()
         characterChatBoxPositionAnimator.stopAnimation(true)
         characterChatBoxPositionAnimator.addAnimations { [weak self] in

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/ViewControllers/ORBCharacterChatViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/ViewControllers/ORBCharacterChatViewController.swift
@@ -420,75 +420,13 @@ extension ORBCharacterChatViewController {
         if animated {
             characterChatBoxModeChangingAnimator.addAnimations { [weak self] in
                 guard let self else { return }
-                switch mode {
-                case .withReplyButtonShrinked:
-                    self.rootView.characterChatBox.messageLabel.isHidden = false
-                    self.rootView.characterChatBox.replyButton.isHidden = false
-                    self.rootView.characterChatBox.chevronImageButton.imageView?.transform = .identity
-                    self.rootView.characterChatBox.loadingAnimationView.isHidden = true
-                    self.rootView.characterChatBox.loadingAnimationView.stop()
-                case .withReplyButtonExpanded:
-                    self.rootView.characterChatBox.messageLabel.isHidden = false
-                    self.rootView.characterChatBox.replyButton.isHidden = false
-                    self.rootView.characterChatBox.chevronImageButton.imageView?.transform = .init(rotationAngle: .pi * 0.9999)
-                    self.rootView.characterChatBox.loadingAnimationView.isHidden = true
-                    self.rootView.characterChatBox.loadingAnimationView.stop()
-                case .withoutReplyButtonShrinked:
-                    self.rootView.characterChatBox.messageLabel.isHidden = false
-                    self.rootView.characterChatBox.replyButton.isHidden = true
-                    self.rootView.characterChatBox.chevronImageButton.imageView?.transform = .identity
-                    self.rootView.characterChatBox.loadingAnimationView.isHidden = true
-                    self.rootView.characterChatBox.loadingAnimationView.stop()
-                case .withoutReplyButtonExpanded:
-                    self.rootView.characterChatBox.messageLabel.isHidden = false
-                    self.rootView.characterChatBox.replyButton.isHidden = true
-                    self.rootView.characterChatBox.chevronImageButton.imageView?.transform = .init(rotationAngle: .pi * 0.9999)
-                    self.rootView.characterChatBox.loadingAnimationView.isHidden = true
-                    self.rootView.characterChatBox.loadingAnimationView.stop()
-                case .loading:
-                    self.rootView.characterChatBox.messageLabel.isHidden = true
-                    self.rootView.characterChatBox.replyButton.isHidden = true
-                    self.rootView.characterChatBox.chevronImageButton.imageView?.transform = .identity
-                    self.rootView.characterChatBox.loadingAnimationView.isHidden = false
-                    self.rootView.characterChatBox.loadingAnimationView.play()
-                }
+                self.rootView.characterChatBox.setupHiddenState(mode: mode)
                 self.rootView.characterChatBox.setupAdditionalLayout()
                 self.rootView.layoutIfNeeded()
             }
             characterChatBoxModeChangingAnimator.startAnimation()
         } else {
-            switch mode {
-            case .withReplyButtonShrinked:
-                self.rootView.characterChatBox.messageLabel.isHidden = false
-                self.rootView.characterChatBox.replyButton.isHidden = false
-                self.rootView.characterChatBox.chevronImageButton.imageView?.transform = .identity
-                self.rootView.characterChatBox.loadingAnimationView.isHidden = true
-                self.rootView.characterChatBox.loadingAnimationView.stop()
-            case .withReplyButtonExpanded:
-                self.rootView.characterChatBox.messageLabel.isHidden = false
-                self.rootView.characterChatBox.replyButton.isHidden = false
-                self.rootView.characterChatBox.chevronImageButton.imageView?.transform = .init(rotationAngle: .pi * 0.99)
-                self.rootView.characterChatBox.loadingAnimationView.isHidden = true
-                self.rootView.characterChatBox.loadingAnimationView.stop()
-            case .withoutReplyButtonShrinked:
-                self.rootView.characterChatBox.messageLabel.isHidden = false
-                self.rootView.characterChatBox.replyButton.isHidden = true
-                self.rootView.characterChatBox.chevronImageButton.imageView?.transform = .identity
-                self.rootView.characterChatBox.loadingAnimationView.isHidden = true
-                self.rootView.characterChatBox.loadingAnimationView.stop()
-            case .withoutReplyButtonExpanded:
-                self.rootView.characterChatBox.messageLabel.isHidden = false
-                self.rootView.characterChatBox.replyButton.isHidden = true
-                self.rootView.characterChatBox.chevronImageButton.imageView?.transform = .init(rotationAngle: .pi * 0.99)
-                self.rootView.characterChatBox.loadingAnimationView.isHidden = true
-                self.rootView.characterChatBox.loadingAnimationView.stop()
-            case .loading:
-                self.rootView.characterChatBox.messageLabel.isHidden = true
-                self.rootView.characterChatBox.replyButton.isHidden = true
-                self.rootView.characterChatBox.chevronImageButton.imageView?.transform = .identity
-                self.rootView.characterChatBox.loadingAnimationView.isHidden = false
-                self.rootView.characterChatBox.loadingAnimationView.play()
-            }
+            rootView.characterChatBox.setupHiddenState(mode: mode)
             rootView.characterChatBox.setupAdditionalLayout()
             rootView.layoutIfNeeded()
         }

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/ViewControllers/ORBCharacterChatViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/ViewControllers/ORBCharacterChatViewController.swift
@@ -69,23 +69,30 @@ extension ORBCharacterChatViewController {
     }
     
     @objc private func panGestureHandler(sender: UIPanGestureRecognizer) {
-        guard rootView.characterChatBox.mode == .withReplyButtonShrinked
-                || rootView.characterChatBox.mode == .withReplyButtonExpanded else { return }
+        let hasReplyButton = rootView.characterChatBox.mode == .withReplyButtonShrinked
+        || rootView.characterChatBox.mode == .withReplyButtonExpanded
         switch sender.state {
         case .possible, .began:
             return
         case .changed:
             let verticalPosition = sender.translation(in: rootView).y
-            if verticalPosition < 0 {
+            if verticalPosition < 0, hasReplyButton {
                 let transform = CGAffineTransform(translationX: 0, y: verticalPosition)
                 rootView.characterChatBox.transform = transform
-            } else {
+                
+            } else if verticalPosition < 0, !hasReplyButton {
+                let maximumDragDistance: CGFloat = 60
+                let transform = CGAffineTransform(translationX: 0, y: -maximumDragDistance * (1 - exp(-0.5 * -verticalPosition / maximumDragDistance)))
+                rootView.characterChatBox.transform = transform
+                
+            } else if verticalPosition > 0 {
                 let maximumDragDistance: CGFloat = 60
                 let transform = CGAffineTransform(translationX: 0, y: maximumDragDistance * (1 - exp(-0.5 * verticalPosition / maximumDragDistance)))
                 rootView.characterChatBox.transform = transform
+                
             }
         case .ended, .cancelled, .failed:
-            if sender.velocity(in: rootView).y < -100 {
+            if sender.velocity(in: rootView).y < -100, hasReplyButton {
                 hideCharacterChatBox()
             } else {
                 showCharacterChatBox()

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/ViewControllers/ORBCharacterChatViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/ViewControllers/ORBCharacterChatViewController.swift
@@ -114,6 +114,7 @@ extension ORBCharacterChatViewController {
     @objc private func touchUpInside() {
         rootView.characterChatBox.expand()
         guard rootView.characterChatBox.mode != .loading else { return }
+        patchChatReadRelay.accept(())
         ORBCharacterChatManager.shared.shouldPushCharacterChatLogViewController
             .onNext(MyInfoManager.shared.representativeCharacterID ?? 1)
     }
@@ -260,8 +261,11 @@ extension ORBCharacterChatViewController {
             NetworkService.shared.characterChatService.patchChatRead { [weak self] networkResult in
                 guard let self else { return }
                 switch networkResult {
-                case .success: return
-                default: self.showToast(message: ErrorMessages.networkError, inset: 66)
+                case .success:
+                    ORBCharacterChatManager.shared.didReadLastChat.accept(())
+                    return
+                default:
+                    self.showToast(message: ErrorMessages.networkError, inset: 66)
                 }
             }
         }).disposed(by: disposeBag)

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/Views/ORBCharacterChatBox.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/Views/ORBCharacterChatBox.swift
@@ -22,10 +22,11 @@ enum ChatBoxMode {
     case loading
 }
 
-class ORBCharacterChatBox: UIView {
+class ORBCharacterChatBox: UIControl {
     
     var mode: ChatBoxMode
     
+    let shrinkBehaviorAnimator = UIViewPropertyAnimator(duration: 0.4, dampingRatio: 1)
     let characterNameLabel = UILabel()
     let messageLabel = UILabel()
     let loadingAnimationView = LottieAnimationView(name: "loading2")
@@ -190,6 +191,27 @@ extension ORBCharacterChatBox {
     
     private func setupHierarchy() {
         addSubviews(characterNameLabel, messageLabel, loadingAnimationView, chevronImageButton, replyButton)
+    }
+    
+    //MARK: - Func
+    
+    func shrink() {
+        shrinkBehaviorAnimator.stopAnimation(true)
+        shrinkBehaviorAnimator.addAnimations { [weak self] in
+            guard let self else { return }
+            let shrinkTransform = CGAffineTransform(scaleX: 0.97, y: 0.97)
+            self.transform = shrinkTransform
+        }
+        shrinkBehaviorAnimator.startAnimation()
+    }
+    
+    func expand() {
+        shrinkBehaviorAnimator.stopAnimation(true)
+        shrinkBehaviorAnimator.addAnimations { [weak self] in
+            guard let self else { return }
+            transform = CGAffineTransform.identity
+        }
+        shrinkBehaviorAnimator.startAnimation()
     }
     
 }

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/Views/ORBCharacterChatBox.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/Views/ORBCharacterChatBox.swift
@@ -214,4 +214,39 @@ extension ORBCharacterChatBox {
         shrinkBehaviorAnimator.startAnimation()
     }
     
+    func setupHiddenState(mode: ChatBoxMode) {
+        switch mode {
+        case .withReplyButtonShrinked:
+            messageLabel.isHidden = false
+            replyButton.isHidden = false
+            chevronImageButton.imageView?.transform = .identity
+            loadingAnimationView.isHidden = true
+            loadingAnimationView.stop()
+        case .withReplyButtonExpanded:
+            messageLabel.isHidden = false
+            replyButton.isHidden = false
+            chevronImageButton.imageView?.transform = .init(rotationAngle: .pi * 0.9999)
+            loadingAnimationView.isHidden = true
+            loadingAnimationView.stop()
+        case .withoutReplyButtonShrinked:
+            messageLabel.isHidden = false
+            replyButton.isHidden = true
+            chevronImageButton.imageView?.transform = .identity
+            loadingAnimationView.isHidden = true
+            loadingAnimationView.stop()
+        case .withoutReplyButtonExpanded:
+            messageLabel.isHidden = false
+            replyButton.isHidden = true
+            chevronImageButton.imageView?.transform = .init(rotationAngle: .pi * 0.9999)
+            loadingAnimationView.isHidden = true
+            loadingAnimationView.stop()
+        case .loading:
+            messageLabel.isHidden = true
+            replyButton.isHidden = true
+            chevronImageButton.imageView?.transform = .identity
+            loadingAnimationView.isHidden = false
+            loadingAnimationView.play()
+        }
+    }
+    
 }

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/Views/ORBCharacterChatBox.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/Views/ORBCharacterChatBox.swift
@@ -51,7 +51,7 @@ class ORBCharacterChatBox: UIControl {
         setupStyle()
         setupHierarchy()
         setupLayout()
-        setupAdditionalLayout()
+        setupAdditionalLayout(mode: mode)
     }
     
     required init?(coder: NSCoder) {
@@ -98,7 +98,7 @@ extension ORBCharacterChatBox {
         }
     }
     
-    func setupAdditionalLayout() {
+    func setupAdditionalLayout(mode: ChatBoxMode) {
         switch mode {
         case .withReplyButtonShrinked:
             messageLabel.numberOfLines = 1

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/Views/ORBCharacterChatBox.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/Views/ORBCharacterChatBox.swift
@@ -106,7 +106,7 @@ extension ORBCharacterChatBox {
             replyButtonTopConstraint.isActive = true
             replyButtonBottomConstraint.isActive = true
         case .withReplyButtonExpanded:
-            messageLabel.numberOfLines = 0
+            messageLabel.numberOfLines = 3
             messageLabelTrailingConstraintToChevronImageButton.isActive = true
             messageLabelTrailingConstraintToSuperview.isActive = false
             replyButtonTopConstraint.isActive = true
@@ -118,7 +118,7 @@ extension ORBCharacterChatBox {
             replyButtonTopConstraint.isActive = false
             replyButtonBottomConstraint.isActive = false
         case .withoutReplyButtonExpanded:
-            messageLabel.numberOfLines = 0
+            messageLabel.numberOfLines = 3
             messageLabelTrailingConstraintToChevronImageButton.isActive = true
             messageLabelTrailingConstraintToSuperview.isActive = false
             replyButtonTopConstraint.isActive = false

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/Views/ORBCharacterChatBox.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/Views/ORBCharacterChatBox.swift
@@ -86,10 +86,10 @@ extension ORBCharacterChatBox {
         }
         
         chevronImageButton.snp.makeConstraints { make in
-            make.top.equalToSuperview().inset(19)
+            make.centerY.equalTo(messageLabel.snp.top).offset(12)
             make.trailing.equalToSuperview().inset(24)
             make.width.equalTo(34)
-            make.height.equalTo(22)
+            make.height.equalTo(34)
         }
         
         replyButton.snp.makeConstraints { make in
@@ -172,6 +172,7 @@ extension ORBCharacterChatBox {
         
         chevronImageButton.do { button in
             button.setImage(.icnChatViewChevronDown, for: .normal)
+            button.configureBackgroundColorWhen(normal: .clear, highlighted: .grayscale(.gray100))
         }
         
         replyButton.do { button in

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/Views/ORBCharacterChatView.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/Views/ORBCharacterChatView.swift
@@ -124,6 +124,11 @@ extension ORBCharacterChatView {
         userChatView.do { view in
             view.backgroundColor = .primary(.white)
             view.roundCorners(cornerRadius: 20, maskedCorners: [.layerMinXMinYCorner, .layerMaxXMinYCorner])
+            view.layer.shadowColor = UIColor.primary(.black).cgColor
+            view.layer.shadowOffset = .zero
+            view.layer.shadowOpacity = 0.2
+            view.layer.shadowRadius = 10
+            view.layer.masksToBounds = false
         }
         meLabel.do { label in
             label.textColor = .main(.main2)

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/ChatLog/ViewControllers/CharacterChatLogViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/ChatLog/ViewControllers/CharacterChatLogViewController.swift
@@ -44,6 +44,9 @@ class CharacterChatLogViewController: OffroadTabBarViewController {
     private let isTextViewEmpty = BehaviorRelay<Bool>(value: true)
     private let patchChatReadRelay = PublishRelay<Int?>()
     
+    /// 채팅 로그 뷰가 떠 있을 때 캐릭터 채팅 푸시 알림이 오면 캐릭터 채팅 내용을 전달
+    let characterChatPushedRelay = PublishRelay<String>()
+    
     private var disposeBag = DisposeBag()
     private var characterId: Int?
     private var characterName: String {
@@ -99,6 +102,7 @@ class CharacterChatLogViewController: OffroadTabBarViewController {
         guard let tabBarController = tabBarController as? OffroadTabBarController else { return }
         tabBarController.showTabBarAnimation()
         rootView.backgroundView.isHidden = false
+        ORBCharacterChatManager.shared.currentChatLogViewController = self
         ORBCharacterChatManager.shared.endChat()
     }
     
@@ -124,6 +128,12 @@ class CharacterChatLogViewController: OffroadTabBarViewController {
         
         rootView.backgroundView.isHidden = true
         rootView.userChatInputView.resignFirstResponder()
+    }
+    
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        
+        ORBCharacterChatManager.shared.currentChatLogViewController = nil
     }
     
 }
@@ -393,6 +403,11 @@ extension CharacterChatLogViewController {
                 guard let self else { return }
                 self.rootView.sendButton.isEnabled = shouldEnableSendButton
             }.disposed(by: disposeBag)
+        
+        characterChatPushedRelay.subscribe(onNext: { [weak self] message in
+            guard let self else { return }
+            self.sendChatBubble(isUserChat: false, text: message, isLoading: false)
+        }).disposed(by: disposeBag)
     }
     
     private func setupNotifications() {

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/ChatLog/ViewControllers/CharacterChatLogViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/ChatLog/ViewControllers/CharacterChatLogViewController.swift
@@ -323,12 +323,14 @@ extension CharacterChatLogViewController {
                 let userMessage = self.rootView.userChatInputView.text
                 self.rootView.sendButton.isEnabled = false
                 // 사용자 채팅 버블 추가
-                self.sendChatBubble(isUserChat: true, text: self.rootView.userChatInputView.text, isLoading: false) { [weak self] in
-                    guard let self else { return }
-                    // 캐릭터 셀 추가
-                    self.sendChatBubble(isUserChat: false, text: "", isLoading: true) { [weak self] in
+                self.sendChatBubble(isUserChat: true, text: self.rootView.userChatInputView.text, isLoading: false) {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
                         guard let self else { return }
-                        self.postCharacterChat(characterId: characterId, message: userMessage!)
+                        // 캐릭터 셀 추가
+                        self.sendChatBubble(isUserChat: false, text: "", isLoading: true) { [weak self] in
+                            guard let self else { return }
+                            self.postCharacterChat(characterId: characterId, message: userMessage!)
+                        }
                     }
                 }
                 self.rootView.userChatInputView.text = ""
@@ -453,11 +455,11 @@ extension CharacterChatLogViewController {
         )
         
         chatLogDataList.insert(chatDataModelToAppend, at: 0)
-        updateCollectionView(animatingDifferences: true, completion: { [weak self] in
+        updateCollectionView(animatingDifferences: true, completion: { completion?() })
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { [weak self] in
             guard let self else { return }
             self.scrollToFirstCell(animated: true)
-            completion?()
-        })
+        }
     }
     
     private func postCharacterChat(characterId: Int?, message: String) {

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/ChatLog/ViewControllers/CharacterChatLogViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/ChatLog/ViewControllers/CharacterChatLogViewController.swift
@@ -368,7 +368,8 @@ extension CharacterChatLogViewController {
             self.rootView.layoutIfNeeded()
         }).disposed(by: disposeBag)
         
-        patchChatReadRelay.subscribe(onNext: { characterId in
+        patchChatReadRelay.subscribe(onNext: { [weak self] characterId in
+            guard let self else { return }
             NetworkService.shared.characterChatService.patchChatRead(characterId: characterId) { [weak self] networkResult in
                 guard let self else { return }
                 switch networkResult {

--- a/Offroad-iOS/Offroad-iOS/Presentation/Home/ViewController/HomeViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Home/ViewController/HomeViewController.swift
@@ -274,7 +274,7 @@ extension HomeViewController {
             ORBCharacterChatManager.shared.showCharacterChatBox(
                 character: lastUnreadChatInfo.characterName ?? MyInfoManager.shared.representativeCharacterName ?? "",
                 message: lastUnreadChatInfo.content ?? "",
-                mode: .withoutReplyButtonExpanded
+                mode: .withoutReplyButtonShrinked
             )
         }
         ORBCharacterChatManager.shared.startChat()

--- a/Offroad-iOS/Offroad-iOS/Presentation/Home/ViewController/HomeViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Home/ViewController/HomeViewController.swift
@@ -283,7 +283,8 @@ extension HomeViewController {
             ORBCharacterChatManager.shared.showCharacterChatBox(
                 character: lastUnreadChatInfo.characterName ?? MyInfoManager.shared.representativeCharacterName ?? "",
                 message: lastUnreadChatInfo.content ?? "",
-                mode: .withoutReplyButtonShrinked
+                mode: .withoutReplyButtonShrinked,
+                isAutoDismiss: false
             )
         }
         ORBCharacterChatManager.shared.startChat()

--- a/Offroad-iOS/Offroad-iOS/Presentation/Home/ViewController/HomeViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Home/ViewController/HomeViewController.swift
@@ -273,7 +273,7 @@ extension HomeViewController {
         if let lastUnreadChatInfo {
             ORBCharacterChatManager.shared.showCharacterChatBox(
                 character: lastUnreadChatInfo.characterName ?? MyInfoManager.shared.representativeCharacterName ?? "",
-                message: lastUnreadChatInfo.characterName ?? "",
+                message: lastUnreadChatInfo.content ?? "",
                 mode: .withoutReplyButtonExpanded
             )
         }

--- a/Offroad-iOS/Offroad-iOS/Presentation/MyPage/Coupon/ViewController/CouponDetailViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/MyPage/Coupon/ViewController/CouponDetailViewController.swift
@@ -166,6 +166,7 @@ extension CouponDetailViewController {
                 attributes: [.foregroundColor: UIColor.grayscale(.gray300)]
             )
             textField.attributedPlaceholder = attributedPlaceholder
+            textField.delegate = self
         }
         
         present(alertController, animated: true)
@@ -179,3 +180,16 @@ extension CouponDetailViewController {
     
 }
 
+//MARK: - UITextFieldDelegate
+
+extension CouponDetailViewController: UITextFieldDelegate {
+    
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        if ORBCharacterChatManager.shared.chatViewController.isUserChatInputViewShown {
+            return false
+        } else {
+            return true
+        }
+    }
+    
+}


### PR DESCRIPTION
### 🌴 작업한 브랜치
- #385 


### ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->

### 작업한 내용들이 꽤 많습니다. 대부분 캐릭터 채팅과 관련된 기능이며, 작업 내용들은 다음과 같습니다. 
단어가 헷갈릴 수도 있어서, 본 PR에서는 캐릭터 선톡 시에 위에서 내려오는 토스트?를 "캐릭터 채팅 박스" 라는 단어로 통일하겠습니다.

- 캐릭터 채팅 창 터치 피드백 구현, 제스처 개선
- 현재 캐릭터 채팅 창에서 답장하기 버튼이 있는 경우에 한해서 채팅을 탭 하면 채팅 로그로 이동하도록 되어있는데,
답장하기 버튼이 없는 경우에도 탭 시 채팅 로그로 이동하도록 구현
- 캐릭터 채팅 박스에 뜨는 메시지 줄 수 제한
- 캐릭터 채팅 박스 chevron 버튼 탭 영역 확장
- 처음 한 번 채팅 박스 혹은 채팅 입력창이 뜰 때 이상하게 나타났다 사라지는 문제 해결
(초깃값을 숨김 처리하였으며, 캐릭터 채팅 박스가 보이거나 채팅 입력창이 보일 때 `isHidden`에 `false`를 할당하였습니다.)
- 채팅 로그뷰를 보고 있을 때 선톡이 오는 경우 캐릭터 채팅 박스가 뜨는 대신 채팅 말풍선이 추가되도록 구현
- 홈 화면에서 최근 채팅 읽음 여부를 나타내는 빨간 점? 구현
- ORBAlertController의 textField로 인해 키보드 올라왔을 때 캐릭터 선톡이 오면 이상하게 동작하는 현상 해결
- 채팅 입력창 흰색 테두리 주변으로 그림자 추가
쿠폰 입력 시 ORBAlertController의 배경색과 채팅 입력 창의 배경색이 같아 경계가 보이지 않는 문제가 있어 그림자를 추가하였습니다. 
- 캐릭터 선톡 3초 뒤에 사라지도록 구현
조건부임. 답장하기 버튼을 누르거나, 사용자가 메시지를 보내고 캐릭터로부터 온 답장의 경우는 자동으로 사라지지 않음.
ORBCharacterChatViewController의 showChatButton 메서드에 isAutoDismiss 매개변수 추가
- 채팅 로그에서 채팅 버블 보내는 애니메이션 개선(애니메이션 시작 시점 변경)


<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### ❗️PR Point
<!-- 부족했던 점 혹은 개선하고 싶은 방향이 있다면 얘기해주세요 -->

<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->

|뷰|뷰|
|:------:|:---:|
|   <img src="https://github.com/user-attachments/assets/bb628ab6-2827-4d04-8b44-b2e522f47658" width =200>     |  <img src="https://github.com/user-attachments/assets/392b21b4-5d05-4747-ad6d-99a1fa954377" width=200>   |


- Resolved: #385 
