### PR TITLE
[Feat] #453 - 개발용 앱에서 로그 확인 기능 구현

### DIFF
--- a/Offroad-iOS/Offroad-iOS.xcodeproj/project.pbxproj
+++ b/Offroad-iOS/Offroad-iOS.xcodeproj/project.pbxproj
@@ -37,6 +37,8 @@
 		4E09BF562C48A5AF009B316A /* AdventuresPlaceAuthenticationRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E09BF522C48A2F8009B316A /* AdventuresPlaceAuthenticationRequestDTO.swift */; };
 		4E09BF572C48A5B7009B316A /* AdventuresPlaceAuthenticationResponsetDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E09BF542C48A406009B316A /* AdventuresPlaceAuthenticationResponsetDTO.swift */; };
 		4E0C69692C4724A100B6453E /* ORBNMFMarker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E0C69682C4724A100B6453E /* ORBNMFMarker.swift */; };
+		4E1CFDEF2D4E5CB70067344B /* PrintLogInDevApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E1CFDEE2D4E5CB70067344B /* PrintLogInDevApp.swift */; };
+		4E1CFDF02D4E5CB70067344B /* PrintLogInDevApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E1CFDEE2D4E5CB70067344B /* PrintLogInDevApp.swift */; };
 		4E1E94112C39870700A7B08A /* ColorLiterals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E1E94102C39870700A7B08A /* ColorLiterals.swift */; };
 		4E1E94132C398C4200A7B08A /* String+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E1E94122C398C4200A7B08A /* String+.swift */; };
 		4E1E94192C3AC27C00A7B08A /* ORBMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E1E94182C3AC27C00A7B08A /* ORBMapView.swift */; };
@@ -614,6 +616,7 @@
 		4E09BF522C48A2F8009B316A /* AdventuresPlaceAuthenticationRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdventuresPlaceAuthenticationRequestDTO.swift; sourceTree = "<group>"; };
 		4E09BF542C48A406009B316A /* AdventuresPlaceAuthenticationResponsetDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdventuresPlaceAuthenticationResponsetDTO.swift; sourceTree = "<group>"; };
 		4E0C69682C4724A100B6453E /* ORBNMFMarker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ORBNMFMarker.swift; sourceTree = "<group>"; };
+		4E1CFDEE2D4E5CB70067344B /* PrintLogInDevApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrintLogInDevApp.swift; sourceTree = "<group>"; };
 		4E1E94102C39870700A7B08A /* ColorLiterals.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorLiterals.swift; sourceTree = "<group>"; };
 		4E1E94122C398C4200A7B08A /* String+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+.swift"; sourceTree = "<group>"; };
 		4E1E94182C3AC27C00A7B08A /* ORBMapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ORBMapView.swift; sourceTree = "<group>"; };
@@ -1707,6 +1710,7 @@
 				4EA5F4EF2D4C970600A59AB1 /* ConsoleLogWindow.swift */,
 				4EA5F4F22D4C975C00A59AB1 /* ConsoleLogViewController.swift */,
 				4EA5F4F42D4C977300A59AB1 /* ConsoleLogView.swift */,
+				4E1CFDEE2D4E5CB70067344B /* PrintLogInDevApp.swift */,
 			);
 			path = ConsoleLog;
 			sourceTree = "<group>";
@@ -3162,6 +3166,7 @@
 				4E09BF562C48A5AF009B316A /* AdventuresPlaceAuthenticationRequestDTO.swift in Sources */,
 				4EEC2FA82C41216700007353 /* OffroadTabBarViewController.swift in Sources */,
 				D0E7966C2C457D64005B47A5 /* AdventureInfoResponseDTO.swift in Sources */,
+				4E1CFDF02D4E5CB70067344B /* PrintLogInDevApp.swift in Sources */,
 				4E1E94192C3AC27C00A7B08A /* ORBMapView.swift in Sources */,
 				4EFCDFE32C92C1F1006DEBB6 /* ORBAlertButton.swift in Sources */,
 				4EBE34922C3FC73C006DB244 /* QuestQRViewController.swift in Sources */,
@@ -3533,6 +3538,7 @@
 				4E4F31CC2D4718F400C3B2FF /* ColorLiterals.swift in Sources */,
 				4E4F31CD2D4718F400C3B2FF /* BaseTargetType.swift in Sources */,
 				4E4F31CE2D4718F400C3B2FF /* RegisteredPlaceRequestDTO.swift in Sources */,
+				4E1CFDEF2D4E5CB70067344B /* PrintLogInDevApp.swift in Sources */,
 				4E4F31CF2D4718F400C3B2FF /* ProfileAPI.swift in Sources */,
 				4E4F31D02D4718F400C3B2FF /* EmblemAPI.swift in Sources */,
 				4E4F31D12D4718F400C3B2FF /* TermsListTableViewCell.swift in Sources */,

--- a/Offroad-iOS/Offroad-iOS.xcodeproj/project.pbxproj
+++ b/Offroad-iOS/Offroad-iOS.xcodeproj/project.pbxproj
@@ -365,6 +365,10 @@
 		4E9900882CE0768B007EEFF7 /* loading1.json in Resources */ = {isa = PBXBuildFile; fileRef = 4E9900862CE0768B007EEFF7 /* loading1.json */; };
 		4E9900892CE0768B007EEFF7 /* loading2.json in Resources */ = {isa = PBXBuildFile; fileRef = 4E9900872CE0768B007EEFF7 /* loading2.json */; };
 		4E99008B2CE0CB61007EEFF7 /* UITextView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E99008A2CE0CB61007EEFF7 /* UITextView+.swift */; };
+		4EA5F4EE2D4C96BD00A59AB1 /* ConsoleLogManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EA5F4EC2D4C96BD00A59AB1 /* ConsoleLogManager.swift */; };
+		4EA5F4F12D4C970600A59AB1 /* ConsoleLogWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EA5F4EF2D4C970600A59AB1 /* ConsoleLogWindow.swift */; };
+		4EA5F4F32D4C975C00A59AB1 /* ConsoleLogViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EA5F4F22D4C975C00A59AB1 /* ConsoleLogViewController.swift */; };
+		4EA5F4F52D4C977300A59AB1 /* ConsoleLogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EA5F4F42D4C977300A59AB1 /* ConsoleLogView.swift */; };
 		4EA90AC62C4521C50046A6E1 /* MyPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EA90AC52C4521C50046A6E1 /* MyPageViewController.swift */; };
 		4EADB9712CC9518000930140 /* CharacterDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EADB9702CC9518000930140 /* CharacterDetailViewModel.swift */; };
 		4EB32BE72C67A2B0003F98F2 /* QuestListViewControllers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EB32BE62C67A2B0003F98F2 /* QuestListViewControllers.swift */; };
@@ -666,6 +670,10 @@
 		4E9900862CE0768B007EEFF7 /* loading1.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = loading1.json; sourceTree = "<group>"; };
 		4E9900872CE0768B007EEFF7 /* loading2.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = loading2.json; sourceTree = "<group>"; };
 		4E99008A2CE0CB61007EEFF7 /* UITextView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextView+.swift"; sourceTree = "<group>"; };
+		4EA5F4EC2D4C96BD00A59AB1 /* ConsoleLogManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsoleLogManager.swift; sourceTree = "<group>"; };
+		4EA5F4EF2D4C970600A59AB1 /* ConsoleLogWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsoleLogWindow.swift; sourceTree = "<group>"; };
+		4EA5F4F22D4C975C00A59AB1 /* ConsoleLogViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsoleLogViewController.swift; sourceTree = "<group>"; };
+		4EA5F4F42D4C977300A59AB1 /* ConsoleLogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsoleLogView.swift; sourceTree = "<group>"; };
 		4EA90AC52C4521C50046A6E1 /* MyPageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageViewController.swift; sourceTree = "<group>"; };
 		4EADB9702CC9518000930140 /* CharacterDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CharacterDetailViewModel.swift; sourceTree = "<group>"; };
 		4EB32BE62C67A2B0003F98F2 /* QuestListViewControllers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestListViewControllers.swift; sourceTree = "<group>"; };
@@ -1692,6 +1700,17 @@
 			path = Lotties;
 			sourceTree = "<group>";
 		};
+		4EA5F4EB2D4C960500A59AB1 /* ConsoleLog */ = {
+			isa = PBXGroup;
+			children = (
+				4EA5F4EC2D4C96BD00A59AB1 /* ConsoleLogManager.swift */,
+				4EA5F4EF2D4C970600A59AB1 /* ConsoleLogWindow.swift */,
+				4EA5F4F22D4C975C00A59AB1 /* ConsoleLogViewController.swift */,
+				4EA5F4F42D4C977300A59AB1 /* ConsoleLogView.swift */,
+			);
+			path = ConsoleLog;
+			sourceTree = "<group>";
+		};
 		4EA90AC42C4521AF0046A6E1 /* ViewControllers */ = {
 			isa = PBXGroup;
 			children = (
@@ -1867,6 +1886,7 @@
 		4EFCDFDB2C92B647006DEBB6 /* Overlay */ = {
 			isa = PBXGroup;
 			children = (
+				4EA5F4EB2D4C960500A59AB1 /* ConsoleLog */,
 				4E3A32872CE733D4007228D0 /* Loading */,
 				4E700C812CB3C99900C664C2 /* Toast */,
 				4E700C802CB3C95E00C664C2 /* Alert */,
@@ -3431,6 +3451,7 @@
 				4E4F317D2D4718F400C3B2FF /* CustomIntensityBlurView.swift in Sources */,
 				4E4F317E2D4718F400C3B2FF /* KakaoAuthManager.swift in Sources */,
 				4E4F317F2D4718F400C3B2FF /* MarketingConsentRequestDTO.swift in Sources */,
+				4EA5F4F52D4C977300A59AB1 /* ConsoleLogView.swift in Sources */,
 				4E4F31802D4718F400C3B2FF /* CharacterChatLogViewModel.swift in Sources */,
 				4E4F31812D4718F400C3B2FF /* LogoutView.swift in Sources */,
 				4E4F31822D4718F400C3B2FF /* MyPageCustomButton.swift in Sources */,
@@ -3444,6 +3465,7 @@
 				4E4F318A2D4718F400C3B2FF /* CharacterDetailViewController.swift in Sources */,
 				4E4F318B2D4718F400C3B2FF /* CharacterChatReadGetResponseDTO.swift in Sources */,
 				4E4F318C2D4718F400C3B2FF /* UserInfoResponseDTO.swift in Sources */,
+				4EA5F4EE2D4C96BD00A59AB1 /* ConsoleLogManager.swift in Sources */,
 				4E4F318D2D4718F400C3B2FF /* CharacterDetailCell.swift in Sources */,
 				4E4F318E2D4718F400C3B2FF /* QuestService.swift in Sources */,
 				4E4F318F2D4718F400C3B2FF /* MoyaPlugin.swift in Sources */,
@@ -3480,6 +3502,7 @@
 				4E4F31AE2D4718F400C3B2FF /* QuestListCollectionViewCell.swift in Sources */,
 				4E4F31AF2D4718F400C3B2FF /* UIScreen+.swift in Sources */,
 				4E4F31B02D4718F400C3B2FF /* CouponRedemptionRequestDTO.swift in Sources */,
+				4EA5F4F12D4C970600A59AB1 /* ConsoleLogWindow.swift in Sources */,
 				4E4F31B12D4718F400C3B2FF /* ShrinkableCollectionViewCell.swift in Sources */,
 				4E4F31B22D4718F400C3B2FF /* ORBAlertBackgroundView.swift in Sources */,
 				4E4F31B32D4718F400C3B2FF /* CouponRedemptionResponseDTO.swift in Sources */,
@@ -3581,6 +3604,7 @@
 				4E4F32132D4718F400C3B2FF /* ChangeEmblemResponseDTO.swift in Sources */,
 				4E4F32142D4718F400C3B2FF /* ORBNMFMarker.swift in Sources */,
 				4E4F32152D4718F400C3B2FF /* CustomRecentProgressView.swift in Sources */,
+				4EA5F4F32D4C975C00A59AB1 /* ConsoleLogViewController.swift in Sources */,
 				4E4F32162D4718F400C3B2FF /* DeleteAccountViewController.swift in Sources */,
 				4E4F32172D4718F400C3B2FF /* TermsConsentPopupViewController.swift in Sources */,
 				4E4F32182D4718F400C3B2FF /* NoticeResponseDTO.swift in Sources */,

--- a/Offroad-iOS/Offroad-iOS/Application/SceneDelegate.swift
+++ b/Offroad-iOS/Offroad-iOS/Application/SceneDelegate.swift
@@ -36,6 +36,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         #if DevTarget
         ORBToastManager.shared.showToast(message: "이 애플리케이션은 개발용 애플리케이션입니다.", inset: 30)
+        ConsoleLogManager.shared
         #endif
     }
     

--- a/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/ConsoleLog/ConsoleLogManager.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/ConsoleLog/ConsoleLogManager.swift
@@ -1,0 +1,20 @@
+//
+//  ConsoleLogManager.swift
+//  ORB(Dev)
+//
+//  Created by 김민성 on 1/31/25.
+//
+
+import Foundation
+
+class ConsoleLogManager {
+    
+    static let shared = ConsoleLogManager()
+    
+    let consoleLogWindow = ConsoleLogWindow()
+    
+    private init() { }
+    
+    
+    
+}

--- a/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/ConsoleLog/ConsoleLogManager.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/ConsoleLog/ConsoleLogManager.swift
@@ -9,9 +9,15 @@ import Foundation
 
 class ConsoleLogManager {
     
+    //MARK: Type Properties
+    
     static let shared = ConsoleLogManager()
     
+    //MARK: - Properties
+    
     let consoleLogWindow = ConsoleLogWindow()
+    
+    //MARK: - Life Cycle
     
     private init() { }
     

--- a/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/ConsoleLog/ConsoleLogManager.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/ConsoleLog/ConsoleLogManager.swift
@@ -15,6 +15,17 @@ class ConsoleLogManager {
     
     private init() { }
     
+}
+
+extension ConsoleLogManager {
     
+    //MARK: - Func
+    
+    func printLog(_ log: String) {
+        DispatchQueue.main.async { [weak self] in
+            guard let consoleLogViewController = self?.consoleLogWindow.rootViewController as? ConsoleLogViewController else { return }
+            consoleLogViewController.printLog(log)
+        }
+    }
     
 }

--- a/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/ConsoleLog/ConsoleLogView.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/ConsoleLog/ConsoleLogView.swift
@@ -11,12 +11,14 @@ class ConsoleLogView: UIView {
     
 //    let floatingButton = ShrinkableButton(shrinkScale: 0.9)
     let floatingButton = UIButton()
+    let logTextView = UITextView()
     
     override init(frame: CGRect) {
         super.init(frame: frame)
         
         setupStyle()
         setupHierarchy()
+        setupLayout()
     }
     
     required init?(coder: NSCoder) {
@@ -24,7 +26,6 @@ class ConsoleLogView: UIView {
     }
     
 }
-
 
 extension ConsoleLogView {
     
@@ -38,12 +39,50 @@ extension ConsoleLogView {
             button.roundCorners(cornerRadius: 30)
             button.frame = CGRect(x: 20, y: 100, width: 60, height: 60)
         }
+        
+        logTextView.do { textView in
+            textView.backgroundColor = .black.withAlphaComponent(0.6)
+            textView.isHidden = true
+            textView.isEditable = false
+            textView.isSelectable = false
+            textView.delegate = self
+            textView.font = .systemFont(ofSize: 14)
+            textView.textColor = .white
+            textView.contentInset = .init(top: 5, left: 5, bottom: 5, right: 5)
+            textView.roundCorners(cornerRadius: 20)
+            textView.text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\nLorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\nLorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\nLorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+            let transform = CGAffineTransform(scaleX: 1, y: 0.1)
+            textView.transform = transform
+        }
     }
     
     // MARK: - Private Func
     
     private func setupHierarchy() {
-        addSubview(floatingButton)
-    }    
+        addSubviews(logTextView, floatingButton)
+    }
+    
+    private func setupLayout() {
+        if #available(iOS 16.0, *) {
+            logTextView.anchorPoint = .init(x: 0.5, y: 0)
+            logTextView.snp.makeConstraints { make in
+                make.centerY.equalTo(safeAreaLayoutGuide.snp.top)
+                make.horizontalEdges.equalToSuperview().inset(20)
+                make.height.equalTo(100)
+            }
+        } else {
+            logTextView.snp.makeConstraints { make in
+                make.top.equalTo(safeAreaLayoutGuide)
+                make.horizontalEdges.equalToSuperview().inset(20)
+                make.height.equalTo(100)
+            }
+        }
+    }
+    
+}
+
+//MARK: - UITextViewDelegate
+
+extension ConsoleLogView: UITextViewDelegate {
     
 }

--- a/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/ConsoleLog/ConsoleLogView.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/ConsoleLog/ConsoleLogView.swift
@@ -9,14 +9,13 @@ import UIKit
 
 class ConsoleLogView: UIView {
     
-    let floatingButton = UIButton()
+    let floatingButton = ShrinkableButton(shrinkScale: 0.9)
     
     override init(frame: CGRect) {
         super.init(frame: frame)
         
         setupStyle()
         setupHierarchy()
-        setupLayout()
     }
     
     required init?(coder: NSCoder) {
@@ -32,11 +31,11 @@ extension ConsoleLogView {
     
     private func setupStyle() {
         floatingButton.do { button in
-            button.setTitle("🐞", for: .normal)
+            button.setTitle("🛠️", for: .normal)
             button.backgroundColor = UIColor.black.withAlphaComponent(0.7)
             button.setTitleColor(.white, for: .normal)
-            button.layer.cornerRadius = 25
-            button.frame = CGRect(x: 20, y: 100, width: 50, height: 50)
+            button.roundCorners(cornerRadius: 30)
+            button.frame = CGRect(x: 20, y: 100, width: 60, height: 60)
         }
     }
     
@@ -44,11 +43,6 @@ extension ConsoleLogView {
     
     private func setupHierarchy() {
         addSubview(floatingButton)
-    }
-    
-    private func setupLayout() {
-        
-    }
-    
+    }    
     
 }

--- a/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/ConsoleLog/ConsoleLogView.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/ConsoleLog/ConsoleLogView.swift
@@ -9,14 +9,19 @@ import UIKit
 
 class ConsoleLogView: UIView {
     
-//    let floatingButton = ShrinkableButton(shrinkScale: 0.9)
+    //MARK: - Properties
+    
+    lazy var floatingViewTopConstraintToSafeArea = floatingView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor, constant: 5)
+    
+    //MARK: - UI Properties
+    
     let floatingView = UIView()
     let floatingViewGrabber = UIView()
     let floatingViewGrabberTouchArea = UIView()
     let floatingButton = UIButton()
     let logTextView = UITextView()
     
-    lazy var floatingViewTopConstraintToSafeArea = floatingView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor, constant: 5)
+    //MARK: - Life Cycle
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -36,56 +41,7 @@ extension ConsoleLogView {
     
     // MARK: - Layout Func
     
-    private func setupStyle() {
-        floatingButton.do { button in
-            button.setTitle("🛠️", for: .normal)
-            button.backgroundColor = UIColor.black.withAlphaComponent(0.7)
-            button.setTitleColor(.white, for: .normal)
-            button.roundCorners(cornerRadius: 30)
-            button.frame = CGRect(x: 20, y: 100, width: 60, height: 60)
-        }
-        
-        floatingView.do { view in
-            view.backgroundColor = .black.withAlphaComponent(0.3)
-            view.isHidden = true
-            view.roundCorners(cornerRadius: 20)
-            view.layer.cornerCurve = .continuous
-            let transform = CGAffineTransform(scaleX: 1, y: 0.1)
-            view.transform = transform
-        }
-        
-        floatingViewGrabberTouchArea.do({ view in
-            view.backgroundColor = .clear
-            view.isUserInteractionEnabled = true
-        })
-        
-        floatingViewGrabber.do { view in
-            view.backgroundColor = .black.withAlphaComponent(0.4)
-            view.roundCorners(cornerRadius: 3)
-        }
-        
-        logTextView.do { textView in
-            textView.backgroundColor = .black.withAlphaComponent(0.6)
-            textView.isEditable = false
-            textView.isSelectable = false
-            textView.delegate = self
-            textView.font = .systemFont(ofSize: 10)
-            textView.textColor = .white
-            textView.contentInset = .init(top: 2, left: 5, bottom: 2, right: 5)
-            textView.roundCorners(cornerRadius: 16)
-            textView.layer.cornerCurve = .continuous
-        }
-    }
-    
-    // MARK: - Private Func
-    
-    private func setupHierarchy() {
-        floatingView.addSubviews(logTextView, floatingViewGrabber, floatingViewGrabberTouchArea)
-        addSubviews(floatingView, floatingButton)
-    }
-    
     private func setupLayout() {
-        
         floatingViewGrabber.snp.makeConstraints { make in
             make.centerX.equalToSuperview()
             make.top.equalToSuperview().inset(8)
@@ -112,10 +68,51 @@ extension ConsoleLogView {
         }
     }
     
-}
-
-//MARK: - UITextViewDelegate
-
-extension ConsoleLogView: UITextViewDelegate {
+    // MARK: - Private Func
+    
+    private func setupStyle() {
+        floatingButton.do { button in
+            button.setTitle("🛠️", for: .normal)
+            button.backgroundColor = UIColor.black.withAlphaComponent(0.7)
+            button.setTitleColor(.white, for: .normal)
+            button.roundCorners(cornerRadius: 30)
+            button.frame = CGRect(x: 20, y: 100, width: 60, height: 60)
+        }
+        
+        floatingView.do { view in
+            view.backgroundColor = .black.withAlphaComponent(0.3)
+            view.isHidden = true
+            view.roundCorners(cornerRadius: 20)
+            view.layer.cornerCurve = .continuous
+            let transform = CGAffineTransform(scaleX: 1, y: 0.1)
+            view.transform = transform
+        }
+        
+        floatingViewGrabberTouchArea.do { view in
+            view.backgroundColor = .clear
+            view.isUserInteractionEnabled = true
+        }
+        
+        floatingViewGrabber.do { view in
+            view.backgroundColor = .black.withAlphaComponent(0.4)
+            view.roundCorners(cornerRadius: 3)
+        }
+        
+        logTextView.do { textView in
+            textView.backgroundColor = .black.withAlphaComponent(0.6)
+            textView.isEditable = false
+            textView.isSelectable = false
+            textView.font = .systemFont(ofSize: 10)
+            textView.textColor = .white
+            textView.contentInset = .init(top: 2, left: 5, bottom: 2, right: 5)
+            textView.roundCorners(cornerRadius: 16)
+            textView.layer.cornerCurve = .continuous
+        }
+    }
+    
+    private func setupHierarchy() {
+        floatingView.addSubviews(logTextView, floatingViewGrabber, floatingViewGrabberTouchArea)
+        addSubviews(floatingView, floatingButton)
+    }
     
 }

--- a/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/ConsoleLog/ConsoleLogView.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/ConsoleLog/ConsoleLogView.swift
@@ -10,6 +10,8 @@ import UIKit
 class ConsoleLogView: UIView {
     
 //    let floatingButton = ShrinkableButton(shrinkScale: 0.9)
+    let floatingView = UIView()
+    let floatingViewGrabber = UIView()
     let floatingButton = UIButton()
     let logTextView = UITextView()
     
@@ -40,42 +42,67 @@ extension ConsoleLogView {
             button.frame = CGRect(x: 20, y: 100, width: 60, height: 60)
         }
         
+        floatingView.do { view in
+            view.backgroundColor = .black.withAlphaComponent(0.3)
+            view.isHidden = true
+            view.roundCorners(cornerRadius: 20)
+            view.layer.cornerCurve = .continuous
+            let transform = CGAffineTransform(scaleX: 1, y: 0.1)
+            view.transform = transform
+        }
+        
+        floatingViewGrabber.do { view in
+            view.backgroundColor = .black.withAlphaComponent(0.4)
+            view.roundCorners(cornerRadius: 3)
+        }
+        
         logTextView.do { textView in
             textView.backgroundColor = .black.withAlphaComponent(0.6)
-            textView.isHidden = true
             textView.isEditable = false
             textView.isSelectable = false
             textView.delegate = self
             textView.font = .systemFont(ofSize: 14)
             textView.textColor = .white
-            textView.contentInset = .init(top: 5, left: 5, bottom: 5, right: 5)
-            textView.roundCorners(cornerRadius: 20)
-            textView.text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\nLorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\nLorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\nLorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
-            let transform = CGAffineTransform(scaleX: 1, y: 0.1)
-            textView.transform = transform
+            textView.contentInset = .init(top: 2, left: 5, bottom: 2, right: 5)
+            textView.roundCorners(cornerRadius: 16)
+            textView.layer.cornerCurve = .continuous
         }
     }
     
     // MARK: - Private Func
     
     private func setupHierarchy() {
-        addSubviews(logTextView, floatingButton)
+        floatingView.addSubviews(logTextView, floatingViewGrabber)
+        addSubviews(floatingView, floatingButton)
     }
     
     private func setupLayout() {
+        
+        floatingViewGrabber.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.top.equalToSuperview().inset(7)
+            make.width.equalTo(90)
+            make.height.equalTo(6)
+        }
+        
         if #available(iOS 16.0, *) {
-            logTextView.anchorPoint = .init(x: 0.5, y: 0)
-            logTextView.snp.makeConstraints { make in
+            floatingView.anchorPoint = .init(x: 0.5, y: 0)
+            floatingView.snp.makeConstraints { make in
                 make.centerY.equalTo(safeAreaLayoutGuide.snp.top)
                 make.horizontalEdges.equalToSuperview().inset(20)
-                make.height.equalTo(100)
+                make.height.equalTo(200)
             }
         } else {
-            logTextView.snp.makeConstraints { make in
+            floatingView.snp.makeConstraints { make in
                 make.top.equalTo(safeAreaLayoutGuide)
                 make.horizontalEdges.equalToSuperview().inset(20)
-                make.height.equalTo(100)
+                make.height.equalTo(200)
             }
+        }
+        
+        logTextView.snp.makeConstraints { make in
+            make.top.equalTo(floatingViewGrabber.snp.bottom).offset(7)
+            make.horizontalEdges.bottom.equalToSuperview().inset(5)
         }
     }
     

--- a/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/ConsoleLog/ConsoleLogView.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/ConsoleLog/ConsoleLogView.swift
@@ -9,7 +9,8 @@ import UIKit
 
 class ConsoleLogView: UIView {
     
-    let floatingButton = ShrinkableButton(shrinkScale: 0.9)
+//    let floatingButton = ShrinkableButton(shrinkScale: 0.9)
+    let floatingButton = UIButton()
     
     override init(frame: CGRect) {
         super.init(frame: frame)

--- a/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/ConsoleLog/ConsoleLogView.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/ConsoleLog/ConsoleLogView.swift
@@ -1,0 +1,54 @@
+//
+//  ConsoleLogView.swift
+//  ORB(Dev)
+//
+//  Created by 김민성 on 1/31/25.
+//
+
+import UIKit
+
+class ConsoleLogView: UIView {
+    
+    let floatingButton = UIButton()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setupStyle()
+        setupHierarchy()
+        setupLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+}
+
+
+extension ConsoleLogView {
+    
+    // MARK: - Layout Func
+    
+    private func setupStyle() {
+        floatingButton.do { button in
+            button.setTitle("🐞", for: .normal)
+            button.backgroundColor = UIColor.black.withAlphaComponent(0.7)
+            button.setTitleColor(.white, for: .normal)
+            button.layer.cornerRadius = 25
+            button.frame = CGRect(x: 20, y: 100, width: 50, height: 50)
+        }
+    }
+    
+    // MARK: - Private Func
+    
+    private func setupHierarchy() {
+        addSubview(floatingButton)
+    }
+    
+    private func setupLayout() {
+        
+    }
+    
+    
+}

--- a/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/ConsoleLog/ConsoleLogView.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/ConsoleLog/ConsoleLogView.swift
@@ -59,7 +59,7 @@ extension ConsoleLogView {
         floatingViewTopConstraintToSafeArea.isActive = true
         floatingView.snp.makeConstraints { make in
             make.horizontalEdges.equalToSuperview().inset(5)
-            make.height.equalTo(300)
+            make.height.equalTo(250)
         }
         
         logTextView.snp.makeConstraints { make in
@@ -72,11 +72,14 @@ extension ConsoleLogView {
     
     private func setupStyle() {
         floatingButton.do { button in
-            button.setTitle("🛠️", for: .normal)
+            button.setTitle("💬", for: .normal)
             button.backgroundColor = UIColor.black.withAlphaComponent(0.7)
             button.setTitleColor(.white, for: .normal)
             button.roundCorners(cornerRadius: 30)
-            button.frame = CGRect(x: 20, y: 100, width: 60, height: 60)
+            button.frame = CGRect(x: UIScreen.currentScreenSize.width - 20 - 60,
+                                  y: UIScreen.currentScreenSize.height * 3/4,
+                                  width: 60,
+                                  height: 60)
         }
         
         floatingView.do { view in

--- a/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/ConsoleLog/ConsoleLogView.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/ConsoleLog/ConsoleLogView.swift
@@ -12,8 +12,11 @@ class ConsoleLogView: UIView {
 //    let floatingButton = ShrinkableButton(shrinkScale: 0.9)
     let floatingView = UIView()
     let floatingViewGrabber = UIView()
+    let floatingViewGrabberTouchArea = UIView()
     let floatingButton = UIButton()
     let logTextView = UITextView()
+    
+    lazy var floatingViewTopConstraintToSafeArea = floatingView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor, constant: 5)
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -51,6 +54,11 @@ extension ConsoleLogView {
             view.transform = transform
         }
         
+        floatingViewGrabberTouchArea.do({ view in
+            view.backgroundColor = .clear
+            view.isUserInteractionEnabled = true
+        })
+        
         floatingViewGrabber.do { view in
             view.backgroundColor = .black.withAlphaComponent(0.4)
             view.roundCorners(cornerRadius: 3)
@@ -72,7 +80,7 @@ extension ConsoleLogView {
     // MARK: - Private Func
     
     private func setupHierarchy() {
-        floatingView.addSubviews(logTextView, floatingViewGrabber)
+        floatingView.addSubviews(logTextView, floatingViewGrabber, floatingViewGrabberTouchArea)
         addSubviews(floatingView, floatingButton)
     }
     
@@ -80,28 +88,26 @@ extension ConsoleLogView {
         
         floatingViewGrabber.snp.makeConstraints { make in
             make.centerX.equalToSuperview()
-            make.top.equalToSuperview().inset(7)
+            make.top.equalToSuperview().inset(8)
             make.width.equalTo(90)
             make.height.equalTo(6)
         }
         
-        if #available(iOS 16.0, *) {
-            floatingView.anchorPoint = .init(x: 0.5, y: 0)
-            floatingView.snp.makeConstraints { make in
-                make.centerY.equalTo(safeAreaLayoutGuide.snp.top)
-                make.horizontalEdges.equalToSuperview().inset(20)
-                make.height.equalTo(300)
-            }
-        } else {
-            floatingView.snp.makeConstraints { make in
-                make.top.equalTo(safeAreaLayoutGuide)
-                make.horizontalEdges.equalToSuperview().inset(20)
-                make.height.equalTo(300)
-            }
+        floatingViewGrabberTouchArea.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.top.equalToSuperview()
+            make.width.equalTo(90)
+            make.bottom.equalTo(logTextView.snp.top).offset(5)
+        }
+        
+        floatingViewTopConstraintToSafeArea.isActive = true
+        floatingView.snp.makeConstraints { make in
+            make.horizontalEdges.equalToSuperview().inset(5)
+            make.height.equalTo(300)
         }
         
         logTextView.snp.makeConstraints { make in
-            make.top.equalTo(floatingViewGrabber.snp.bottom).offset(7)
+            make.top.equalTo(floatingViewGrabber.snp.bottom).offset(8)
             make.horizontalEdges.bottom.equalToSuperview().inset(5)
         }
     }

--- a/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/ConsoleLog/ConsoleLogView.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/ConsoleLog/ConsoleLogView.swift
@@ -61,7 +61,7 @@ extension ConsoleLogView {
             textView.isEditable = false
             textView.isSelectable = false
             textView.delegate = self
-            textView.font = .systemFont(ofSize: 14)
+            textView.font = .systemFont(ofSize: 10)
             textView.textColor = .white
             textView.contentInset = .init(top: 2, left: 5, bottom: 2, right: 5)
             textView.roundCorners(cornerRadius: 16)
@@ -90,13 +90,13 @@ extension ConsoleLogView {
             floatingView.snp.makeConstraints { make in
                 make.centerY.equalTo(safeAreaLayoutGuide.snp.top)
                 make.horizontalEdges.equalToSuperview().inset(20)
-                make.height.equalTo(200)
+                make.height.equalTo(300)
             }
         } else {
             floatingView.snp.makeConstraints { make in
                 make.top.equalTo(safeAreaLayoutGuide)
                 make.horizontalEdges.equalToSuperview().inset(20)
-                make.height.equalTo(200)
+                make.height.equalTo(300)
             }
         }
         

--- a/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/ConsoleLog/ConsoleLogViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/ConsoleLog/ConsoleLogViewController.swift
@@ -13,6 +13,10 @@ import RxCocoa
 class ConsoleLogViewController: UIViewController {
     
     var disposeBag = DisposeBag()
+    private var animator: UIDynamicAnimator?
+    private var dynamicBehavior: UIDynamicItemBehavior?
+    private var collisionBehavior: UICollisionBehavior?
+    
     
     let rootView = ConsoleLogView()
     let panGesture = UIPanGestureRecognizer()
@@ -26,6 +30,7 @@ class ConsoleLogViewController: UIViewController {
         
         setupGestures()
         setupActions()
+        animator = UIDynamicAnimator(referenceView: view)
     }
     
 }
@@ -43,8 +48,24 @@ extension ConsoleLogViewController {
     
     private func panGestureAction(sender: UIPanGestureRecognizer) {
         let translation = sender.translation(in: view)
-        rootView.floatingButton.center = CGPoint(x: rootView.floatingButton.center.x + translation.x,
-                                                 y: rootView.floatingButton.center.y + translation.y)
+        
+        switch sender.state {
+        case .began:
+            animator?.removeAllBehaviors()
+        case .changed:
+            // floatingButton 한 변의 길이: 60
+            rootView.floatingButton.center = CGPoint(
+                x: min(rootView.frame.width - 30, max(30, rootView.floatingButton.center.x + translation.x)),
+                y: min(rootView.frame.height - 30, max(30, rootView.floatingButton.center.y + translation.y))
+            )
+        case .ended:
+            let velocity = sender.velocity(in: rootView)
+            rootView.floatingButton.layoutIfNeeded()
+            applyInertiaEffect(velocity: velocity)
+        default:
+            break
+        }
+        
         sender.setTranslation(.zero, in: view)
     }
     
@@ -52,8 +73,44 @@ extension ConsoleLogViewController {
         rootView.floatingButton.rx.tap
             .subscribe(onNext: { [weak self] in
                 // floatingButton action
-                print("floatingButton action")
+                self?.floatingButtonAction()
             }).disposed(by: disposeBag)
+    }
+    
+    private func floatingButtonAction() {
+        print("floatingButton action")
+    }
+    
+    private func applyInertiaEffect(velocity: CGPoint) {
+        let dynamic = UIDynamicItemBehavior(items: [rootView.floatingButton])
+        dynamic.addLinearVelocity(velocity, for: rootView.floatingButton)
+        dynamic.resistance = 15.0
+        dynamic.elasticity = 0.3
+        dynamic.allowsRotation = false
+        animator?.addBehavior(dynamic)
+        dynamicBehavior = dynamic
+        
+        let inset: CGFloat = 20
+        let boundaryFrame = view.bounds.insetBy(dx: inset, dy: inset)
+        let collision = UICollisionBehavior(items: [rootView.floatingButton])
+        collision.addBoundary(withIdentifier: "top" as NSString,
+                              from: CGPoint(x: boundaryFrame.minX, y: boundaryFrame.minY),
+                              to: CGPoint(x: boundaryFrame.maxX, y: boundaryFrame.minY))
+        
+        collision.addBoundary(withIdentifier: "left" as NSString,
+                              from: CGPoint(x: boundaryFrame.minX, y: boundaryFrame.minY),
+                              to: CGPoint(x: boundaryFrame.minX, y: boundaryFrame.maxY))
+        
+        collision.addBoundary(withIdentifier: "right" as NSString,
+                              from: CGPoint(x: boundaryFrame.maxX, y: boundaryFrame.minY),
+                              to: CGPoint(x: boundaryFrame.maxX, y: boundaryFrame.maxY))
+        
+        collision.addBoundary(withIdentifier: "bottom" as NSString,
+                              from: CGPoint(x: boundaryFrame.minX, y: boundaryFrame.maxY),
+                              to: CGPoint(x: boundaryFrame.maxX, y: boundaryFrame.maxY))
+        
+        animator?.addBehavior(collision)
+        collisionBehavior = collision
     }
     
 }

--- a/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/ConsoleLog/ConsoleLogViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/ConsoleLog/ConsoleLogViewController.swift
@@ -7,9 +7,15 @@
 
 import UIKit
 
+import RxSwift
+import RxCocoa
+
 class ConsoleLogViewController: UIViewController {
     
+    var disposeBag = DisposeBag()
+    
     let rootView = ConsoleLogView()
+    let panGesture = UIPanGestureRecognizer()
     
     override func loadView() {
         view = rootView
@@ -18,8 +24,36 @@ class ConsoleLogViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        
-        
+        setupGestures()
+        setupActions()
+    }
+    
+}
+
+extension ConsoleLogViewController {
+    
+    //MARK: - Private Func
+    
+    private func setupGestures() {
+        rootView.floatingButton.addGestureRecognizer(panGesture)
+        panGesture.rx.event.subscribe(onNext: { [weak self] gesture in
+            self?.panGestureAction(sender: gesture)
+        }).disposed(by: disposeBag)
+    }
+    
+    private func panGestureAction(sender: UIPanGestureRecognizer) {
+        let translation = sender.translation(in: view)
+        rootView.floatingButton.center = CGPoint(x: rootView.floatingButton.center.x + translation.x,
+                                                 y: rootView.floatingButton.center.y + translation.y)
+        sender.setTranslation(.zero, in: view)
+    }
+    
+    private func setupActions() {
+        rootView.floatingButton.rx.tap
+            .subscribe(onNext: { [weak self] in
+                // floatingButton action
+                print("floatingButton action")
+            }).disposed(by: disposeBag)
     }
     
 }

--- a/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/ConsoleLog/ConsoleLogViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/ConsoleLog/ConsoleLogViewController.swift
@@ -97,7 +97,7 @@ extension ConsoleLogViewController {
             
             // floatingView의 높이: 300, floatingView의 위 아래 최소 padding 값: 5
             let finalPosition =
-            min(rootView.safeAreaLayoutGuide.layoutFrame.height - 300 - 5,
+            min(rootView.safeAreaLayoutGuide.layoutFrame.height - 250 - 5,
                 max(5, rootView.floatingViewTopConstraintToSafeArea.constant + verticalPosition + vertialVelocity / 5))
             
             floatingViewDeceleratingAnimator.addAnimations { [weak self] in

--- a/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/ConsoleLog/ConsoleLogViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/ConsoleLog/ConsoleLogViewController.swift
@@ -12,6 +12,8 @@ import RxCocoa
 
 class ConsoleLogViewController: UIViewController {
     
+    //MARK: - Properties
+    
     var disposeBag = DisposeBag()
     private var isfloatingViewShown: Bool = false
     private let floatingViewShowingAnimator = UIViewPropertyAnimator(duration: 0.3, dampingRatio: 1)
@@ -20,10 +22,11 @@ class ConsoleLogViewController: UIViewController {
     private var dynamicBehavior: UIDynamicItemBehavior?
     private var collisionBehavior: UICollisionBehavior?
     
-    
     let rootView = ConsoleLogView()
     private let floatingButtonPanGesture = UIPanGestureRecognizer()
     private let floatinViewPanGesture = UIPanGestureRecognizer()
+    
+    //MARK: - Life Cycle
     
     override func loadView() {
         view = rootView
@@ -79,7 +82,6 @@ extension ConsoleLogViewController {
         sender.setTranslation(.zero, in: view)
     }
     
-    
     private func panGestureHandler(sender: UIPanGestureRecognizer) {
         floatingViewDeceleratingAnimator.stopAnimation(true)
         let verticalPosition = sender.translation(in: rootView).y
@@ -119,12 +121,10 @@ extension ConsoleLogViewController {
     }
     
     private func floatingButtonAction() {
-        print("floatingButton action")
-//        let isLogTextViewShown = !rootView.logTextView.isHidden
         if isfloatingViewShown {
-            self.hideLogTextView()
+            self.hide()
         } else {
-            self.showLogTextView()
+            self.showLog()
         }
     }
     
@@ -160,7 +160,7 @@ extension ConsoleLogViewController {
         collisionBehavior = collision
     }
     
-    private func showLogTextView() {
+    private func showLog() {
         floatingViewShowingAnimator.stopAnimation(true)
         rootView.floatingView.isHidden = false
         isfloatingViewShown = true
@@ -175,7 +175,7 @@ extension ConsoleLogViewController {
         floatingViewShowingAnimator.startAnimation()
     }
     
-    private func hideLogTextView() {
+    private func hide() {
         floatingViewShowingAnimator.stopAnimation(true)
         isfloatingViewShown = false
         let transform = CGAffineTransform(scaleX: 1, y: 0.1)

--- a/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/ConsoleLog/ConsoleLogViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/ConsoleLog/ConsoleLogViewController.swift
@@ -13,8 +13,8 @@ import RxCocoa
 class ConsoleLogViewController: UIViewController {
     
     var disposeBag = DisposeBag()
-    var isLogTextViewShown: Bool = false
-    private let logTextViewAnimator = UIViewPropertyAnimator(duration: 0.3, dampingRatio: 1)
+    private var isfloatingViewShown: Bool = false
+    private let floatingViewShowingAnimator = UIViewPropertyAnimator(duration: 0.3, dampingRatio: 1)
     private var dynamicAnimator: UIDynamicAnimator?
     private var dynamicBehavior: UIDynamicItemBehavior?
     private var collisionBehavior: UICollisionBehavior?
@@ -82,7 +82,7 @@ extension ConsoleLogViewController {
     private func floatingButtonAction() {
         print("floatingButton action")
 //        let isLogTextViewShown = !rootView.logTextView.isHidden
-        if isLogTextViewShown {
+        if isfloatingViewShown {
             self.hideLogTextView()
         } else {
             self.showLogTextView()
@@ -122,32 +122,32 @@ extension ConsoleLogViewController {
     }
     
     private func showLogTextView() {
-        logTextViewAnimator.stopAnimation(true)
-        rootView.logTextView.isHidden = false
-        isLogTextViewShown = true
+        floatingViewShowingAnimator.stopAnimation(true)
+        rootView.floatingView.isHidden = false
+        isfloatingViewShown = true
         let transform = CGAffineTransform.identity
-        logTextViewAnimator.addAnimations { [weak self] in
-            self?.rootView.logTextView.transform = transform
-            self?.rootView.logTextView.alpha = 1
+        floatingViewShowingAnimator.addAnimations { [weak self] in
+            self?.rootView.floatingView.transform = transform
+            self?.rootView.floatingView.alpha = 1
         }
-        logTextViewAnimator.addCompletion { [weak self] _ in
-            self?.rootView.logTextView.layoutIfNeeded()
+        floatingViewShowingAnimator.addCompletion { [weak self] _ in
+            self?.rootView.floatingView.layoutIfNeeded()
         }
-        logTextViewAnimator.startAnimation()
+        floatingViewShowingAnimator.startAnimation()
     }
     
     private func hideLogTextView() {
-        logTextViewAnimator.stopAnimation(true)
-        isLogTextViewShown = false
+        floatingViewShowingAnimator.stopAnimation(true)
+        isfloatingViewShown = false
         let transform = CGAffineTransform(scaleX: 1, y: 0.1)
-        logTextViewAnimator.addAnimations { [weak self] in
-            self?.rootView.logTextView.transform = transform
-            self?.rootView.logTextView.alpha = 0
+        floatingViewShowingAnimator.addAnimations { [weak self] in
+            self?.rootView.floatingView.transform = transform
+            self?.rootView.floatingView.alpha = 0
         }
-        logTextViewAnimator.addCompletion { [weak self] _ in
-            self?.rootView.logTextView.isHidden = true
+        floatingViewShowingAnimator.addCompletion { [weak self] _ in
+            self?.rootView.floatingView.isHidden = true
         }
-        logTextViewAnimator.startAnimation()
+        floatingViewShowingAnimator.startAnimation()
     }
     
 }

--- a/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/ConsoleLog/ConsoleLogViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/ConsoleLog/ConsoleLogViewController.swift
@@ -1,0 +1,25 @@
+//
+//  ConsoleLogViewController.swift
+//  ORB(Dev)
+//
+//  Created by 김민성 on 1/31/25.
+//
+
+import UIKit
+
+class ConsoleLogViewController: UIViewController {
+    
+    let rootView = ConsoleLogView()
+    
+    override func loadView() {
+        view = rootView
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        
+        
+    }
+    
+}

--- a/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/ConsoleLog/ConsoleLogViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/ConsoleLog/ConsoleLogViewController.swift
@@ -13,7 +13,9 @@ import RxCocoa
 class ConsoleLogViewController: UIViewController {
     
     var disposeBag = DisposeBag()
-    private var animator: UIDynamicAnimator?
+    var isLogTextViewShown: Bool = false
+    private let logTextViewAnimator = UIViewPropertyAnimator(duration: 0.3, dampingRatio: 1)
+    private var dynamicAnimator: UIDynamicAnimator?
     private var dynamicBehavior: UIDynamicItemBehavior?
     private var collisionBehavior: UICollisionBehavior?
     
@@ -30,7 +32,7 @@ class ConsoleLogViewController: UIViewController {
         
         setupGestures()
         setupActions()
-        animator = UIDynamicAnimator(referenceView: view)
+        dynamicAnimator = UIDynamicAnimator(referenceView: view)
     }
     
 }
@@ -51,7 +53,7 @@ extension ConsoleLogViewController {
         
         switch sender.state {
         case .began:
-            animator?.removeAllBehaviors()
+            dynamicAnimator?.removeAllBehaviors()
         case .changed:
             // floatingButton 한 변의 길이: 60
             rootView.floatingButton.center = CGPoint(
@@ -79,6 +81,12 @@ extension ConsoleLogViewController {
     
     private func floatingButtonAction() {
         print("floatingButton action")
+//        let isLogTextViewShown = !rootView.logTextView.isHidden
+        if isLogTextViewShown {
+            self.hideLogTextView()
+        } else {
+            self.showLogTextView()
+        }
     }
     
     private func applyInertiaEffect(velocity: CGPoint) {
@@ -87,7 +95,7 @@ extension ConsoleLogViewController {
         dynamic.resistance = 15.0
         dynamic.elasticity = 0.3
         dynamic.allowsRotation = false
-        animator?.addBehavior(dynamic)
+        dynamicAnimator?.addBehavior(dynamic)
         dynamicBehavior = dynamic
         
         let inset: CGFloat = 20
@@ -109,8 +117,37 @@ extension ConsoleLogViewController {
                               from: CGPoint(x: boundaryFrame.minX, y: boundaryFrame.maxY),
                               to: CGPoint(x: boundaryFrame.maxX, y: boundaryFrame.maxY))
         
-        animator?.addBehavior(collision)
+        dynamicAnimator?.addBehavior(collision)
         collisionBehavior = collision
+    }
+    
+    private func showLogTextView() {
+        logTextViewAnimator.stopAnimation(true)
+        rootView.logTextView.isHidden = false
+        isLogTextViewShown = true
+        let transform = CGAffineTransform.identity
+        logTextViewAnimator.addAnimations { [weak self] in
+            self?.rootView.logTextView.transform = transform
+            self?.rootView.logTextView.alpha = 1
+        }
+        logTextViewAnimator.addCompletion { [weak self] _ in
+            self?.rootView.logTextView.layoutIfNeeded()
+        }
+        logTextViewAnimator.startAnimation()
+    }
+    
+    private func hideLogTextView() {
+        logTextViewAnimator.stopAnimation(true)
+        isLogTextViewShown = false
+        let transform = CGAffineTransform(scaleX: 1, y: 0.1)
+        logTextViewAnimator.addAnimations { [weak self] in
+            self?.rootView.logTextView.transform = transform
+            self?.rootView.logTextView.alpha = 0
+        }
+        logTextViewAnimator.addCompletion { [weak self] _ in
+            self?.rootView.logTextView.isHidden = true
+        }
+        logTextViewAnimator.startAnimation()
     }
     
 }

--- a/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/ConsoleLog/ConsoleLogViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/ConsoleLog/ConsoleLogViewController.swift
@@ -150,4 +150,10 @@ extension ConsoleLogViewController {
         floatingViewShowingAnimator.startAnimation()
     }
     
+    //MARK: - Func
+    
+    func printLog(_ log: String) {
+        rootView.logTextView.text = "\(log)"
+    }
+    
 }

--- a/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/ConsoleLog/ConsoleLogViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/ConsoleLog/ConsoleLogViewController.swift
@@ -49,17 +49,17 @@ extension ConsoleLogViewController {
     private func setupGestures() {
         rootView.floatingButton.addGestureRecognizer(floatingButtonPanGesture)
         floatingButtonPanGesture.rx.event.subscribe(onNext: { [weak self] gesture in
-            self?.panGestureAction(sender: gesture)
+            self?.floatingButtonPanGestureHandler(sender: gesture)
         }).disposed(by: disposeBag)
         
         rootView.floatingViewGrabberTouchArea.addGestureRecognizer(floatinViewPanGesture)
         floatinViewPanGesture.rx.event.subscribe(onNext: { [weak self] gesture in
-            self?.panGestureHandler(sender: gesture)
+            self?.floatingViewPanGestureHandler(sender: gesture)
         }).disposed(by: disposeBag)
         
     }
     
-    private func panGestureAction(sender: UIPanGestureRecognizer) {
+    private func floatingButtonPanGestureHandler(sender: UIPanGestureRecognizer) {
         let translation = sender.translation(in: view)
         
         switch sender.state {
@@ -82,7 +82,7 @@ extension ConsoleLogViewController {
         sender.setTranslation(.zero, in: view)
     }
     
-    private func panGestureHandler(sender: UIPanGestureRecognizer) {
+    private func floatingViewPanGestureHandler(sender: UIPanGestureRecognizer) {
         floatingViewDeceleratingAnimator.stopAnimation(true)
         let verticalPosition = sender.translation(in: rootView).y
         let initialTopConstraint = rootView.floatingViewTopConstraintToSafeArea.constant
@@ -106,7 +106,6 @@ extension ConsoleLogViewController {
                 self.rootView.layoutIfNeeded()
             }
             floatingViewDeceleratingAnimator.startAnimation()
-            break
         default:
             break
         }
@@ -122,12 +121,13 @@ extension ConsoleLogViewController {
     
     private func floatingButtonAction() {
         if isfloatingViewShown {
-            self.hide()
+            self.shrinkFloatingView()
         } else {
-            self.showLog()
+            self.spreadFloatingView()
         }
     }
     
+    // 버튼의 드래그가 끝난 후 부드럽게 감속하는 효과를 주고 버튼이 멈출 경계를 설정하는 함수
     private func applyInertiaEffect(velocity: CGPoint) {
         let dynamic = UIDynamicItemBehavior(items: [rootView.floatingButton])
         dynamic.addLinearVelocity(velocity, for: rootView.floatingButton)
@@ -160,7 +160,7 @@ extension ConsoleLogViewController {
         collisionBehavior = collision
     }
     
-    private func showLog() {
+    private func spreadFloatingView() {
         floatingViewShowingAnimator.stopAnimation(true)
         rootView.floatingView.isHidden = false
         isfloatingViewShown = true
@@ -175,7 +175,7 @@ extension ConsoleLogViewController {
         floatingViewShowingAnimator.startAnimation()
     }
     
-    private func hide() {
+    private func shrinkFloatingView() {
         floatingViewShowingAnimator.stopAnimation(true)
         isfloatingViewShown = false
         let transform = CGAffineTransform(scaleX: 1, y: 0.1)

--- a/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/ConsoleLog/ConsoleLogWindow.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/ConsoleLog/ConsoleLogWindow.swift
@@ -9,7 +9,11 @@ import UIKit
 
 class ConsoleLogWindow: UIWindow {
     
+    //MARK: - Properties
+    
     let consoleLogViewController = ConsoleLogViewController()
+    
+    //MARK: - Life Cycle
     
     init() {
         super.init(windowScene: UIWindowScene.current)
@@ -23,7 +27,13 @@ class ConsoleLogWindow: UIWindow {
         fatalError("init(coder:) has not been implemented")
     }
     
-    override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {        
+}
+
+extension ConsoleLogWindow {
+    
+    //MARK: - Func
+    
+    override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
         if consoleLogViewController.rootView.floatingButton.frame.contains(point) ||
             consoleLogViewController.rootView.floatingView.frame.contains(point) {
             return super.hitTest(point, with: event)

--- a/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/ConsoleLog/ConsoleLogWindow.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/ConsoleLog/ConsoleLogWindow.swift
@@ -1,0 +1,27 @@
+//
+//  ConsoleLogWindow.swift
+//  ORB(Dev)
+//
+//  Created by 김민성 on 1/31/25.
+//
+
+import UIKit
+
+class ConsoleLogWindow: UIWindow {
+    
+    let consoleLogViewController = ConsoleLogViewController()
+    
+    init() {
+        super.init(windowScene: UIWindowScene.current)
+        
+        rootViewController = consoleLogViewController
+        windowLevel = UIWindow.Level.alert + 2
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    
+    
+}

--- a/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/ConsoleLog/ConsoleLogWindow.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/ConsoleLog/ConsoleLogWindow.swift
@@ -16,12 +16,19 @@ class ConsoleLogWindow: UIWindow {
         
         rootViewController = consoleLogViewController
         windowLevel = UIWindow.Level.alert + 2
+        isHidden = false
     }
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
     
-    
+    override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {        
+        if consoleLogViewController.rootView.floatingButton.frame.contains(point) {
+            return super.hitTest(point, with: event)
+        } else {
+            return nil
+        }
+    }
     
 }

--- a/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/ConsoleLog/ConsoleLogWindow.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/ConsoleLog/ConsoleLogWindow.swift
@@ -25,7 +25,7 @@ class ConsoleLogWindow: UIWindow {
     
     override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {        
         if consoleLogViewController.rootView.floatingButton.frame.contains(point) ||
-            consoleLogViewController.rootView.logTextView.frame.contains(point) {
+            consoleLogViewController.rootView.floatingView.frame.contains(point) {
             return super.hitTest(point, with: event)
         } else {
             return nil

--- a/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/ConsoleLog/ConsoleLogWindow.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/ConsoleLog/ConsoleLogWindow.swift
@@ -24,7 +24,8 @@ class ConsoleLogWindow: UIWindow {
     }
     
     override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {        
-        if consoleLogViewController.rootView.floatingButton.frame.contains(point) {
+        if consoleLogViewController.rootView.floatingButton.frame.contains(point) ||
+            consoleLogViewController.rootView.logTextView.frame.contains(point) {
             return super.hitTest(point, with: event)
         } else {
             return nil

--- a/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/ConsoleLog/PrintLogInDevApp.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/ConsoleLog/PrintLogInDevApp.swift
@@ -1,0 +1,17 @@
+//
+//  PrintLogInDevApp.swift
+//  Offroad-iOS
+//
+//  Created by 김민성 on 2/1/25.
+//
+
+/*
+ 개발용 앱에 한하여 원하는 문구를 앱 내에 띄워줄 수 있습니다.
+ */
+func printLog(_ log: String) {
+    #if DevTarget
+    ConsoleLogManager.shared.printLog(log)
+    #else
+    return
+    #endif
+}

--- a/Offroad-iOS/Offroad-iOS/Network/Base/MoyaPlugin.swift
+++ b/Offroad-iOS/Offroad-iOS/Network/Base/MoyaPlugin.swift
@@ -16,6 +16,7 @@ final class MoyaPlugin: PluginType {
     func willSend(_ request: RequestType, target: TargetType) {
         guard let httpRequest = request.request else {
             print("--> ❌❌❌유효하지 않은 요청❌❌❌")
+            printLog("--> ❌❌❌유효하지 않은 요청❌❌❌")
             return
         }
         let url = httpRequest.description
@@ -30,6 +31,7 @@ final class MoyaPlugin: PluginType {
         }
         log.append("=========================== END \(method) ===========================")
         print(log)
+        printLog(log)
     }
 
     // MARK: - Response
@@ -56,6 +58,7 @@ final class MoyaPlugin: PluginType {
         }
         log.append("=========================== END HTTP ===========================")
         print(log)
+        printLog(log)
     }
 
     func onFail(_ error: MoyaError) {
@@ -68,6 +71,7 @@ final class MoyaPlugin: PluginType {
         log.append("\(error.failureReason ?? error.errorDescription ?? "unknown error")\n")
         log.append("<-- END HTTP")
         print(log)
+        printLog(log)
         
         ORBToastManager.shared.showToast(message: ErrorMessages.networkError, inset: 54)
     }

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/ViewControllers/ORBCharacterChatViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/ViewControllers/ORBCharacterChatViewController.swift
@@ -208,6 +208,7 @@ extension ORBCharacterChatViewController {
                 self.userChatInputViewTextInputViewHeightRelay.accept(self.rootView.userChatInputView.textInputView.bounds.height)
                 if text.trimmingCharacters(in: .whitespacesAndNewlines) != "" {
                     print("입력된 텍스트: \(text)")
+                    printLog("입력된 텍스트: \(text)")
                     self.rootView.userChatDisplayView.isHidden = true
                     self.rootView.loadingAnimationView.isHidden = false
                     self.rootView.loadingAnimationView.play()
@@ -215,6 +216,7 @@ extension ORBCharacterChatViewController {
                     self.updateChatDisplayViewHeight(height: 20)
                 } else {
                     print("입력된 텍스트 없음")
+                    printLog("입력된 텍스트 없음")
                     userChatDisplayViewTextInputViewHeightRelay.accept(rootView.userChatDisplayView.textInputView.frame.height)
                     self.rootView.userChatDisplayView.isHidden = false
                     self.rootView.loadingAnimationView.currentProgress = 0

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/ChatLog/ViewControllers/CharacterChatLogViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/ChatLog/ViewControllers/CharacterChatLogViewController.swift
@@ -315,11 +315,13 @@ extension CharacterChatLogViewController {
                 self.userChatInputViewTextInputViewHeightRelay.accept(self.rootView.userChatInputView.textInputView.bounds.height)
                 if text.trimmingCharacters(in: .whitespacesAndNewlines) != "" {
                     print("입력된 텍스트: \(text)")
+                    printLog("입력된 텍스트: \(text)")
                     self.rootView.loadingAnimationView.isHidden = false
                     self.rootView.loadingAnimationView.play()
                     self.isTextViewEmpty.accept(false)
                 } else {
                     print("입력된 텍스트 없음")
+                    printLog("입력된 텍스트 없음")
                     self.rootView.loadingAnimationView.currentProgress = 0
                     self.rootView.loadingAnimationView.pause()
                     self.rootView.loadingAnimationView.isHidden = true

--- a/Offroad-iOS/Offroad-iOS/Presentation/MyPage/Coupon/ViewController/CouponDetailViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/MyPage/Coupon/ViewController/CouponDetailViewController.swift
@@ -112,7 +112,8 @@ class CouponDetailViewController: UIViewController {
             switch result {
             case .success(let response):
                 guard let response else { return }
-                print("쿠폰 사용 결과: " + "\(response.data.success)")
+                print("쿠폰 사용 결과: \(response.data.success)")
+                printLog("쿠폰 사용 결과: \(response.data.success)")
                 self.afterCouponRedemptionRelay.accept(response.data.success)
             default:
                 self.afterCouponRedemptionRelay.accept(false)


### PR DESCRIPTION
### 🌴 작업한 브랜치
- #453 


### ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->
개발용 앱에서 로그를 확인할 수 있도록 구현하였습니다. 

엑스코드 콘솔이 있어야만 확인할 수 있는 문구들을 개발용 앱에서도 볼 수 있으면 좋을 것 같아 이러한 기능을 만들어 보았습니다. 

- 특정 위치에 로그가 고정되어있기에는 로그가 길 경우, UI를 가리게 될 것 같아 플로팅 버튼을 만들어 이 버튼을 눌렀을 때 로그가 보이거나 숨겨질 수 있도록 구현하였습니다.
- 로그가 펼쳐진 후에도 로그 뷰의 세로 위치를 조정할 수 있도록 하였습니다. 
- `printLog(_:)` 메서드를 이용하여 앱 내에서 원하는 로그를 띄울 수 있습니다.
OS에서 출력하는 로그는표시하지 않고, 개발자가 원하는 내용만 표시할 수 있습니다.
현재는 `MoyaPlugin`에서 출력하는 내용과, 제가 개발했던 코드의 일부에서 `printLog(_:)`를 사용하였습니다. 
- `printLog(_:)`는 호출할 때마다 로그가 누적되어 표현되는 것이 아니라 새 로그가 표시됩니다. 
(로그가 누적되면 버벅거리고, 메모리가 너무 늘어날 것 같아 새로고침되도록 하였습니다. 자세한 로그를 확인하고자 한다면 Xcode를 참고해 주세요.))
<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### ❗️PR Point
<!-- 부족했던 점 혹은 개선하고 싶은 방향이 있다면 얘기해주세요 -->

- ### 지금 생각해보니, `Console` 이라는 단어를 뺴는 것이 더 적절해 보이기도 합니다. `LogPrinter`와 같은 이름이 더 직관적인것 같네요.
  콘솔 자체는 명령어를 입력받을 수 있어야 하는데, 여기서 구현된 것은 콘솔이라기보다는 그저 로그를 출력해주는 창 정도에 더 가깝기 때문입니다. 
이에 관한 파트원들의 의견을 받습니다. 
(2월 4일 자정까지 리뷰가 없을 경우, 콘솔이라는 이름을 제거하고 `LogPrinter` 등의 이름으로 변경한 후에 main에 머지하도록 하겠습니다.)

- 이 기능은 실제 릴리즈되는 기능이 아니므로, 코드 퀄리티는 크게 신경쓰지 않았습니다. 이 점 참고해 주세요.
기능이 제대로 동작하는지, 배포용 앱에서 보이는 등의 부작용이 있는지 위주로 확인해 주시면 감사하겠습니다. 
- 추후 여유가 될 경우 다른 기능들을 추가할 수 있습니다. 팀원들의 제안도 환영입니다. 
(개인적으로는 탐험 성공 시에도 테스트해볼 수 있어야 하기 때문에 위치와 상관없이 탐험을 성공할 수 있도록 하는 기능 등을 구현하면 좋을 것 같습니다. )
<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->

|플로팅 버튼 구현|`printLog(_:)를 이용하여 로그 확인|
|:------:|:---:|
|   <img src="https://github.com/user-attachments/assets/3a7fcf77-c7ba-438d-9ea1-ec10ce75c1f9" width=200>    |    <img src="https://github.com/user-attachments/assets/61551446-1277-4be7-869d-3b50aeb9a646" width=200> |


- Resolved: #453 
