### PR TITLE
[Fix] #441 - 채팅 로그 뷰의 배경이 부자연스럽게 나타나는 현상

### DIFF
--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/Views/ORBCharacterChatWindow.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/Views/ORBCharacterChatWindow.swift
@@ -9,7 +9,6 @@ import UIKit
 
 class ORBCharacterChatWindow: UIWindow {
     
-    
     override init(windowScene: UIWindowScene) {
         super.init(windowScene: windowScene)
         rootViewController = ORBCharacterChatViewController()

--- a/Offroad-iOS/Offroad-iOS/Presentation/MyPage/CharacterList/View/CharacterDetailView.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/MyPage/CharacterList/View/CharacterDetailView.swift
@@ -22,7 +22,7 @@ class CharacterDetailView: UIView, SVGFetchable {
     let customNavigationBar = UIView()
     let customBackButton = NavigationPopButton()
     let chatLogButton = ShrinkableButton(shrinkScale: 0.93)
-    private let scrollView = UIScrollView()
+    let scrollView = UIScrollView()
     private let contentView = UIView()
     let characterImageView = UIImageView()
     private let labelView = UIView()

--- a/Offroad-iOS/Offroad-iOS/Presentation/MyPage/CharacterList/ViewController/CharacterDetailViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/MyPage/CharacterList/ViewController/CharacterDetailViewController.swift
@@ -105,6 +105,7 @@ extension CharacterDetailViewController {
         rootView.chatLogButton.rx.tap.bind(onNext: { [weak self] in
             guard let self else { return }
             guard let orbNavigationController = navigationController as? ORBNavigationController else { return }
+            rootView.scrollView.setContentOffset(rootView.scrollView.contentOffset, animated: false)
             orbNavigationController.pushChatLogViewController(characterId: viewModel.characterId)
         }).disposed(by: disposeBag)
         


### PR DESCRIPTION
### 🌴 작업한 브랜치
- #441 


### ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->
채팅 로그의 뷰가 부자연스럽게 나타나는 현상을 일부 해결하였습니다. 

현재 채팅 로그에 진입할 때, 배경에 투명도를 주어 이전 화면의 블러가 표시되도록 구현한 상태입니다.
그런데, `UINavigationController`의 기본 동작은 push되면서 이전 화면이 왼쪽으로 슬라이딩되기 때문에
이전 화면을 캡처한 후 이를 채팅 로그의 배경에 넣는 방식으로 구현한 상태인데요,
채팅 로그 뷰가 push되는 순간에 이전 화면이 스크롤되는 경우, 캡처하는 시점의 화면과 다른 화면이 채팅 로그의 배경으로 사용되어 어색한 부분이 발생합니다.

채팅 로그가 push되는 시점에 이전 화면의 스크롤을 제한하여 조금 더 자연스러운 UI를 구현하였습니다. 
아직 일부 상황에서는 여전히 부자연스럽게 동작하나, 사용자 경험에 크게 영향을 미치는 부분이 아니라고 판단하여 간단한 변경점만을 적용하였습니다. 

<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### ❗️PR Point
<!-- 부족했던 점 혹은 개선하고 싶은 방향이 있다면 얘기해주세요 -->

<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->

| 전 | 후 |
|:------:|:---:|
|    <img src="https://github.com/user-attachments/assets/8d93b8f6-1804-45f4-9e74-e24504e7926d" width=300>   |   <img src="https://github.com/user-attachments/assets/db574848-cb30-4759-a12b-64f8a3275c6e" width=300>  |


- Resolved: #441 
