### PR TITLE
[Refactor] #461 - 지도 뷰 코드 개선

### DIFF
--- a/Offroad-iOS/Offroad-iOS.xcodeproj/project.pbxproj
+++ b/Offroad-iOS/Offroad-iOS.xcodeproj/project.pbxproj
@@ -388,6 +388,10 @@
 		4EC6F0A62CF4747400895A87 /* UIScrollView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EC6F0A52CF4747400895A87 /* UIScrollView+.swift */; };
 		4ECCC95E2CC80088002B9C4F /* ORBToastView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ECCC95D2CC80088002B9C4F /* ORBToastView.swift */; };
 		4ECEEA6E2CB2C15E0029369A /* ORBTabBarShapeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ECEEA6D2CB2C15E0029369A /* ORBTabBarShapeView.swift */; };
+		4EDB392B2D54ED270082F8E6 /* ORBMapHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EDB392A2D54ED270082F8E6 /* ORBMapHelper.swift */; };
+		4EDB392C2D54ED270082F8E6 /* ORBMapHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EDB392A2D54ED270082F8E6 /* ORBMapHelper.swift */; };
+		4EDB392E2D54EF750082F8E6 /* PlaceInfoTooltipHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EDB392D2D54EF750082F8E6 /* PlaceInfoTooltipHelper.swift */; };
+		4EDB392F2D54EF750082F8E6 /* PlaceInfoTooltipHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EDB392D2D54EF750082F8E6 /* PlaceInfoTooltipHelper.swift */; };
 		4EDC3D412C31271F006A1493 /* Pretendard-Bold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 4EDC3D382C31271E006A1493 /* Pretendard-Bold.otf */; };
 		4EDC3D422C31271F006A1493 /* Pretendard-Light.otf in Resources */ = {isa = PBXBuildFile; fileRef = 4EDC3D392C31271E006A1493 /* Pretendard-Light.otf */; };
 		4EDC3D432C31271F006A1493 /* Pretendard-Regular.otf in Resources */ = {isa = PBXBuildFile; fileRef = 4EDC3D3A2C31271E006A1493 /* Pretendard-Regular.otf */; };
@@ -694,6 +698,8 @@
 		4EC6F0A52CF4747400895A87 /* UIScrollView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIScrollView+.swift"; sourceTree = "<group>"; };
 		4ECCC95D2CC80088002B9C4F /* ORBToastView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ORBToastView.swift; sourceTree = "<group>"; };
 		4ECEEA6D2CB2C15E0029369A /* ORBTabBarShapeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ORBTabBarShapeView.swift; sourceTree = "<group>"; };
+		4EDB392A2D54ED270082F8E6 /* ORBMapHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ORBMapHelper.swift; sourceTree = "<group>"; };
+		4EDB392D2D54EF750082F8E6 /* PlaceInfoTooltipHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaceInfoTooltipHelper.swift; sourceTree = "<group>"; };
 		4EDC3D382C31271E006A1493 /* Pretendard-Bold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Bold.otf"; sourceTree = "<group>"; };
 		4EDC3D392C31271E006A1493 /* Pretendard-Light.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Light.otf"; sourceTree = "<group>"; };
 		4EDC3D3A2C31271E006A1493 /* Pretendard-Regular.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Regular.otf"; sourceTree = "<group>"; };
@@ -1436,6 +1442,7 @@
 			isa = PBXGroup;
 			children = (
 				4E1E94182C3AC27C00A7B08A /* ORBMapView.swift */,
+				4EDB392A2D54ED270082F8E6 /* ORBMapHelper.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -1612,6 +1619,7 @@
 			isa = PBXGroup;
 			children = (
 				4E4E2C012CCE2841000A634D /* PlaceInfoTooltip.swift */,
+				4EDB392D2D54EF750082F8E6 /* PlaceInfoTooltipHelper.swift */,
 			);
 			path = PlaceInfoTooltip;
 			sourceTree = "<group>";
@@ -3187,6 +3195,8 @@
 				4E58FC052C7DFEAC002A951B /* QuestListResponseDTO.swift in Sources */,
 				4E1E94192C3AC27C00A7B08A /* ORBMapView.swift in Sources */,
 				4EC4A1ED2D24380700A8C130 /* CustomIntensityBlurView.swift in Sources */,
+				4EDB392C2D54ED270082F8E6 /* ORBMapHelper.swift in Sources */,
+				4EDB392E2D54EF750082F8E6 /* PlaceInfoTooltipHelper.swift in Sources */,
 				D004F8CF2CB4DDE600D5A2CD /* KakaoAuthManager.swift in Sources */,
 				D06466AC2C8A0FD600CF10FD /* MarketingConsentRequestDTO.swift in Sources */,
 				4E3A32A42CE8E353007228D0 /* CharacterChatLogViewModel.swift in Sources */,
@@ -3433,6 +3443,7 @@
 				4E4F31672D4718F400C3B2FF /* LogoutViewController.swift in Sources */,
 				4E4F31682D4718F400C3B2FF /* AdventuresPlaceAuthenticationRequestDTO.swift in Sources */,
 				4E4F31692D4718F400C3B2FF /* OffroadTabBarViewController.swift in Sources */,
+				4EDB392B2D54ED270082F8E6 /* ORBMapHelper.swift in Sources */,
 				4E4F316A2D4718F400C3B2FF /* AdventureInfoResponseDTO.swift in Sources */,
 				4E4F316B2D4718F400C3B2FF /* ORBMapView.swift in Sources */,
 				4E4F316C2D4718F400C3B2FF /* ORBAlertButton.swift in Sources */,
@@ -3463,6 +3474,7 @@
 				4E4F31832D4718F400C3B2FF /* CouponListResponseDTO.swift in Sources */,
 				4E4F31842D4718F400C3B2FF /* NicknameView.swift in Sources */,
 				4E4F31852D4718F400C3B2FF /* ORBAlertViewBaseUI.swift in Sources */,
+				4EDB392F2D54EF750082F8E6 /* PlaceInfoTooltipHelper.swift in Sources */,
 				4E4F31862D4718F400C3B2FF /* PushNotificationService.swift in Sources */,
 				4E4F31872D4718F400C3B2FF /* UIButton+.swift in Sources */,
 				4E4F31882D4718F400C3B2FF /* ORBMapViewModel.swift in Sources */,

--- a/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/Alert/ORBAlertController.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/Alert/ORBAlertController.swift
@@ -258,10 +258,16 @@ extension ORBAlertController {
         configure(defaultTextField!)
     }
     
+    /**
+     alert controller의 `messageLabel`의 속성을 변경하는 함수.
+     */
     func configureMessageLabel(_ configure: (UILabel) -> Void) {
         configure(self.rootView.alertView.messageLabel)
     }
     
+    /**
+     alert controller의 `subMessageLabel`의 속성을 변경하는 함수.
+     */
     func configureSubMessagelabel(_ configure: (UILabel) -> Void) {
         guard let alertViewTextFieldWithSubMessage = rootView.alertView as? ORBAlertViewTextFieldWithSubMessage else { return }
         configure(alertViewTextFieldWithSubMessage.subMessageLabel)
@@ -272,6 +278,10 @@ extension ORBAlertController {
         configure(alertViewScrollableContent.scrollableContentView)
     }
     
+    /**
+     alert controller의 `rootView` 타입이 `ORBAlertViewExplorationResult`인 경우 배경 이미지를 설정하는 함수.
+     alert controller의 `rootView` 타입이 `ORBAlertViewExplorationResult`가 아닌 경우, 이 함수는 아무런 동작도 하지 않는다.
+     */
     func configureExplorationResultImage(_ configure: (UIImageView) -> Void) {
         guard let alertViewExplorationResult = rootView.alertView as? ORBAlertViewExplorationResult else { return }
         configure(alertViewExplorationResult.explorationResultImageView)

--- a/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/LogPrinter/LogPrinterViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/LogPrinter/LogPrinterViewController.swift
@@ -15,7 +15,7 @@ class LogPrinterViewController: UIViewController {
     //MARK: - Properties
     
     var disposeBag = DisposeBag()
-    private var isfloatingViewShown: Bool = false
+    var isfloatingViewShown: Bool = false
     private let floatingViewShowingAnimator = UIViewPropertyAnimator(duration: 0.3, dampingRatio: 1)
     private let floatingViewDeceleratingAnimator = UIViewPropertyAnimator(duration: 0.4, dampingRatio: 1)
     private var dynamicAnimator: UIDynamicAnimator?

--- a/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/LogPrinter/LogPrinterWindow.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/LogPrinter/LogPrinterWindow.swift
@@ -35,7 +35,8 @@ extension LogPrinterWindow {
     
     override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
         if logPrinterViewController.rootView.floatingButton.frame.contains(point) ||
-            logPrinterViewController.rootView.floatingView.frame.contains(point) {
+            (logPrinterViewController.isfloatingViewShown &&
+             logPrinterViewController.rootView.floatingView.frame.contains(point)) {
             return super.hitTest(point, with: event)
         } else {
             return nil

--- a/Offroad-iOS/Offroad-iOS/Global/Literals/StringLiterals.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Literals/StringLiterals.swift
@@ -31,6 +31,13 @@ struct AlertMessage {
     static let locationUnauthorizedAdventureMessage = "위치정보 사용 동의 후 이용 가능합니다."
     static let locationServicesDisabledMessage = "모험가님의 위치를 찾을 수 없어요.\n탐험을 위해서 위치 기능을 활성화해주세요."
     static let locationReducedAccuracyMessage = "모험가님의 정확한 위치를 찾을 수 없어요.\n탐험을 위해서 정확한 위치 접근 권한을 허용해주세요."
+    static let completeQuestsTitle = "퀘스트 성공 !"
+    static func completeSingleQuestMessage(questName: String) -> String {
+        "퀘스트 '\(questName)'을(를) 클리어했어요! 마이페이지에서 보상을 확인해보세요."
+    }
+    static func completeMultipleQuestsMessage(firstQuestName: String, questCount: Int) -> String {
+        "퀘스트 '\(firstQuestName)' 외 \(questCount - 1)개를 클리어했어요! 마이페이지에서 보상을 확인해보세요."
+    }
 }
 
 struct LoadingMessage {

--- a/Offroad-iOS/Offroad-iOS/Presentation/QuestMap/PlaceInfoTooltip/PlaceInfoTooltipHelper.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/QuestMap/PlaceInfoTooltip/PlaceInfoTooltipHelper.swift
@@ -1,0 +1,86 @@
+//
+//  PlaceInfoTooltipHelper.swift
+//  Offroad-iOS
+//
+//  Created by 김민성 on 2/6/25.
+//
+
+import UIKit
+
+final class PlaceInfoTooltipHelper {
+    
+    //MARK: - Properties
+    
+    let tooltip: PlaceInfoTooltip
+    let shadingView: UIView
+    
+    var isTooltipShown: Bool = false
+    private let shadingAnimator = UIViewPropertyAnimator(duration: 0.3, dampingRatio: 1)
+    private let tooltipTransparencyAnimator = UIViewPropertyAnimator(duration: 0.2, dampingRatio: 1)
+    private let tooltipShowingAnimator = UIViewPropertyAnimator(duration: 0.4, dampingRatio: 0.8)
+    private let tooltipHidingAnimator = UIViewPropertyAnimator(duration: 0.25, dampingRatio: 1)
+    
+    //MARK: - Life Cycle
+    
+    init(tooltip: PlaceInfoTooltip, shadingView: UIView) {
+        self.tooltip = tooltip
+        self.shadingView = shadingView
+    }
+    
+}
+
+extension PlaceInfoTooltipHelper {
+    
+    //MARK: - Func
+    
+    func showTooltip(completion: (() -> Void)? = nil) {
+        tooltip.transform = CGAffineTransform(scaleX: 0.1, y: 0.1)
+        tooltip.alpha = 0
+        tooltip.superview?.layoutIfNeeded()
+        tooltipHidingAnimator.stopAnimation(true)
+        
+        shadingAnimator.addAnimations { [weak self] in
+            self?.shadingView.backgroundColor = .blackOpacity(.black25)
+        }
+        tooltipTransparencyAnimator.addAnimations { [weak self] in
+            self?.tooltip.alpha = 1
+        }
+        tooltipShowingAnimator.addAnimations { [weak self] in
+            self?.tooltip.transform = .identity
+            self?.tooltip.superview?.layoutIfNeeded()
+        }
+        tooltipShowingAnimator.addCompletion { _ in
+            completion?()
+        }
+        
+        isTooltipShown = true
+        shadingView.isUserInteractionEnabled = true
+        tooltipTransparencyAnimator.startAnimation()
+        shadingAnimator.startAnimation()
+        tooltipShowingAnimator.startAnimation()
+    }
+    
+    func hideTooltip(completion: (() -> Void)? = nil) {
+        guard isTooltipShown else { return }
+        tooltipShowingAnimator.stopAnimation(true)
+        
+        shadingAnimator.addAnimations { [weak self] in
+            self?.shadingView.backgroundColor = .clear
+        }
+        tooltipHidingAnimator.addAnimations { [weak self] in
+            self?.tooltip.transform = CGAffineTransform(scaleX: 0.05, y: 0.05)
+        }
+        tooltipHidingAnimator.addAnimations({ [weak self] in
+            self?.tooltip.alpha = 0
+        }, delayFactor: 0.3)
+        tooltipHidingAnimator.addCompletion { [weak self] _ in
+            self?.tooltip.configure(with: nil)
+            self?.shadingView.isUserInteractionEnabled = false
+            completion?()
+        }
+        isTooltipShown = false
+        shadingAnimator.startAnimation()
+        tooltipHidingAnimator.startAnimation()
+    }
+    
+}

--- a/Offroad-iOS/Offroad-iOS/Presentation/QuestMap/PlaceInfoTooltip/PlaceInfoTooltipHelper.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/QuestMap/PlaceInfoTooltip/PlaceInfoTooltipHelper.swift
@@ -11,7 +11,7 @@ final class PlaceInfoTooltipHelper {
     
     //MARK: - Properties
     
-    let tooltip: PlaceInfoTooltip
+    unowned let tooltip: PlaceInfoTooltip
     let shadingView: UIView
     
     var isTooltipShown: Bool = false

--- a/Offroad-iOS/Offroad-iOS/Presentation/QuestMap/ViewControllers/ORBMapViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/QuestMap/ViewControllers/ORBMapViewController.swift
@@ -418,11 +418,18 @@ extension ORBMapViewController {
             if completeQuests.count <= 0 {
                 return
             } else if completeQuests.count == 1 {
-                message = "퀘스트 '\(completeQuests.first!.name)'을(를) 클리어했어요! 마이페이지에서 보상을 확인해보세요."
+                message = AlertMessage.completeSingleQuestMessage(questName: completeQuests.first!.name)
             } else { //if completeQuests.count > 1
-                message = "퀘스트 '\(completeQuests.first!.name)' 외 \(completeQuests.count-1)개를 클리어했어요! 마이페이지에서 보상을 확인해보세요."
+                message = AlertMessage.completeMultipleQuestsMessage(
+                    firstQuestName: completeQuests.first!.name,
+                    questCount: completeQuests.count
+                )
             }
-            let questCompleteAlertController = ORBAlertController(title: "퀘스트 성공 !", message: message, type: .normal)
+            let questCompleteAlertController = ORBAlertController(
+                title: AlertMessage.completeQuestsTitle,
+                message: message,
+                type: .normal
+            )
             questCompleteAlertController.xButton.isHidden = true
             let action = ORBAlertAction(title: "확인", style: .default) { _ in return }
             questCompleteAlertController.addAction(action)

--- a/Offroad-iOS/Offroad-iOS/Presentation/QuestMap/ViewControllers/ORBMapViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/QuestMap/ViewControllers/ORBMapViewController.swift
@@ -328,7 +328,9 @@ extension ORBMapViewController {
         completeQuests: [CompleteQuest]?,
         isFirstVisitToday: Bool
     ) {
-        let title: String = (isValidLocation && isFirstVisitToday) ? AlertMessage.adventureSuccessTitle : AlertMessage.adventureFailureTitle
+        let title: String = (isValidLocation && isFirstVisitToday
+                             ? AlertMessage.adventureSuccessTitle
+                             : AlertMessage.adventureFailureTitle)
         let message: String
         let buttonTitle: String
         
@@ -352,40 +354,44 @@ extension ORBMapViewController {
         alertController.configureExplorationResultImage { $0.image = image }
         alertController.configureMessageLabel {
             $0.highlightText(targetText: "위치", font: .offroad(style: .iosTextBold))
-            $0.highlightText(targetText: "한 번", font: .offroad(style: .iosTextBold))
             $0.highlightText(targetText: "내일 다시", font: .offroad(style: .iosTextBold))
+            if isValidLocation && !isFirstVisitToday {
+                $0.highlightText(targetText: "한 번", font: .offroad(style: .iosTextBold))
+            }
         }
         alertController.xButton.isHidden = true
         let okAction = ORBAlertAction(title: buttonTitle, style: .default) { [weak self] _ in
-            guard let self else { return }
-            if isValidLocation && isFirstVisitToday {
-                self.tabBarController?.selectedIndex = 0
+            guard isValidLocation && isFirstVisitToday else { return }
+            self?.tabBarController?.selectedIndex = 0
+            if let completeQuests {
+                self?.popupQuestCompletion(completeQuests: completeQuests)
             }
-            
-            guard let completeQuests, isValidLocation else { return }
-            let message: String
-            if completeQuests.count <= 0 {
-                return
-            } else if completeQuests.count == 1 {
-                message = AlertMessage.completeSingleQuestMessage(questName: completeQuests.first!.name)
-            } else { //if completeQuests.count > 1
-                message = AlertMessage.completeMultipleQuestsMessage(
-                    firstQuestName: completeQuests.first!.name,
-                    questCount: completeQuests.count
-                )
-            }
-            let questCompleteAlertController = ORBAlertController(
-                title: AlertMessage.completeQuestsTitle,
-                message: message,
-                type: .normal
-            )
-            questCompleteAlertController.xButton.isHidden = true
-            let action = ORBAlertAction(title: "확인", style: .default) { _ in return }
-            questCompleteAlertController.addAction(action)
-            present(questCompleteAlertController, animated: true)
         }
         alertController.addAction(okAction)
         present(alertController, animated: true)
+    }
+    
+    private func popupQuestCompletion(completeQuests: [CompleteQuest]) {
+        let message: String
+        if completeQuests.count <= 0 {
+            return
+        } else if completeQuests.count == 1 {
+            message = AlertMessage.completeSingleQuestMessage(questName: completeQuests.first!.name)
+        } else { //if completeQuests.count > 1
+            message = AlertMessage.completeMultipleQuestsMessage(
+                firstQuestName: completeQuests.first!.name,
+                questCount: completeQuests.count
+            )
+        }
+        let questCompleteAlertController = ORBAlertController(
+            title: AlertMessage.completeQuestsTitle,
+            message: message,
+            type: .normal
+        )
+        questCompleteAlertController.xButton.isHidden = true
+        let action = ORBAlertAction(title: "확인", style: .default) { _ in return }
+        questCompleteAlertController.addAction(action)
+        present(questCompleteAlertController, animated: true)
     }
     
     private func showTooltip() { rootView.showTooltip() }

--- a/Offroad-iOS/Offroad-iOS/Presentation/QuestMap/ViewControllers/ORBMapViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/QuestMap/ViewControllers/ORBMapViewController.swift
@@ -61,7 +61,7 @@ class ORBMapViewController: OffroadTabBarViewController {
             if authorizationCase != .fullAccuracy && authorizationCase != .reducedAccuracy {
                 // 사용자 위치 불러올 수 없을 시 초기 위치 설정
                 // 초기 위치: 광화문광장 (37.5716229, 126.9767879)
-                self.moveCamera(scrollTo: .init(lat: 37.5716229, lng: 126.9767879), animationDuration: 0)
+                self.rootView.moveCamera(scrollTo: .init(lat: 37.5716229, lng: 126.9767879), animationDuration: 0)
                 self.viewModel.updateRegisteredPlaces(at: .init(lat: 37.5716229, lng: 126.9767879))
             }
         }
@@ -278,64 +278,13 @@ extension ORBMapViewController {
     
     private func focusToMarker(_ marker: NMFMarker) {
         let markerLatLng = NMGLatLng(lat: marker.position.lat, lng: marker.position.lng)
-        moveCamera(scrollTo: markerLatLng, reason: 20)
+        rootView.moveCamera(scrollTo: markerLatLng, reason: 20)
     }
     
     private func focusToMyPosition(completion: ((Bool) -> Void)? = nil) {
         guard let currentCoord = locationManager.location?.coordinate else { return }
         let currentLatLng = NMGLatLng(lat: currentCoord.latitude, lng: currentCoord.longitude)
-        moveCamera(scrollTo: currentLatLng, reason: 1) { isCancelled in
-            completion?(isCancelled)
-        }
-    }
-    
-    /// 지도의 카메라를 지정된 좌표(`NMGLatLng`)로 이동시키는 함수
-    /// - Parameters:
-    ///   - coordinate: 이동하고자 하는 좌표값. `NMGLatLng` 타입
-    ///   - animationCurve: 지도가 움직일 때의 애니메이션 종류. NMFCameraUpdateAnimation 타입.
-    ///   - animationDuration: 애니메이션 시간. 0으로 설정할 경우, 애니메이션 없이 바로 이동. 기본값은 NAVER Map iOS SDK에서 설정하는 0.2
-    ///   - reason: 카메라 이동에 사용될 `NMFCameraUpdate` 타입의 `reason` 속성에 할당할 값. 기본값은 `NMFMapChangedByDeveloper`이며, -1에 해당. (개발자가 API를 호출해 카메라가 움직였음을 의미)
-    ///   - completion: 카메라 이동이 완료되었을 때 호출되는 콜백 블록. 애니메이션이 있으면 완전히 끝난 후에 호출됩니다. `Bool` 타입의 매개변수는 카메라 이동이 완료되기 전에 다른 카메라 이동이 호출되거나 사용자가 제스처로 지도를 조작한 경우 `true`입니다.
-    private func moveCamera(
-        scrollTo coordinate: NMGLatLng,
-        animationCurve: NMFCameraUpdateAnimation = .easeOut,
-        // NAVER Map iOS SDK에서 지정하는 기본값이 0.2
-        animationDuration: TimeInterval = 0.2,
-        reason: Int32 = Int32(NMFMapChangedByDeveloper),
-        completion: ((Bool) -> Void)? = nil
-    ) {
-        let cameraUpdate = NMFCameraUpdate(scrollTo: coordinate)
-        cameraUpdate.reason = reason
-        cameraUpdate.animation = animationCurve
-        cameraUpdate.animationDuration = animationDuration
-        DispatchQueue.main.async { [weak self] in
-            guard let self else { return }
-            self.rootView.naverMapView.mapView.moveCamera(cameraUpdate) { isCancelled in
-                completion?(isCancelled)
-            }
-        }
-    }
-    
-    /// 지도의 카메라를 현재 위치에서 `delta` 포인트만큼 이동시키는 함수
-    /// - Parameters:
-    ///   - delta: 이동할 거리. 가로, 세로로 `pt` 단위이며 각각의 값을 `x`, `y` 속성으로 갖는 `CGPoint` 값.
-    ///   - animationCurve: 지도가 움직일 때의 애니메이션 종류. NMFCameraUpdateAnimation 타입.
-    ///   - animationDuration: 애니메이션 시간. 0으로 설정할 경우, 애니메이션 없이 바로 이동. 기본값은 NAVER Map iOS SDK에서 설정하는 0.2
-    ///   - reason: 카메라 이동에 사용될 `NMFCameraUpdate` 타입의 `reason` 속성에 할당할 값. 기본값은 `NMFMapChangedByDeveloper`이며, -1에 해당. (개발자가 API를 호출해 카메라가 움직였음을 의미)
-    ///   - completion: 카메라 이동이 완료되었을 때 호출되는 콜백 블록. 애니메이션이 있으면 완전히 끝난 후에 호출됩니다. `Bool` 타입의 매개변수는 카메라 이동이 완료되기 전에 다른 카메라 이동이 호출되거나 사용자가 제스처로 지도를 조작한 경우 `true`입니다.
-    private func moveCamera(
-        scrollBy delta: CGPoint,
-        animationCurve: NMFCameraUpdateAnimation = .easeOut,
-        // NAVER Map iOS SDK에서 지정하는 기본값이 0.2
-        animationDuration: TimeInterval = 0.2,
-        reason: Int32 = Int32(NMFMapChangedByDeveloper),
-        completion: ((Bool) -> Void)? = nil
-    ) {
-        let cameraUpdate = NMFCameraUpdate(scrollBy: delta)
-        cameraUpdate.reason = reason
-        cameraUpdate.animation = animationCurve
-        cameraUpdate.animationDuration = animationDuration
-        rootView.naverMapView.mapView.moveCamera(cameraUpdate) { isCancelled in
+        rootView.moveCamera(scrollTo: currentLatLng, reason: 1) { isCancelled in
             completion?(isCancelled)
         }
     }
@@ -361,14 +310,14 @@ extension ORBMapViewController {
         
         let tilt = rootView.naverMapView.mapView.cameraPosition.tilt
         if tilt > 30 {
-            moveCamera(scrollTo: marker.position, animationCurve: .fly, animationDuration: 0.5)
+            rootView.moveCamera(scrollTo: marker.position, animationCurve: .fly, animationDuration: 0.5)
         } else {
             let mapSize = rootView.naverMapView.mapView.frame.size
             let delta = viewModel.caculateDeltaToShowTooltip(point: point,
                                                              at: mapSize,
                                                              tooltipSize: rootView.tooltip.frame.size,
                                                              contentInset: 20)
-            moveCamera(scrollBy: delta, animationDuration: 0.3)
+            rootView.moveCamera(scrollBy: delta, animationDuration: 0.3)
         }
         return true
     }

--- a/Offroad-iOS/Offroad-iOS/Presentation/QuestMap/ViewControllers/ORBMapViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/QuestMap/ViewControllers/ORBMapViewController.swift
@@ -192,7 +192,7 @@ extension ORBMapViewController {
                 MyInfoManager.shared.didSuccessAdventure.accept(())
             }
             self.view.stopLoading()
-            if locationValidation && isFirstVisitToday { self.hideTooltip() }
+            if locationValidation && isFirstVisitToday { self.hideTooltipFromMap() }
             self.popupAdventureResult(isValidLocation: locationValidation,
                                       image: image,
                                       completeQuests: completeQuests,
@@ -204,7 +204,7 @@ extension ORBMapViewController {
             self.rootView.reloadPlaceButton.isEnabled = false
             try? self.viewModel.markersSubject.value().forEach({ marker in marker.mapView = nil })
             self.viewModel.updateRegisteredPlaces(at: self.currentPositionTarget)
-            self.hideTooltip()
+            self.hideTooltipFromMap()
         }.disposed(by: disposeBag)
         
         rootView.switchTrackingModeButton.rx.tap.bind { [weak self] _ in
@@ -261,7 +261,7 @@ extension ORBMapViewController {
         
         rootView.tooltip.closeButton.rx.tap.bind(onNext: { [weak self] in
             guard let self else { return }
-            self.hideTooltip()
+            self.hideTooltipFromMap()
         }).disposed(by: disposeBag)
     }
     
@@ -275,7 +275,7 @@ extension ORBMapViewController {
         let tapGestureRecognizer = UITapGestureRecognizer()
         tapGestureRecognizer.rx.event.subscribe(onNext: { [weak self] gesture in
             guard let self else { return }
-            self.hideTooltip()
+            self.hideTooltipFromMap()
         }).disposed(by: disposeBag)
         rootView.shadingView.addGestureRecognizer(tapGestureRecognizer)
     }
@@ -310,7 +310,7 @@ extension ORBMapViewController {
         // 툴팁 보이기
         rootView.tooltip.configure(with: marker.placeInfo)
         rootView.tooltipAnchorPoint = markerPoint!
-        showTooltip()
+        showTooltipOnMap()
         
         let tilt = rootView.naverMapView.mapView.cameraPosition.tilt
         if tilt > 30 {
@@ -398,12 +398,12 @@ extension ORBMapViewController {
         present(questCompleteAlertController, animated: true)
     }
     
-    private func showTooltip() {
+    private func showTooltipOnMap() {
         tooltipHelper.showTooltip()
         rootView.compass.isHidden = true
     }
     
-    private func hideTooltip() {
+    private func hideTooltipFromMap() {
         tooltipHelper.hideTooltip { [weak self] in self?.selectedMarker = nil }
         rootView.compass.isHidden = false
     }
@@ -444,7 +444,7 @@ extension ORBMapViewController: NMFMapViewCameraDelegate {
             
             guard selectedMarker != nil else { return }
             // 툴팁 숨기기
-            hideTooltip()
+            hideTooltipFromMap()
         default:
             return
         }
@@ -486,7 +486,7 @@ extension ORBMapViewController: NMFMapViewTouchDelegate {
     func mapView(_ mapView: NMFMapView, didTapMap latlng: NMGLatLng, point: CGPoint) {
         if selectedMarker != nil {
             // 툴팁 숨김처리
-            hideTooltip()
+            hideTooltipFromMap()
         }
     }
     
@@ -526,7 +526,7 @@ extension ORBMapViewController: CLLocationManagerDelegate {
             case .fullAccuracy:
                 DispatchQueue.main.async { [weak self] in
                     guard let self else { return }
-                    self.hideTooltip()
+                    self.hideTooltipFromMap()
                     self.focusToMyPosition()
                     self.rootView.naverMapView.mapView.positionMode = .direction
                     setLocationOverlayHiddenState(to: false)

--- a/Offroad-iOS/Offroad-iOS/Presentation/QuestMap/ViewControllers/ORBMapViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/QuestMap/ViewControllers/ORBMapViewController.swift
@@ -438,13 +438,6 @@ extension ORBMapViewController {
         rootView.hideTooltip { [weak self] in self?.selectedMarker = nil }
     }
     
-    private func setLocationOverlayHiddenState(to isHidden: Bool) {
-        DispatchQueue.main.async { [weak self] in
-            guard let self else { return }
-            self.rootView.naverMapView.mapView.locationOverlay.hidden = isHidden
-        }
-    }
-    
 }
 
 //MARK: - NMFMapViewCameraDelegate
@@ -549,6 +542,13 @@ extension ORBMapViewController: CLLocationManagerDelegate {
     }
     
     func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+        
+        func setLocationOverlayHiddenState(to isHidden: Bool) {
+            DispatchQueue.main.async { [weak self] in
+                self?.rootView.naverMapView.mapView.locationOverlay.hidden = isHidden
+            }
+        }
+        
         viewModel.checkLocationAuthorizationStatus { authorizationCase in
             switch authorizationCase {
             case .notDetermined, .reducedAccuracy:
@@ -559,14 +559,14 @@ extension ORBMapViewController: CLLocationManagerDelegate {
                     self.hideTooltip()
                     self.focusToMyPosition()
                     self.rootView.naverMapView.mapView.positionMode = .direction
-                    self.setLocationOverlayHiddenState(to: false)
+                    setLocationOverlayHiddenState(to: false)
                 }
             case .denied, .restricted:
                 self.showToast(message: AlertMessage.locationUnauthorizedAdventureMessage, inset: 66)
-                self.setLocationOverlayHiddenState(to: true)
+                setLocationOverlayHiddenState(to: true)
             case .servicesDisabled:
                 self.viewModel.locationServicesDisabledRelay.accept(())
-                self.setLocationOverlayHiddenState(to: true)
+                setLocationOverlayHiddenState(to: true)
             }
         }
     }

--- a/Offroad-iOS/Offroad-iOS/Presentation/QuestMap/Views/ORBMapHelper.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/QuestMap/Views/ORBMapHelper.swift
@@ -1,0 +1,80 @@
+//
+//  ORBMapHelper.swift
+//  Offroad-iOS
+//
+//  Created by 김민성 on 2/6/25.
+//
+
+import Foundation
+
+import NMapsMap
+
+final class ORBMapHelper {
+    
+    //MARK: - Properties
+    
+    let mapView: NMFMapView
+    
+    //MARK: - Life Cycle
+    
+    init (map: NMFMapView) {
+        self.mapView = map
+    }
+    
+}
+
+extension ORBMapHelper {
+    
+    //MARK: - Func
+    
+    /// 지도의 카메라를 지정된 좌표(`NMGLatLng`)로 이동시키는 함수
+    /// - Parameters:
+    ///   - coordinate: 이동하고자 하는 좌표값. `NMGLatLng` 타입
+    ///   - animationCurve: 지도가 움직일 때의 애니메이션 종류. NMFCameraUpdateAnimation 타입.
+    ///   - animationDuration: 애니메이션 시간. 0으로 설정할 경우, 애니메이션 없이 바로 이동. 기본값은 NAVER Map iOS SDK에서 설정하는 0.2
+    ///   - reason: 카메라 이동에 사용될 `NMFCameraUpdate` 타입의 `reason` 속성에 할당할 값. 기본값은 `NMFMapChangedByDeveloper`이며, -1에 해당. (개발자가 API를 호출해 카메라가 움직였음을 의미)
+    ///   - completion: 카메라 이동이 완료되었을 때 호출되는 콜백 블록. 애니메이션이 있으면 완전히 끝난 후에 호출됩니다. `Bool` 타입의 매개변수는 카메라 이동이 완료되기 전에 다른 카메라 이동이 호출되거나 사용자가 제스처로 지도를 조작한 경우 `true`입니다.
+    func moveCamera(
+        scrollTo coordinate: NMGLatLng,
+        animationCurve: NMFCameraUpdateAnimation = .easeOut,
+        // NAVER Map iOS SDK에서 지정하는 기본값이 0.2
+        animationDuration: TimeInterval = 0.2,
+        reason: Int32 = Int32(NMFMapChangedByDeveloper),
+        completion: ((Bool) -> Void)? = nil
+    ) {
+        let cameraUpdate = NMFCameraUpdate(scrollTo: coordinate)
+        cameraUpdate.reason = reason
+        cameraUpdate.animation = animationCurve
+        cameraUpdate.animationDuration = animationDuration
+        DispatchQueue.main.async { [weak self] in
+            self?.mapView.moveCamera(cameraUpdate) { isCancelled in
+                completion?(isCancelled)
+            }
+        }
+    }
+    
+    /// 지도의 카메라를 현재 위치에서 `delta` 포인트만큼 이동시키는 함수
+    /// - Parameters:
+    ///   - delta: 이동할 거리. 가로, 세로로 `pt` 단위이며 각각의 값을 `x`, `y` 속성으로 갖는 `CGPoint` 값.
+    ///   - animationCurve: 지도가 움직일 때의 애니메이션 종류. NMFCameraUpdateAnimation 타입.
+    ///   - animationDuration: 애니메이션 시간. 0으로 설정할 경우, 애니메이션 없이 바로 이동. 기본값은 NAVER Map iOS SDK에서 설정하는 0.2
+    ///   - reason: 카메라 이동에 사용될 `NMFCameraUpdate` 타입의 `reason` 속성에 할당할 값. 기본값은 `NMFMapChangedByDeveloper`이며, -1에 해당. (개발자가 API를 호출해 카메라가 움직였음을 의미)
+    ///   - completion: 카메라 이동이 완료되었을 때 호출되는 콜백 블록. 애니메이션이 있으면 완전히 끝난 후에 호출됩니다. `Bool` 타입의 매개변수는 카메라 이동이 완료되기 전에 다른 카메라 이동이 호출되거나 사용자가 제스처로 지도를 조작한 경우 `true`입니다.
+    func moveCamera(
+        scrollBy delta: CGPoint,
+        animationCurve: NMFCameraUpdateAnimation = .easeOut,
+        // NAVER Map iOS SDK에서 지정하는 기본값이 0.2
+        animationDuration: TimeInterval = 0.2,
+        reason: Int32 = Int32(NMFMapChangedByDeveloper),
+        completion: ((Bool) -> Void)? = nil
+    ) {
+        let cameraUpdate = NMFCameraUpdate(scrollBy: delta)
+        cameraUpdate.reason = reason
+        cameraUpdate.animation = animationCurve
+        cameraUpdate.animationDuration = animationDuration
+        mapView.moveCamera(cameraUpdate) { isCancelled in
+            completion?(isCancelled)
+        }
+    }
+    
+}

--- a/Offroad-iOS/Offroad-iOS/Presentation/QuestMap/Views/ORBMapHelper.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/QuestMap/Views/ORBMapHelper.swift
@@ -13,7 +13,7 @@ final class ORBMapHelper {
     
     //MARK: - Properties
     
-    let mapView: NMFMapView
+    unowned let mapView: NMFMapView
     
     //MARK: - Life Cycle
     

--- a/Offroad-iOS/Offroad-iOS/Presentation/QuestMap/Views/ORBMapView.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/QuestMap/Views/ORBMapView.swift
@@ -319,4 +319,55 @@ extension ORBMapView {
         tooltipHidingAnimator.startAnimation()
     }
     
+    /// 지도의 카메라를 지정된 좌표(`NMGLatLng`)로 이동시키는 함수
+    /// - Parameters:
+    ///   - coordinate: 이동하고자 하는 좌표값. `NMGLatLng` 타입
+    ///   - animationCurve: 지도가 움직일 때의 애니메이션 종류. NMFCameraUpdateAnimation 타입.
+    ///   - animationDuration: 애니메이션 시간. 0으로 설정할 경우, 애니메이션 없이 바로 이동. 기본값은 NAVER Map iOS SDK에서 설정하는 0.2
+    ///   - reason: 카메라 이동에 사용될 `NMFCameraUpdate` 타입의 `reason` 속성에 할당할 값. 기본값은 `NMFMapChangedByDeveloper`이며, -1에 해당. (개발자가 API를 호출해 카메라가 움직였음을 의미)
+    ///   - completion: 카메라 이동이 완료되었을 때 호출되는 콜백 블록. 애니메이션이 있으면 완전히 끝난 후에 호출됩니다. `Bool` 타입의 매개변수는 카메라 이동이 완료되기 전에 다른 카메라 이동이 호출되거나 사용자가 제스처로 지도를 조작한 경우 `true`입니다.
+    func moveCamera(
+        scrollTo coordinate: NMGLatLng,
+        animationCurve: NMFCameraUpdateAnimation = .easeOut,
+        // NAVER Map iOS SDK에서 지정하는 기본값이 0.2
+        animationDuration: TimeInterval = 0.2,
+        reason: Int32 = Int32(NMFMapChangedByDeveloper),
+        completion: ((Bool) -> Void)? = nil
+    ) {
+        let cameraUpdate = NMFCameraUpdate(scrollTo: coordinate)
+        cameraUpdate.reason = reason
+        cameraUpdate.animation = animationCurve
+        cameraUpdate.animationDuration = animationDuration
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            self.naverMapView.mapView.moveCamera(cameraUpdate) { isCancelled in
+                completion?(isCancelled)
+            }
+        }
+    }
+    
+    /// 지도의 카메라를 현재 위치에서 `delta` 포인트만큼 이동시키는 함수
+    /// - Parameters:
+    ///   - delta: 이동할 거리. 가로, 세로로 `pt` 단위이며 각각의 값을 `x`, `y` 속성으로 갖는 `CGPoint` 값.
+    ///   - animationCurve: 지도가 움직일 때의 애니메이션 종류. NMFCameraUpdateAnimation 타입.
+    ///   - animationDuration: 애니메이션 시간. 0으로 설정할 경우, 애니메이션 없이 바로 이동. 기본값은 NAVER Map iOS SDK에서 설정하는 0.2
+    ///   - reason: 카메라 이동에 사용될 `NMFCameraUpdate` 타입의 `reason` 속성에 할당할 값. 기본값은 `NMFMapChangedByDeveloper`이며, -1에 해당. (개발자가 API를 호출해 카메라가 움직였음을 의미)
+    ///   - completion: 카메라 이동이 완료되었을 때 호출되는 콜백 블록. 애니메이션이 있으면 완전히 끝난 후에 호출됩니다. `Bool` 타입의 매개변수는 카메라 이동이 완료되기 전에 다른 카메라 이동이 호출되거나 사용자가 제스처로 지도를 조작한 경우 `true`입니다.
+    func moveCamera(
+        scrollBy delta: CGPoint,
+        animationCurve: NMFCameraUpdateAnimation = .easeOut,
+        // NAVER Map iOS SDK에서 지정하는 기본값이 0.2
+        animationDuration: TimeInterval = 0.2,
+        reason: Int32 = Int32(NMFMapChangedByDeveloper),
+        completion: ((Bool) -> Void)? = nil
+    ) {
+        let cameraUpdate = NMFCameraUpdate(scrollBy: delta)
+        cameraUpdate.reason = reason
+        cameraUpdate.animation = animationCurve
+        cameraUpdate.animationDuration = animationDuration
+        naverMapView.mapView.moveCamera(cameraUpdate) { isCancelled in
+            completion?(isCancelled)
+        }
+    }
+    
 }

--- a/Offroad-iOS/Offroad-iOS/Presentation/QuestMap/Views/ORBMapView.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/QuestMap/Views/ORBMapView.swift
@@ -38,6 +38,12 @@ class ORBMapView: UIView {
     lazy var tooltipCenterYConstraint = tooltip.centerYAnchor.constraint(equalTo: self.topAnchor, constant: 0)
     lazy var tooltipCenterXConstraint = tooltip.centerXAnchor.constraint(equalTo: self.leadingAnchor, constant: 0)
     
+    var isTooltipShown: Bool = false
+    private let shadingAnimator = UIViewPropertyAnimator(duration: 0.3, dampingRatio: 1)
+    private let tooltipTransparencyAnimator = UIViewPropertyAnimator(duration: 0.2, dampingRatio: 1)
+    private let tooltipShowingAnimator = UIViewPropertyAnimator(duration: 0.4, dampingRatio: 0.8)
+    private let tooltipHidingAnimator = UIViewPropertyAnimator(duration: 0.25, dampingRatio: 1)
+    
     var tooltipAnchorPoint: CGPoint = .zero {
         didSet {
             updateTooltipPosition()
@@ -259,6 +265,58 @@ extension ORBMapView {
         default:
             break
         }
+    }
+    
+    func showTooltip(completion: (() -> Void)? = nil) {
+        tooltip.transform = CGAffineTransform(scaleX: 0.1, y: 0.1)
+        tooltip.alpha = 0
+        layoutIfNeeded()
+        tooltipHidingAnimator.stopAnimation(true)
+        
+        shadingAnimator.addAnimations { [weak self] in
+            self?.shadingView.backgroundColor = .blackOpacity(.black25)
+        }
+        tooltipTransparencyAnimator.addAnimations { [weak self] in
+            self?.tooltip.alpha = 1
+        }
+        tooltipShowingAnimator.addAnimations { [weak self] in
+            self?.tooltip.transform = .identity
+            self?.layoutIfNeeded()
+        }
+        tooltipShowingAnimator.addCompletion { _ in
+            completion?()
+        }
+        
+        isTooltipShown = true
+        compass.isHidden = true
+        shadingView.isUserInteractionEnabled = true
+        tooltipTransparencyAnimator.startAnimation()
+        shadingAnimator.startAnimation()
+        tooltipShowingAnimator.startAnimation()
+    }
+    
+    func hideTooltip(completion: (() -> Void)? = nil) {
+        guard isTooltipShown else { return }
+        tooltipShowingAnimator.stopAnimation(true)
+        
+        shadingAnimator.addAnimations { [weak self] in
+            self?.shadingView.backgroundColor = .clear
+        }
+        tooltipHidingAnimator.addAnimations { [weak self] in
+            self?.tooltip.transform = CGAffineTransform(scaleX: 0.05, y: 0.05)
+        }
+        tooltipHidingAnimator.addAnimations({ [weak self] in
+            self?.tooltip.alpha = 0
+        }, delayFactor: 0.3)
+        tooltipHidingAnimator.addCompletion { [weak self] _ in
+            self?.tooltip.configure(with: nil)
+            self?.shadingView.isUserInteractionEnabled = false
+            completion?()
+        }
+        isTooltipShown = false
+        compass.isHidden = false
+        shadingAnimator.startAnimation()
+        tooltipHidingAnimator.startAnimation()
     }
     
 }

--- a/Offroad-iOS/Offroad-iOS/Presentation/QuestMap/Views/ORBMapView.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/QuestMap/Views/ORBMapView.swift
@@ -38,12 +38,6 @@ class ORBMapView: UIView {
     lazy var tooltipCenterYConstraint = tooltip.centerYAnchor.constraint(equalTo: self.topAnchor, constant: 0)
     lazy var tooltipCenterXConstraint = tooltip.centerXAnchor.constraint(equalTo: self.leadingAnchor, constant: 0)
     
-    var isTooltipShown: Bool = false
-    private let shadingAnimator = UIViewPropertyAnimator(duration: 0.3, dampingRatio: 1)
-    private let tooltipTransparencyAnimator = UIViewPropertyAnimator(duration: 0.2, dampingRatio: 1)
-    private let tooltipShowingAnimator = UIViewPropertyAnimator(duration: 0.4, dampingRatio: 0.8)
-    private let tooltipHidingAnimator = UIViewPropertyAnimator(duration: 0.25, dampingRatio: 1)
-    
     var tooltipAnchorPoint: CGPoint = .zero {
         didSet {
             updateTooltipPosition()
@@ -264,109 +258,6 @@ extension ORBMapView {
             }
         default:
             break
-        }
-    }
-    
-    func showTooltip(completion: (() -> Void)? = nil) {
-        tooltip.transform = CGAffineTransform(scaleX: 0.1, y: 0.1)
-        tooltip.alpha = 0
-        layoutIfNeeded()
-        tooltipHidingAnimator.stopAnimation(true)
-        
-        shadingAnimator.addAnimations { [weak self] in
-            self?.shadingView.backgroundColor = .blackOpacity(.black25)
-        }
-        tooltipTransparencyAnimator.addAnimations { [weak self] in
-            self?.tooltip.alpha = 1
-        }
-        tooltipShowingAnimator.addAnimations { [weak self] in
-            self?.tooltip.transform = .identity
-            self?.layoutIfNeeded()
-        }
-        tooltipShowingAnimator.addCompletion { _ in
-            completion?()
-        }
-        
-        isTooltipShown = true
-        compass.isHidden = true
-        shadingView.isUserInteractionEnabled = true
-        tooltipTransparencyAnimator.startAnimation()
-        shadingAnimator.startAnimation()
-        tooltipShowingAnimator.startAnimation()
-    }
-    
-    func hideTooltip(completion: (() -> Void)? = nil) {
-        guard isTooltipShown else { return }
-        tooltipShowingAnimator.stopAnimation(true)
-        
-        shadingAnimator.addAnimations { [weak self] in
-            self?.shadingView.backgroundColor = .clear
-        }
-        tooltipHidingAnimator.addAnimations { [weak self] in
-            self?.tooltip.transform = CGAffineTransform(scaleX: 0.05, y: 0.05)
-        }
-        tooltipHidingAnimator.addAnimations({ [weak self] in
-            self?.tooltip.alpha = 0
-        }, delayFactor: 0.3)
-        tooltipHidingAnimator.addCompletion { [weak self] _ in
-            self?.tooltip.configure(with: nil)
-            self?.shadingView.isUserInteractionEnabled = false
-            completion?()
-        }
-        isTooltipShown = false
-        compass.isHidden = false
-        shadingAnimator.startAnimation()
-        tooltipHidingAnimator.startAnimation()
-    }
-    
-    /// 지도의 카메라를 지정된 좌표(`NMGLatLng`)로 이동시키는 함수
-    /// - Parameters:
-    ///   - coordinate: 이동하고자 하는 좌표값. `NMGLatLng` 타입
-    ///   - animationCurve: 지도가 움직일 때의 애니메이션 종류. NMFCameraUpdateAnimation 타입.
-    ///   - animationDuration: 애니메이션 시간. 0으로 설정할 경우, 애니메이션 없이 바로 이동. 기본값은 NAVER Map iOS SDK에서 설정하는 0.2
-    ///   - reason: 카메라 이동에 사용될 `NMFCameraUpdate` 타입의 `reason` 속성에 할당할 값. 기본값은 `NMFMapChangedByDeveloper`이며, -1에 해당. (개발자가 API를 호출해 카메라가 움직였음을 의미)
-    ///   - completion: 카메라 이동이 완료되었을 때 호출되는 콜백 블록. 애니메이션이 있으면 완전히 끝난 후에 호출됩니다. `Bool` 타입의 매개변수는 카메라 이동이 완료되기 전에 다른 카메라 이동이 호출되거나 사용자가 제스처로 지도를 조작한 경우 `true`입니다.
-    func moveCamera(
-        scrollTo coordinate: NMGLatLng,
-        animationCurve: NMFCameraUpdateAnimation = .easeOut,
-        // NAVER Map iOS SDK에서 지정하는 기본값이 0.2
-        animationDuration: TimeInterval = 0.2,
-        reason: Int32 = Int32(NMFMapChangedByDeveloper),
-        completion: ((Bool) -> Void)? = nil
-    ) {
-        let cameraUpdate = NMFCameraUpdate(scrollTo: coordinate)
-        cameraUpdate.reason = reason
-        cameraUpdate.animation = animationCurve
-        cameraUpdate.animationDuration = animationDuration
-        DispatchQueue.main.async { [weak self] in
-            guard let self else { return }
-            self.naverMapView.mapView.moveCamera(cameraUpdate) { isCancelled in
-                completion?(isCancelled)
-            }
-        }
-    }
-    
-    /// 지도의 카메라를 현재 위치에서 `delta` 포인트만큼 이동시키는 함수
-    /// - Parameters:
-    ///   - delta: 이동할 거리. 가로, 세로로 `pt` 단위이며 각각의 값을 `x`, `y` 속성으로 갖는 `CGPoint` 값.
-    ///   - animationCurve: 지도가 움직일 때의 애니메이션 종류. NMFCameraUpdateAnimation 타입.
-    ///   - animationDuration: 애니메이션 시간. 0으로 설정할 경우, 애니메이션 없이 바로 이동. 기본값은 NAVER Map iOS SDK에서 설정하는 0.2
-    ///   - reason: 카메라 이동에 사용될 `NMFCameraUpdate` 타입의 `reason` 속성에 할당할 값. 기본값은 `NMFMapChangedByDeveloper`이며, -1에 해당. (개발자가 API를 호출해 카메라가 움직였음을 의미)
-    ///   - completion: 카메라 이동이 완료되었을 때 호출되는 콜백 블록. 애니메이션이 있으면 완전히 끝난 후에 호출됩니다. `Bool` 타입의 매개변수는 카메라 이동이 완료되기 전에 다른 카메라 이동이 호출되거나 사용자가 제스처로 지도를 조작한 경우 `true`입니다.
-    func moveCamera(
-        scrollBy delta: CGPoint,
-        animationCurve: NMFCameraUpdateAnimation = .easeOut,
-        // NAVER Map iOS SDK에서 지정하는 기본값이 0.2
-        animationDuration: TimeInterval = 0.2,
-        reason: Int32 = Int32(NMFMapChangedByDeveloper),
-        completion: ((Bool) -> Void)? = nil
-    ) {
-        let cameraUpdate = NMFCameraUpdate(scrollBy: delta)
-        cameraUpdate.reason = reason
-        cameraUpdate.animation = animationCurve
-        cameraUpdate.animationDuration = animationDuration
-        naverMapView.mapView.moveCamera(cameraUpdate) { isCancelled in
-            completion?(isCancelled)
         }
     }
     


### PR DESCRIPTION
### 🌴 작업한 브랜치
- #461 

### ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->

### 지도 뷰의 코드를 전반적으로 개선하였습니다. 
- #### `ORBMapHelper`와 `PlaceInfoTooltipHelper` 추가

  기존 코드는 `ORBMapViewController`에서 너무 많은 일을 담당하고 있다고 판단하였습니다. 
기존 `ORBMapViewController`는 터치 이벤트를 처리하고, mapView(네이버 지도)의 delegate, locationManager의 delegate 등의 역할을 맡았는데요, 특히, 툴팁과 지도에 부드러운 애니메이션을 적용하기 위한 함수들이 `ViewController`에서 모두 구현되어 있었습니다.

  이로 인해 `ViewController`가 너무 커졌다고 생각했습니다. 
그렇다고 이 애니메이션 코드를 viewModel로 옮기기에는 애매한 게, 애니메이션 코드는 model과는 무관하게 그저 뷰의 UI가 변하는 것만 구현되어있어서, viewModel에서 구현하는 것도 알맞은 위치가 아니라고 생각하였고, view에도 옮겨보았으나(`ORMMapView`) 이 또한 view의 크기를 지나치게 키운다고 생각하여 결국 해당 함수의 역할을 별도의 다른 객체에 분리하는 것이 바람직하다고 판단하였습니다.

  이를 위해 `ORBMapHelper`와 `PlaceInfoTooltipHelper` 두 타입을 추가헀습니다. 
`ORBMapHelper`의 역할은 지도를 움직이는 애니메이션을 구현하는 것 입니다.
`PlaceInfoTooltipHelper`의 역할은 지도에 보일 tooltip이 생기고 사라질 때의 애니메이션을 구현하는 것 입니다. 
뷰컨트롤러에서 두 helper를 생성하여, 지도/툴팁 의 동작(애니메이션)과 관련한 일을 helper가 수행합니다.

  지도의 움직임, 툴팁의 표시와 관련한 애니메이션 역할을 별도의 타입으로 분리함으로써 뷰컨트롤러의 부담을 덜어내고 유지보수성을 높였다고 생각합니다. 

- #### 지도의 위치 불일치로 인한 탐험 실패 시, 문구의 '한 번' 이 강조되어보이는 문제를 해결하였습니다. 

  일일 방문 횟수 제한으로 인해 탐험 실패 시 이를 안내하기 위해 '한 번' 이라는 글자를 강조하는데, 위치 불일치로 인한 탐험 실패 문구에도 반영되는 문제가 있었으며, 이를 해결하였습니다. 

- #### 개발용 앱에서 지도의 '내 위치' 버튼이 잘 눌리지 않는 문제를 해결하였습니다. 

<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### ❗️PR Point
<!-- 부족했던 점 혹은 개선하고 싶은 방향이 있다면 얘기해주세요 -->

<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->

|뷰|설명|
|:------:|:---:|
|        |     |


- Resolved: #461 
