### PR TITLE
[Chore] #428 - 채팅 로그 뷰의 '채팅하기' 버튼이 줄바꿈되어 보이는 문제 해결

### DIFF
--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/ChatLog/Views/CharacterChatLogView.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/ChatLog/Views/CharacterChatLogView.swift
@@ -165,6 +165,7 @@ extension CharacterChatLogView {
             button.setTitle("채팅하기", for: .normal)
             button.isUserInteractionEnabled = false
             button.roundCorners(cornerRadius: 12)
+            button.configureTitleFontWhen(normal: .offroad(style: .iosText))
             button.configureBackgroundColorWhen(
                 normal: .primary(.white).withAlphaComponent(0.33),
                 highlighted: .primary(.white).withAlphaComponent(0.55)


### PR DESCRIPTION
### 🌴 작업한 브랜치
- #428 


### ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->
채팅 로그 뷰의 '채팅하기' 버튼이 줄바꿈되어 보이는 문제 해결하였습니다.
정확한 원인은 파악되지 않았으나, 
기기의 설정에서 텍스트 크기를 변경할 시 채팅 로그 뷰의 '채팅하기' 버튼의 텍스트 크기도 이에 맞추어 변경되는 것을 확인했으며, 
이로 인해 줄바꿈이 되는 것으로 파악됩니다. 
이는 해당 버튼에서 폰트를 별도로 설정해주지 않았기 때문이므로, 해당 버튼에 폰트를 설정해 주었습니다. 
<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### ❗️PR Point
<!-- 부족했던 점 혹은 개선하고 싶은 방향이 있다면 얘기해주세요 -->

<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->

|문제 상황|해결|
|:------:|:---:|
|  <img src="https://github.com/user-attachments/assets/e1272ab7-f1d8-4a61-8b34-9791633d1cfb" width=300>  |  <img src="https://github.com/user-attachments/assets/16e22622-f402-4e31-9844-e062f1bc9736" width=300>  |


- Resolved: #428 
