### PR TITLE
[Chore] #397 - 캐릭터 선톡 시 3초 후 사라지는 로직 개선

### DIFF
--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/ViewControllers/ORBCharacterChatViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/ViewControllers/ORBCharacterChatViewController.swift
@@ -109,6 +109,7 @@ extension ORBCharacterChatViewController {
     }
     
     @objc private func shrinkChatBox() {
+        stopAutoHide()
         rootView.characterChatBox.shrink()
     }
     
@@ -159,6 +160,21 @@ extension ORBCharacterChatViewController {
             .subscribe(onNext: { [weak self] isTransparent in
                 guard let self else { return }
                 self.rootView.keyboardBackgroundView.isHidden = isTransparent
+            }).disposed(by: disposeBag)
+        
+        rootView.characterChatBox.chevronImageButton.rx.controlEvent(.touchDown).bind(onNext: { [weak self] in
+            guard let self else { return }
+            self.stopAutoHide()
+        }).disposed(by: disposeBag)
+        
+        rootView.characterChatBox.chevronImageButton.rx.controlEvent([.touchUpInside, .touchUpOutside])
+            .bind(onNext: { [weak self] in
+                guard let self else { return }
+                let hasReplyButton = self.rootView.characterChatBox.mode == .withReplyButtonShrinked
+                || self.rootView.characterChatBox.mode == .withReplyButtonExpanded
+                if hasReplyButton {
+                    self.restartAutoHide()
+                }
             }).disposed(by: disposeBag)
         
         rootView.characterChatBox.chevronImageButton.rx.tap.bind { [weak self] in


### PR DESCRIPTION
### 🌴 작업한 브랜치
- #397


### ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->
현재 캐릭터 선톡이 오면 채팅 박스가 3초 뒤에 사라지는데, 사용자가 터치에 개입할 경우 3초 카운트를 초기화하도록 구현한 상태입니다.

이때 
- 채팅 박스 확장을 위한 chevron버튼을 눌렀을 경우
- 사용자가 채팅 박스를 press만 하고 있는 경우

에는 3초 카운트가 일시정지되지 않아서, 사용자가 의도하지 않은 상황에 캐릭터 채팅 박스가 사라지는 현상이 발생합니다. 
위의 경우에도 3초 카운트를 초기화하는 로직을 추가하였습니다. 

<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### ❗️PR Point
<!-- 부족했던 점 혹은 개선하고 싶은 방향이 있다면 얘기해주세요 -->

<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->

|변경 전|변경 후|
|:----:|:---:|
|    <img src="https://github.com/user-attachments/assets/63d4c991-8f3b-4137-83e3-10c72c29696d" width=200>    |   <img src="https://github.com/user-attachments/assets/f32ea66a-cbcc-4f46-9f02-8cf6df977653" width=200>  |


- Resolved: #397 
