### PR TITLE
[Chore] #404 - 닉네임 뷰 에러처리 수정사항 적용

### DIFF
--- a/Offroad-iOS/Offroad-iOS/Presentation/Nickname/ViewController/NicknameViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Nickname/ViewController/NicknameViewController.swift
@@ -52,7 +52,7 @@ final class NicknameViewController: UIViewController {
             .subscribe(onNext: { [weak self] in
                 guard let self = self else { return }
                 
-                if self.whetherDuplicate {
+                if self.whetherDuplicate || self.nicknameView.notionLabel.text == "한글 2~8자, 영어 2~16자 이내로 다시 작성해주세요." {
                     self.nicknameView.nicknameTextField.layer.borderColor = UIColor.primary(.errorNew).cgColor
                 } else {
                     self.nicknameView.nicknameTextField.layer.borderColor = UIColor.main(.main2).cgColor
@@ -97,7 +97,7 @@ final class NicknameViewController: UIViewController {
             .bind { [weak self] _ in
                 guard let self = self else { return }
                 self.view.endEditing(true)
-                if self.nicknameView.notionLabel.text == "중복된 닉네임이에요. 다른 멋진 이름이 있으신가요?" {
+                if self.whetherDuplicate || self.nicknameView.notionLabel.text == "한글 2~8자, 영어 2~16자 이내로 다시 작성해주세요." {
                     self.nicknameView.nicknameTextField.layer.borderColor = UIColor.primary(.errorNew).cgColor
                 }
             }


### PR DESCRIPTION
### 🌴 작업한 브랜치
- #404 


### ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->
형식 오류가 생겼을 때 error borderColor가 적용이 안되는 문제를 해결했습니다. 리팩토링 이후 따로 UI 처리를 해줘야 했는데, `self.view.endEditing(true)` 이후에 `primary(.errorNew)`를 적용하여 textfield 포커스가 해제되었을 때도 에러 색상이 유지되도록 했습니다. 
텍스트 필드 focus 이벤트 바인딩하는 부분에서 기존에 `self.whetherDuplicate`의 경우만 분기 처리하여 형식 오류일 때의 에러 색상이 적용이 안되는 문제가 생겼는데, 형식 오류일 때의 분기 처리도 추가하여 해결했습니다.
<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### ❗️PR Point
<!-- 부족했던 점 혹은 개선하고 싶은 방향이 있다면 얘기해주세요 -->

<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->

|뷰|설명|
|:------:|:---:|
|        |     |


- Resolved: #404 
