### PR TITLE
[Fix] #416 - 쿠폰 사용 후 목록이 비었을 때 cell의 갯수가 최신화되지 않는 문제 해결

### DIFF
--- a/Offroad-iOS/Offroad-iOS/Presentation/MyPage/Coupon/ViewController/CouponListViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/MyPage/Coupon/ViewController/CouponListViewController.swift
@@ -146,8 +146,10 @@ extension CouponListViewController{
                 }
                 guard response.data.coupons.count > 0 else {
                     if isUsed {
+                        self.rootView.collectionViewForUsedCoupons.reloadData()
                         self.rootView.collectionViewForUsedCoupons.emptyState = true
                     } else {
+                        self.rootView.collectionViewForAvailableCoupons.reloadData()
                         self.rootView.collectionViewForAvailableCoupons.emptyState = true
                     }
                     return


### PR DESCRIPTION
## 📌 원활한 심사 제출을 위해 12월 27일(금) 정오까지만 리뷰를 받고, 이후 브랜치를 main에 머지하겠습니다. 심사 제출이 늦어질 경우, PR이 더 오래 열려있을 수 있습니다. 


### 🌴 작업한 브랜치
- #416 


### ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->
쿠폰 사용 후 목록이 비었을 때 cell의 갯수가 최신화되지 않는 문제가 발견되었습니다. 
<img src="https://github.com/user-attachments/assets/614de86f-6cb8-4cbe-858d-8a2b17f53dd5" width=250>
쿠폰 사용 후 쿠폰 목록 뷰를 업데이트하게 되는데, 이 과정에서 받아온 쿠폰 목록의 수가 0인 경우, 엠티 케이스가 되어 위 이미지처럼 노바 캐릭터를 띄우도록 되어있습니다. 이때, 캐릭터를 띄우는 작업만 하고, 컬렉션뷰의 data를 reload하는 과정이 생략되어 위와 같은 문제가 발생합니다. 
이를 수정하기 위해 collectionView에서 reloadData() 메서드를 호출하는 코드를 추가하였습니다. 
<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### ❗️PR Point
<!-- 부족했던 점 혹은 개선하고 싶은 방향이 있다면 얘기해주세요 -->
제가 쿠폰이 없어, 잘 동작하는지 확인은 하지 못했으나, 잘 동작할 것으로 예상합니다. 
혹시 쿠폰이 있어 테스트가 가능하신 분은 잘 동작하는지 확인 부탁드립니다. 

<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->

|뷰|설명|
|:------:|:---:|
|        |     |


- Resolved: #416 
