### PR TITLE
[Refactor] #463 - 채팅 입력창 기능 분리

### DIFF
--- a/Offroad-iOS/Offroad-iOS.xcodeproj/project.pbxproj
+++ b/Offroad-iOS/Offroad-iOS.xcodeproj/project.pbxproj
@@ -369,6 +369,8 @@
 		4E99008B2CE0CB61007EEFF7 /* UITextView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E99008A2CE0CB61007EEFF7 /* UITextView+.swift */; };
 		4EA272322D5793BA00F64B20 /* ChatTextInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EA272312D5793BA00F64B20 /* ChatTextInputView.swift */; };
 		4EA272332D5793BA00F64B20 /* ChatTextInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EA272312D5793BA00F64B20 /* ChatTextInputView.swift */; };
+		4EA272552D58E27300F64B20 /* ChatTextDisplayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EA272542D58E27300F64B20 /* ChatTextDisplayView.swift */; };
+		4EA272562D58E27300F64B20 /* ChatTextDisplayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EA272542D58E27300F64B20 /* ChatTextDisplayView.swift */; };
 		4EA5F4EE2D4C96BD00A59AB1 /* LogPrinterManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EA5F4EC2D4C96BD00A59AB1 /* LogPrinterManager.swift */; };
 		4EA5F4F12D4C970600A59AB1 /* LogPrinterWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EA5F4EF2D4C970600A59AB1 /* LogPrinterWindow.swift */; };
 		4EA5F4F32D4C975C00A59AB1 /* LogPrinterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EA5F4F22D4C975C00A59AB1 /* LogPrinterViewController.swift */; };
@@ -676,6 +678,7 @@
 		4E9900872CE0768B007EEFF7 /* loading2.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = loading2.json; sourceTree = "<group>"; };
 		4E99008A2CE0CB61007EEFF7 /* UITextView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextView+.swift"; sourceTree = "<group>"; };
 		4EA272312D5793BA00F64B20 /* ChatTextInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatTextInputView.swift; sourceTree = "<group>"; };
+		4EA272542D58E27300F64B20 /* ChatTextDisplayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatTextDisplayView.swift; sourceTree = "<group>"; };
 		4EA5F4EC2D4C96BD00A59AB1 /* LogPrinterManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogPrinterManager.swift; sourceTree = "<group>"; };
 		4EA5F4EF2D4C970600A59AB1 /* LogPrinterWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogPrinterWindow.swift; sourceTree = "<group>"; };
 		4EA5F4F22D4C975C00A59AB1 /* LogPrinterViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogPrinterViewController.swift; sourceTree = "<group>"; };
@@ -1709,6 +1712,7 @@
 		4EA2722B2D578D5A00F64B20 /* Chat */ = {
 			isa = PBXGroup;
 			children = (
+				4EA272532D58E25000F64B20 /* ChatTextDisplay */,
 				4EA2722D2D578D8200F64B20 /* ChatTextInput */,
 			);
 			path = Chat;
@@ -1720,6 +1724,14 @@
 				4EA272312D5793BA00F64B20 /* ChatTextInputView.swift */,
 			);
 			path = ChatTextInput;
+			sourceTree = "<group>";
+		};
+		4EA272532D58E25000F64B20 /* ChatTextDisplay */ = {
+			isa = PBXGroup;
+			children = (
+				4EA272542D58E27300F64B20 /* ChatTextDisplayView.swift */,
+			);
+			path = ChatTextDisplay;
 			sourceTree = "<group>";
 		};
 		4EA5F4EB2D4C960500A59AB1 /* LogPrinter */ = {
@@ -3405,6 +3417,7 @@
 				D064669F2C898E9D00CF10FD /* EmblemListResponseDTO.swift in Sources */,
 				D03C835E2C61E44700F3094D /* TokenIntercepter.swift in Sources */,
 				4E03942F2C2A9DCE007F0517 /* SceneDelegate.swift in Sources */,
+				4EA272562D58E27300F64B20 /* ChatTextDisplayView.swift in Sources */,
 				4E3A32692CE510DF007228D0 /* CharacterChatAPI.swift in Sources */,
 				4EFC7D252D066D110068367E /* ScrollLoading.swift in Sources */,
 				D0E7961E2C45280F005B47A5 /* SocialLoginResponseDTO.swift in Sources */,
@@ -3476,6 +3489,7 @@
 				4E4F316B2D4718F400C3B2FF /* ORBMapView.swift in Sources */,
 				4E4F317D2D4718F400C3B2FF /* CustomIntensityBlurView.swift in Sources */,
 				4E4F317E2D4718F400C3B2FF /* KakaoAuthManager.swift in Sources */,
+				4EA272552D58E27300F64B20 /* ChatTextDisplayView.swift in Sources */,
 				4E4F317F2D4718F400C3B2FF /* MarketingConsentRequestDTO.swift in Sources */,
 				4EA5F4F52D4C977300A59AB1 /* LogPrinterView.swift in Sources */,
 				4E4F31802D4718F400C3B2FF /* CharacterChatLogViewModel.swift in Sources */,

--- a/Offroad-iOS/Offroad-iOS.xcodeproj/project.pbxproj
+++ b/Offroad-iOS/Offroad-iOS.xcodeproj/project.pbxproj
@@ -367,6 +367,8 @@
 		4E9900882CE0768B007EEFF7 /* loading1.json in Resources */ = {isa = PBXBuildFile; fileRef = 4E9900862CE0768B007EEFF7 /* loading1.json */; };
 		4E9900892CE0768B007EEFF7 /* loading2.json in Resources */ = {isa = PBXBuildFile; fileRef = 4E9900872CE0768B007EEFF7 /* loading2.json */; };
 		4E99008B2CE0CB61007EEFF7 /* UITextView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E99008A2CE0CB61007EEFF7 /* UITextView+.swift */; };
+		4EA272322D5793BA00F64B20 /* ChatTextInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EA272312D5793BA00F64B20 /* ChatTextInputView.swift */; };
+		4EA272332D5793BA00F64B20 /* ChatTextInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EA272312D5793BA00F64B20 /* ChatTextInputView.swift */; };
 		4EA5F4EE2D4C96BD00A59AB1 /* LogPrinterManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EA5F4EC2D4C96BD00A59AB1 /* LogPrinterManager.swift */; };
 		4EA5F4F12D4C970600A59AB1 /* LogPrinterWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EA5F4EF2D4C970600A59AB1 /* LogPrinterWindow.swift */; };
 		4EA5F4F32D4C975C00A59AB1 /* LogPrinterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EA5F4F22D4C975C00A59AB1 /* LogPrinterViewController.swift */; };
@@ -673,6 +675,7 @@
 		4E9900862CE0768B007EEFF7 /* loading1.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = loading1.json; sourceTree = "<group>"; };
 		4E9900872CE0768B007EEFF7 /* loading2.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = loading2.json; sourceTree = "<group>"; };
 		4E99008A2CE0CB61007EEFF7 /* UITextView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextView+.swift"; sourceTree = "<group>"; };
+		4EA272312D5793BA00F64B20 /* ChatTextInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatTextInputView.swift; sourceTree = "<group>"; };
 		4EA5F4EC2D4C96BD00A59AB1 /* LogPrinterManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogPrinterManager.swift; sourceTree = "<group>"; };
 		4EA5F4EF2D4C970600A59AB1 /* LogPrinterWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogPrinterWindow.swift; sourceTree = "<group>"; };
 		4EA5F4F22D4C975C00A59AB1 /* LogPrinterViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogPrinterViewController.swift; sourceTree = "<group>"; };
@@ -1703,6 +1706,22 @@
 			path = Lotties;
 			sourceTree = "<group>";
 		};
+		4EA2722B2D578D5A00F64B20 /* Chat */ = {
+			isa = PBXGroup;
+			children = (
+				4EA2722D2D578D8200F64B20 /* ChatTextInput */,
+			);
+			path = Chat;
+			sourceTree = "<group>";
+		};
+		4EA2722D2D578D8200F64B20 /* ChatTextInput */ = {
+			isa = PBXGroup;
+			children = (
+				4EA272312D5793BA00F64B20 /* ChatTextInputView.swift */,
+			);
+			path = ChatTextInput;
+			sourceTree = "<group>";
+		};
 		4EA5F4EB2D4C960500A59AB1 /* LogPrinter */ = {
 			isa = PBXGroup;
 			children = (
@@ -2221,6 +2240,7 @@
 		D018BB0C2C401F5F0048B6DF /* Components */ = {
 			isa = PBXGroup;
 			children = (
+				4EA2722B2D578D5A00F64B20 /* Chat */,
 				4E1ED3812D188F8C0058C8D9 /* CollectionView */,
 				4EFFAFAF2CE4573D00EFA714 /* NavigationController */,
 				D05C31DE2CDEB55A004761A7 /* AppUtility.swift */,
@@ -3215,6 +3235,7 @@
 				D064669C2C86FCE800CF10FD /* DeleteAccountView.swift in Sources */,
 				D0E7960A2C4522CF005B47A5 /* NetworkService.swift in Sources */,
 				D00A48772C634530008B286A /* SettingBaseView.swift in Sources */,
+				4EA272322D5793BA00F64B20 /* ChatTextInputView.swift in Sources */,
 				D00A487A2C634710008B286A /* SettingBaseCollectionViewCell.swift in Sources */,
 				D05C31DF2CDEB574004761A7 /* AppUtility.swift in Sources */,
 				D0EAF2262C3B7D7F00566543 /* LoginViewController.swift in Sources */,
@@ -3495,6 +3516,7 @@
 				4E4F31A22D4718F400C3B2FF /* MyPageViewController.swift in Sources */,
 				4E4F31A32D4718F400C3B2FF /* QuestListService.swift in Sources */,
 				4E4F31A42D4718F400C3B2FF /* OffroadTabBarController.swift in Sources */,
+				4EA272332D5793BA00F64B20 /* ChatTextInputView.swift in Sources */,
 				4E4F31A52D4718F400C3B2FF /* AdventureAPI.swift in Sources */,
 				4E4F31A62D4718F400C3B2FF /* ZeroDurationAnimator.swift in Sources */,
 				4E4F31A72D4718F400C3B2FF /* SocialLoginRequestDTO.swift in Sources */,

--- a/Offroad-iOS/Offroad-iOS/Global/Components/Chat/ChatTextDisplay/ChatTextDisplayView.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Components/Chat/ChatTextDisplay/ChatTextDisplayView.swift
@@ -72,7 +72,7 @@ public extension ChatTextDisplayView {
             make.top.equalTo(meLabel)
             make.leading.equalTo(meLabel.snp.trailing).offset(10)
             make.trailing.equalToSuperview().inset(24)
-            make.bottom.equalToSuperview().inset(16)
+            make.bottom.equalToSuperview()
         }
     }
     
@@ -139,7 +139,7 @@ public extension ChatTextDisplayView {
         displayTextRelay.accept(text)
     }
     
-    func displayLoading() {
+    func startDisplayLoading() {
         userChatDisplayView.isHidden = true
         userChatDisplayView.text = ""
         loadingAnimationView.isHidden = false
@@ -168,16 +168,20 @@ public extension ChatTextDisplayView {
         }
     }
     
-    func hide(animated: Bool = true, completion: (() -> Void)? = nil) {
+    func hide(erase: Bool = false, animated: Bool = true, completion: (() -> Void)? = nil) {
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
             self.showingAnimator.stopAnimation(true)
             self.hidingAnimator.stopAnimation(true)
             if animated {
                 hidingAnimator.addAnimations { [weak self] in self?.alpha = 0 }
-                hidingAnimator.addCompletion { _ in completion?() }
+                hidingAnimator.addCompletion { [weak self] _ in
+                    if erase { self?.userChatDisplayView.text = "" }
+                    completion?()
+                }
                 hidingAnimator.startAnimation()
             } else {
+                if erase { userChatDisplayView.text = "" }
                 self.alpha = 0
             }
         }

--- a/Offroad-iOS/Offroad-iOS/Global/Components/Chat/ChatTextDisplay/ChatTextDisplayView.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Components/Chat/ChatTextDisplay/ChatTextDisplayView.swift
@@ -176,12 +176,12 @@ public extension ChatTextDisplayView {
             if animated {
                 hidingAnimator.addAnimations { [weak self] in self?.alpha = 0 }
                 hidingAnimator.addCompletion { [weak self] _ in
-                    if erase { self?.userChatDisplayView.text = "" }
+                    if erase { self?.displayTextRelay.accept("") }
                     completion?()
                 }
                 hidingAnimator.startAnimation()
             } else {
-                if erase { userChatDisplayView.text = "" }
+                if erase { displayTextRelay.accept("") }
                 self.alpha = 0
             }
         }

--- a/Offroad-iOS/Offroad-iOS/Global/Components/Chat/ChatTextDisplay/ChatTextDisplayView.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Components/Chat/ChatTextDisplay/ChatTextDisplayView.swift
@@ -48,7 +48,9 @@ public class ChatTextDisplayView: UIView {
     
 }
 
-public extension ChatTextDisplayView {
+//MARK: - Private Extensions
+
+private extension ChatTextDisplayView {
     
     //MARK: - Layout Func
     
@@ -145,6 +147,12 @@ public extension ChatTextDisplayView {
         }
         userChatDisplayViewHeightAnimator.startAnimation()
     }
+    
+}
+
+//MARK: - Public Extensions
+
+public extension ChatTextDisplayView {
     
     //MARK: - Func
     

--- a/Offroad-iOS/Offroad-iOS/Global/Components/Chat/ChatTextDisplay/ChatTextDisplayView.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Components/Chat/ChatTextDisplay/ChatTextDisplayView.swift
@@ -119,8 +119,20 @@ public extension ChatTextDisplayView {
         }).disposed(by: disposeBag)
         
         displayTextRelay.subscribe(onNext: { [weak self] displayText in
-            self?.stopDisplayLoading()
-            self?.userChatDisplayView.text = displayText
+            guard let self else { return }
+            self.stopDisplayLoading()
+            self.userChatDisplayView.text = displayText
+            // userChatDisplayView에 텍스트를 띄울 때 아래에서 올라오도록 구현
+            self.userChatDisplayView.bounds.origin.y = -(self.bounds.height)
+            UIView.animate(
+                withDuration: 0.3,
+                delay: 0,
+                usingSpringWithDamping: 1,
+                initialSpringVelocity: 1
+            ) { [weak self] in
+                self?.userChatDisplayView.bounds.origin.y = 0
+                self?.layoutIfNeeded()
+            }
         }).disposed(by: disposeBag)
     }
     

--- a/Offroad-iOS/Offroad-iOS/Global/Components/Chat/ChatTextDisplay/ChatTextDisplayView.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Components/Chat/ChatTextDisplay/ChatTextDisplayView.swift
@@ -156,10 +156,15 @@ public extension ChatTextDisplayView {
     
     //MARK: - Func
     
+    
+    /// 표시창에 주어진 텍스트를 표시함.
+    /// 표시창에 텍스트를 띄울 때 아래에서 올라오는 애니메이션이 적용됨.
+    /// - Parameter text: 표시할 텍스트
     func display(text: String) {
         displayTextRelay.accept(text)
     }
     
+    /// 현재 표시중이 텍스트를 가리고 로딩 애니메이션을 띄움
     func startDisplayLoading() {
         userChatDisplayView.isHidden = true
         userChatDisplayView.text = ""
@@ -167,6 +172,8 @@ public extension ChatTextDisplayView {
         loadingAnimationView.play()
     }
     
+    /// 현재 로딩중인 애니메이션을 중지 및 숨기고 기존에 표시되었던 텍스트를 표시.
+    /// 이 때에는 아래에서 위로 올라오는 애니메이션이 적용되지 않음.
     func stopDisplayLoading() {
         loadingAnimationView.currentProgress = 0
         loadingAnimationView.pause()
@@ -175,6 +182,8 @@ public extension ChatTextDisplayView {
         userChatDisplayView.isHidden = false
     }
     
+    /// 화면에 표시창을 나타내는 함수. `animated` 매개변수에 `true`를 할당할 경우, fade-in 애니메이션이 적용됨.
+    /// - Parameter animated: fade-in 애니메이션 적용 여부
     func show(animated: Bool = true) {
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
@@ -189,6 +198,11 @@ public extension ChatTextDisplayView {
         }
     }
     
+    /// 화면에서 표시창을 숨기는 함수.
+    /// - Parameters:
+    ///   - erase: 화면에서 숨겨진 후 표시하고 있던 텍스트를 제거할 지 여부. `true`를 할당하면 완전히 숨겨진 후 텍스트를 지우고, `false`를 할당하면 숨겨진 후에도 텍스트를 유지하여 다음 표시 때 텍스트를 여전히 띄움.
+    ///   - animated: 숨겨질 때 fade-out 애니메이션을 적용할 지 여부.
+    ///   - completion: 숨겨진 후 실행할 콜백 함수. 매개변수가 없는 클로저 타입임.
     func hide(erase: Bool = false, animated: Bool = true, completion: (() -> Void)? = nil) {
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }

--- a/Offroad-iOS/Offroad-iOS/Global/Components/Chat/ChatTextDisplay/ChatTextDisplayView.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Components/Chat/ChatTextDisplay/ChatTextDisplayView.swift
@@ -1,0 +1,8 @@
+//
+//  ChatTextDisplayView.swift
+//  Offroad-iOS
+//
+//  Created by 김민성 on 2/9/25.
+//
+
+import Foundation

--- a/Offroad-iOS/Offroad-iOS/Global/Components/Chat/ChatTextDisplay/ChatTextDisplayView.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Components/Chat/ChatTextDisplay/ChatTextDisplayView.swift
@@ -5,4 +5,182 @@
 //  Created by 김민성 on 2/9/25.
 //
 
-import Foundation
+import UIKit
+
+import Lottie
+import RxSwift
+import RxCocoa
+import SnapKit
+
+public class ChatTextDisplayView: UIView {
+    
+    //MARK: - Properties
+    
+    private let userChatDisplayViewHeightAnimator = UIViewPropertyAnimator(duration: 0.3, dampingRatio: 1)
+    private let showingAnimator = UIViewPropertyAnimator(duration: 0.5, dampingRatio: 1)
+    private let hidingAnimator = UIViewPropertyAnimator(duration: 0.3, dampingRatio: 1)
+    
+    private var disposeBag = DisposeBag()
+    private var displayTextRelay = BehaviorRelay<String>(value: "")
+    
+    private lazy var userChatDisplayViewHeightConstraint = userChatDisplayView.heightAnchor.constraint(equalToConstant: 24)
+    
+    //MARK: - UI Properties
+    
+    private let meLabel = UILabel()
+    private let loadingAnimationView = LottieAnimationView(name: "loading2")
+    private let userChatDisplayView = UITextView()
+    
+    //MARK: - Life Cycle
+    
+    init() {
+        super.init(frame: .zero)
+        
+        setupStyle()
+        setupHierarchy()
+        setupLayout()
+        setupActions()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+}
+
+public extension ChatTextDisplayView {
+    
+    //MARK: - Layout Func
+    
+    private func setupLayout() {
+        meLabel.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+        meLabel.snp.makeConstraints { make in
+            make.top.equalToSuperview().inset(16)
+            make.leading.equalToSuperview().inset(38)
+        }
+        
+        loadingAnimationView.snp.makeConstraints { make in
+            make.centerY.equalTo(meLabel)
+            make.leading.equalTo(meLabel).offset(4.2)
+            make.height.equalTo(50)
+            make.width.equalTo(100)
+        }
+        
+        userChatDisplayView.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        userChatDisplayViewHeightConstraint.isActive = true
+        userChatDisplayView.snp.makeConstraints { make in
+            make.top.equalTo(meLabel)
+            make.leading.equalTo(meLabel.snp.trailing).offset(10)
+            make.trailing.equalToSuperview().inset(24)
+            make.bottom.equalToSuperview().inset(16)
+        }
+    }
+    
+    //MARK: - Private Func
+    
+    private func setupStyle() {
+        backgroundColor = .primary(.white)
+        
+        meLabel.do { label in
+            label.textColor = .main(.main2)
+            label.font = .pretendardFont(ofSize: 16, weight: .regular)
+            label.text = "나 :"
+            label.highlightText(targetText: " ", font: .pretendardFont(ofSize: 16, weight: .medium))
+            label.highlightText(targetText: "나", font: .pretendardFont(ofSize: 16, weight: .bold))
+            label.setLineHeight(percentage: 150)
+        }
+        
+        loadingAnimationView.do { animationView in
+            animationView.isHidden = true
+            animationView.contentMode = .scaleAspectFit
+            animationView.loopMode = .loop
+        }
+        
+        userChatDisplayView.do { textView in
+            textView.textColor = .main(.main2)
+            textView.font = .offroad(style: .iosText)
+            textView.backgroundColor = .clear
+            textView.isSelectable = false
+            textView.textContainerInset = .zero
+            textView.textContainer.lineFragmentPadding = 0
+        }
+    }
+    
+    private func setupHierarchy() {
+        addSubviews(meLabel, userChatDisplayView, loadingAnimationView)
+    }
+    
+    private func setupActions() {
+        userChatDisplayView.rx.text.orEmpty.subscribe(onNext: { [weak self] displayText in
+            guard let self else { return }
+            self.updateChatDisplayViewHeight(
+                height: self.userChatDisplayView.textInputView.frame.height
+            )
+        }).disposed(by: disposeBag)
+        
+        displayTextRelay.subscribe(onNext: { [weak self] displayText in
+            self?.stopDisplayLoading()
+            self?.userChatDisplayView.text = displayText
+        }).disposed(by: disposeBag)
+    }
+    
+    private func updateChatDisplayViewHeight(height: CGFloat, animated: Bool = true) {
+        userChatDisplayViewHeightAnimator.stopAnimation(true)
+        userChatDisplayViewHeightAnimator.addAnimations { [weak self] in
+            self?.userChatDisplayViewHeightConstraint.constant = height
+            self?.superview?.layoutIfNeeded()
+        }
+        userChatDisplayViewHeightAnimator.startAnimation()
+    }
+    
+    //MARK: - Func
+    
+    func display(text: String) {
+        displayTextRelay.accept(text)
+    }
+    
+    func displayLoading() {
+        userChatDisplayView.isHidden = true
+        userChatDisplayView.text = ""
+        loadingAnimationView.isHidden = false
+        loadingAnimationView.play()
+    }
+    
+    func stopDisplayLoading() {
+        loadingAnimationView.currentProgress = 0
+        loadingAnimationView.pause()
+        loadingAnimationView.isHidden = true
+        userChatDisplayView.text = displayTextRelay.value
+        userChatDisplayView.isHidden = false
+    }
+    
+    func show(animated: Bool = true) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            self.hidingAnimator.stopAnimation(true)
+            self.showingAnimator.stopAnimation(true)
+            if animated {
+                self.showingAnimator.addAnimations { [weak self] in self?.alpha = 1 }
+                self.showingAnimator.startAnimation()
+            } else {
+                self.alpha = 1
+            }
+        }
+    }
+    
+    func hide(animated: Bool = true, completion: (() -> Void)? = nil) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            self.showingAnimator.stopAnimation(true)
+            self.hidingAnimator.stopAnimation(true)
+            if animated {
+                hidingAnimator.addAnimations { [weak self] in self?.alpha = 0 }
+                hidingAnimator.addCompletion { _ in completion?() }
+                hidingAnimator.startAnimation()
+            } else {
+                self.alpha = 0
+            }
+        }
+    }
+    
+}

--- a/Offroad-iOS/Offroad-iOS/Global/Components/Chat/ChatTextDisplay/ChatTextDisplayView.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Components/Chat/ChatTextDisplay/ChatTextDisplayView.swift
@@ -139,7 +139,7 @@ public extension ChatTextDisplayView {
     private func updateChatDisplayViewHeight(height: CGFloat, animated: Bool = true) {
         userChatDisplayViewHeightAnimator.stopAnimation(true)
         userChatDisplayViewHeightAnimator.addAnimations { [weak self] in
-            self?.userChatDisplayViewHeightConstraint.constant = height
+            self?.userChatDisplayViewHeightConstraint.constant = height >= 30 ? 40 : 20
             self?.superview?.layoutIfNeeded()
         }
         userChatDisplayViewHeightAnimator.startAnimation()

--- a/Offroad-iOS/Offroad-iOS/Global/Components/Chat/ChatTextDisplay/ChatTextDisplayView.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Components/Chat/ChatTextDisplay/ChatTextDisplayView.swift
@@ -103,6 +103,7 @@ public extension ChatTextDisplayView {
             textView.isSelectable = false
             textView.textContainerInset = .zero
             textView.textContainer.lineFragmentPadding = 0
+            textView.indicatorStyle = .black
         }
     }
     

--- a/Offroad-iOS/Offroad-iOS/Global/Components/Chat/ChatTextInput/ChatTextInputView.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Components/Chat/ChatTextInput/ChatTextInputView.swift
@@ -84,6 +84,7 @@ public extension ChatTextInputView {
             textView.textContainer.lineFragmentPadding = 0
             textView.showsVerticalScrollIndicator = false
             textView.verticalScrollIndicatorInsets = .init(top: 4, left: 0, bottom: 4, right: 10)
+            textView.indicatorStyle = .black
             textView.roundCorners(cornerRadius: 12)
         }
         

--- a/Offroad-iOS/Offroad-iOS/Global/Components/Chat/ChatTextInput/ChatTextInputView.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Components/Chat/ChatTextInput/ChatTextInputView.swift
@@ -146,10 +146,10 @@ extension ChatTextInputView {
             self.hidingAnimator.stopAnimation(true)
             self.showingAnimator.stopAnimation(true)
             if animated {
-                self.showingAnimator.addAnimations { [weak self] in self?.isHidden = false }
+                self.showingAnimator.addAnimations { [weak self] in self?.alpha = 1 }
                 self.showingAnimator.startAnimation()
             } else {
-                self.isHidden = false
+                self.alpha = 1
             }
         }
     }
@@ -160,11 +160,11 @@ extension ChatTextInputView {
             self.showingAnimator.stopAnimation(true)
             self.hidingAnimator.stopAnimation(true)
             if animated {
-                hidingAnimator.addAnimations { [weak self] in self?.isHidden = true }
+                hidingAnimator.addAnimations { [weak self] in self?.alpha = 0 }
                 hidingAnimator.addCompletion { _ in completion?() }
                 hidingAnimator.startAnimation()
             } else {
-                self.isHidden = true
+                self.alpha = 0
             }
         }
     }
@@ -177,9 +177,7 @@ extension ChatTextInputView {
     }
     
     func endChat() {
-        hide() { [weak self] in
-            self?.userChatInputView.text = ""
-        }
+        hide()
         userChatInputView.resignFirstResponder()
     }
     

--- a/Offroad-iOS/Offroad-iOS/Global/Components/Chat/ChatTextInput/ChatTextInputView.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Components/Chat/ChatTextInput/ChatTextInputView.swift
@@ -1,0 +1,41 @@
+//
+//  ChatTextInputView.swift
+//  Offroad-iOS
+//
+//  Created by 김민성 on 2/8/25.
+//
+
+import UIKit
+
+import RxSwift
+import RxCocoa
+
+public class ChatTextInputView: UIView {
+    
+    //MARK: - Properties
+    
+    var disposeBag = DisposeBag()
+    
+    //MARK: - UI Properties
+    
+    private let userChatInputView = UITextView()
+    private let sendButton = ShrinkableButton(shrinkScale: 0.9)
+    
+    public init() {
+        super.init(frame: .zero)
+        
+        
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    
+}
+
+extension ChatTextInputView {
+    
+    
+    
+}

--- a/Offroad-iOS/Offroad-iOS/Global/Components/Chat/ChatTextInput/ChatTextInputView.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Components/Chat/ChatTextInput/ChatTextInputView.swift
@@ -9,22 +9,37 @@ import UIKit
 
 import RxSwift
 import RxCocoa
+import SnapKit
 
 public class ChatTextInputView: UIView {
     
     //MARK: - Properties
     
-    var disposeBag = DisposeBag()
+    var inputTextRelay = PublishRelay<String>()
+    var sendingTextRelay = PublishRelay<String>()
+    
+    private let userChatInputViewHeightRelay = PublishRelay<CGFloat>()
+    private let userChatInputViewHeightAnimator = UIViewPropertyAnimator(duration: 0.3, dampingRatio: 1)
+    
+    private var disposeBag = DisposeBag()
+    
+    private lazy var userChatInputViewHeightConstraint = userChatInputView.heightAnchor.constraint(equalToConstant: 40)
     
     //MARK: - UI Properties
     
     private let userChatInputView = UITextView()
     private let sendButton = ShrinkableButton(shrinkScale: 0.9)
     
+    //MARK: - Life Cycle
+    
     public init() {
         super.init(frame: .zero)
         
+        setupStyle()
+        setupHierarchy()
+        setupLayout()
         
+        setupActions()
     }
     
     required init?(coder: NSCoder) {
@@ -36,6 +51,93 @@ public class ChatTextInputView: UIView {
 
 extension ChatTextInputView {
     
+    //MARK: - Layout Func
     
+    private func setupLayout() {
+        userChatInputViewHeightConstraint.isActive = true
+        userChatInputView.snp.makeConstraints { make in
+            make.verticalEdges.equalToSuperview().inset(16)
+            make.leading.equalToSuperview().inset(24)
+        }
+        
+        sendButton.snp.makeConstraints { make in
+            make.centerY.equalTo(userChatInputView)
+            make.leading.equalTo(userChatInputView.snp.trailing).offset(7)
+            make.trailing.equalToSuperview().inset(24)
+            make.size.equalTo(40)
+        }
+    }
+    
+    //MARK: - Private Func
+    
+    private func setupStyle() {
+        backgroundColor = .primary(.white)
+//        roundCorners(cornerRadius: 18, maskedCorners: [.layerMinXMinYCorner, .layerMaxXMinYCorner])
+        
+        userChatInputView.do { textView in
+            textView.textColor = .main(.main2)
+            textView.font = .offroad(style: .iosTextAuto)
+            textView.backgroundColor = .neutral(.btnInactive)
+            textView.contentInset = .init(top: 9, left: 0, bottom: 9, right: 0)
+            textView.textContainerInset = .init(top: 0, left: 20, bottom: 0, right: 20)
+            textView.textContainer.lineFragmentPadding = 0
+            textView.showsVerticalScrollIndicator = false
+            textView.verticalScrollIndicatorInsets = .init(top: 4, left: 0, bottom: 4, right: 10)
+            textView.roundCorners(cornerRadius: 12)
+        }
+        
+        sendButton.do { button in
+            button.setImage(.icnChatViewSendButton, for: .normal)
+        }
+    }
+    
+    private func setupHierarchy() {
+        addSubviews(userChatInputView, sendButton)
+    }
+    
+    private func setupActions() {
+        // 텍스트가 변할 때마다 외부로 텍스트 방출
+        userChatInputView.rx.text.orEmpty.bind(to: inputTextRelay).disposed(by: disposeBag)
+        // 텍스트가 변할 때마다 줄 수를 바탕으로 텍스트뷰의 높이 설정
+        userChatInputView.rx.text.orEmpty
+            .asDriver()
+            .drive(onNext: { [weak self] text in
+                guard let self else { return }
+                let textContentHeight = self.userChatInputView.textInputView.bounds.height
+                let isMultiline: Bool = textContentHeight > 30
+                let shortHeight: CGFloat = 19.0 + (9*2)
+                let longHeight: CGFloat = (19.0*2) + (9.0*2)
+                self.updateChatInputViewHeight(height: isMultiline ? longHeight : shortHeight)
+                self.layoutIfNeeded()
+            }).disposed(by: disposeBag)
+        
+        // sendButton을 탭할 경우 외부로 현재 입력된 텍스트 방출
+        sendButton.rx.tap.subscribe(onNext: { [weak self] _ in
+            guard let self else { return }
+            let currentText = self.userChatInputView.text ?? ""
+            guard !currentText.isEmpty else { return }
+            sendingTextRelay.accept(currentText)
+        }).disposed(by: disposeBag)
+    }
+    
+    private func updateChatInputViewHeight(height: CGFloat, animated: Bool = false) {
+        userChatInputViewHeightAnimator.stopAnimation(true)
+        userChatInputViewHeightAnimator.addAnimations { [weak self] in
+            self?.userChatInputViewHeightConstraint.constant = height
+            self?.superview?.layoutIfNeeded()
+        }
+        userChatInputViewHeightAnimator.startAnimation()
+    }
+    
+    
+    //MARK: - Func
+    
+    func startChat() {
+        userChatInputView.becomeFirstResponder()
+    }
+    
+    func endChat() {
+        userChatInputView.resignFirstResponder()
+    }
     
 }

--- a/Offroad-iOS/Offroad-iOS/Global/Components/Chat/ChatTextInput/ChatTextInputView.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Components/Chat/ChatTextInput/ChatTextInputView.swift
@@ -57,7 +57,9 @@ public class ChatTextInputView: UIView {
     
 }
 
-public extension ChatTextInputView {
+//MARK: - Private Extensions
+
+private extension ChatTextInputView {
     
     //MARK: - Layout Func
     
@@ -176,6 +178,12 @@ public extension ChatTextInputView {
             }
         }
     }
+    
+}
+
+//MARK: - Public Extensions
+
+public extension ChatTextInputView {
     
     //MARK: - Func
     

--- a/Offroad-iOS/Offroad-iOS/Global/Components/Chat/ChatTextInput/ChatTextInputView.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Components/Chat/ChatTextInput/ChatTextInputView.swift
@@ -15,6 +15,8 @@ public class ChatTextInputView: UIView {
     
     //MARK: - Properties
     
+    var onTextInput: Observable<String> { inputTextRelay.asObservable() }
+    var onSendingText: Observable<String> { sendingTextRelay.asObservable() }
     var isSendingAllowed: Bool = true {
         didSet {
             let isTextViewEmpty = userChatInputView.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
@@ -24,9 +26,8 @@ public class ChatTextInputView: UIView {
         }
     }
     
-    let inputTextRelay = PublishRelay<String>()
-    let sendingTextRelay = PublishRelay<String>()
-    
+    private let inputTextRelay = PublishRelay<String>()
+    private let sendingTextRelay = PublishRelay<String>()
     private let userChatInputViewHeightAnimator = UIViewPropertyAnimator(duration: 0.3, dampingRatio: 1)
     private let showingAnimator = UIViewPropertyAnimator(duration: 0.5, dampingRatio: 1)
     private let hidingAnimator = UIViewPropertyAnimator(duration: 0.3, dampingRatio: 1)

--- a/Offroad-iOS/Offroad-iOS/Global/Components/Chat/ChatTextInput/ChatTextInputView.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Components/Chat/ChatTextInput/ChatTextInputView.swift
@@ -176,8 +176,11 @@ public extension ChatTextInputView {
         userChatInputView.becomeFirstResponder()
     }
     
-    func endChat() {
-        hide()
+    func endChat(erase: Bool = false, completion: (() -> Void)? = nil) {
+        hide { [weak self] in
+            if erase { self?.userChatInputView.text = "" }
+            completion?()
+        }
         userChatInputView.resignFirstResponder()
     }
     

--- a/Offroad-iOS/Offroad-iOS/Global/Components/Chat/ChatTextInput/ChatTextInputView.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Components/Chat/ChatTextInput/ChatTextInputView.swift
@@ -50,7 +50,7 @@ public class ChatTextInputView: UIView {
     
 }
 
-extension ChatTextInputView {
+public extension ChatTextInputView {
     
     //MARK: - Layout Func
     

--- a/Offroad-iOS/Offroad-iOS/Global/Components/Chat/ChatTextInput/ChatTextInputView.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Components/Chat/ChatTextInput/ChatTextInputView.swift
@@ -15,7 +15,14 @@ public class ChatTextInputView: UIView {
     
     //MARK: - Properties
     
-    var isSendingAllowed: Bool = true
+    var isSendingAllowed: Bool = true {
+        didSet {
+            let isTextViewEmpty = userChatInputView.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            if isSendingAllowed && !isTextViewEmpty {
+                    sendButton.isEnabled = true
+            }
+        }
+    }
     
     let inputTextRelay = PublishRelay<String>()
     let sendingTextRelay = PublishRelay<String>()

--- a/Offroad-iOS/Offroad-iOS/Global/Components/Chat/ChatTextInput/ChatTextInputView.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Components/Chat/ChatTextInput/ChatTextInputView.swift
@@ -16,10 +16,10 @@ public class ChatTextInputView: UIView {
     //MARK: - Properties
     
     var isSendingAllowed: Bool = true
-    var inputTextRelay = PublishRelay<String>()
-    var sendingTextRelay = PublishRelay<String>()
     
-    private let userChatInputViewHeightRelay = PublishRelay<CGFloat>()
+    let inputTextRelay = PublishRelay<String>()
+    let sendingTextRelay = PublishRelay<String>()
+    
     private let userChatInputViewHeightAnimator = UIViewPropertyAnimator(duration: 0.3, dampingRatio: 1)
     private let showingAnimator = UIViewPropertyAnimator(duration: 0.5, dampingRatio: 1)
     private let hidingAnimator = UIViewPropertyAnimator(duration: 0.3, dampingRatio: 1)

--- a/Offroad-iOS/Offroad-iOS/Global/Components/Chat/ChatTextInput/ChatTextInputView.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Components/Chat/ChatTextInput/ChatTextInputView.swift
@@ -15,7 +15,7 @@ public class ChatTextInputView: UIView {
     
     //MARK: - Properties
     
-    var isSendAllowed: Bool = true
+    var isSendingAllowed: Bool = true
     var inputTextRelay = PublishRelay<String>()
     var sendingTextRelay = PublishRelay<String>()
     
@@ -74,7 +74,6 @@ extension ChatTextInputView {
     
     private func setupStyle() {
         backgroundColor = .primary(.white)
-//        roundCorners(cornerRadius: 18, maskedCorners: [.layerMinXMinYCorner, .layerMaxXMinYCorner])
         
         userChatInputView.do { textView in
             textView.textColor = .main(.main2)
@@ -108,7 +107,7 @@ extension ChatTextInputView {
                 
                 // 입력창이 비어있으면 전송 버튼 비활성화
                 self.sendButton.isEnabled =
-                !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && isSendAllowed
+                !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && isSendingAllowed
                 
                 // 텍스트 줄 수에 따라 입력창 높이 설정
                 let textContentHeight = self.userChatInputView.textInputView.bounds.height
@@ -126,6 +125,7 @@ extension ChatTextInputView {
             let currentText = self.userChatInputView.text ?? ""
             guard !currentText.isEmpty else { return }
             self.userChatInputView.text = ""
+            self.isSendingAllowed = false
             self.sendButton.isEnabled = false
             sendingTextRelay.accept(currentText)
         }).disposed(by: disposeBag)

--- a/Offroad-iOS/Offroad-iOS/Global/Components/Chat/ChatTextInput/ChatTextInputView.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Components/Chat/ChatTextInput/ChatTextInputView.swift
@@ -15,8 +15,15 @@ public class ChatTextInputView: UIView {
     
     //MARK: - Properties
     
+    /// 입력창에 텍스트가 바뀔 때마다 입력된 텍스트를 방출하는 `Observable` 스트림.
     var onTextInput: Observable<String> { inputTextRelay.asObservable() }
+    /// 사용자가 전송 버튼을 눌렀을 때 입력된 텍스트를 방출하는 `Observable` 스트림.
     var onSendingText: Observable<String> { sendingTextRelay.asObservable() }
+    /// 현재 텍스트 전송이 가능한지 여부를 나타내는 속성.
+    ///
+    /// `true`인 경우, 텍스트 입력창이 비어있지 않을 때 전송 버튼이 활성화됨.
+    ///
+    /// `false` 인 경우, 텍스트 입력창이 비어있지 않아도 전송 버튼이 비활성화됨.
     var isSendingAllowed: Bool = true {
         didSet {
             let isTextViewEmpty = userChatInputView.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
@@ -188,11 +195,17 @@ public extension ChatTextInputView {
     
     //MARK: - Func
     
+    /// 채팅을 시작하는 함수.
+    /// - 채팅 입력창을 화면에 표시하고 `firstResponder`로 설정함.
     func startChat() {
         show()
         userChatInputView.becomeFirstResponder()
     }
     
+    /// 채팅을 종료하는 함수. 화면에서 채팅 입력창을 숨기고 `firstResponder`를 resign함.
+    /// - Parameters:
+    ///   - erase: 화면에서 숨겨진 후 입력창에 입력된 텍스트를 제거할 지 여부. `true`를 할당하면 완전히 숨겨진 후 텍스트를 지우고, `false`를 할당하면 숨겨진 후에도 텍스트를 유지하여 다음 표시 때 입력된 텍스트를 여전히 띄움.
+    ///   - completion: 숨겨진 후 실행할 콜백 함수. 매개변수가 없는 클로저 타입임.
     func endChat(erase: Bool = false, completion: (() -> Void)? = nil) {
         hide { [weak self] in
             if erase { self?.userChatInputView.text = "" }

--- a/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/Alert/ORBAlertController.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/Alert/ORBAlertController.swift
@@ -232,7 +232,7 @@ extension ORBAlertController {
             })
             .bind { [weak self] recognizer in
                 print("tapped in view")
-                guard !ORBCharacterChatManager.shared.chatViewController.isUserChatInputViewShown else { return }
+                guard !ORBCharacterChatManager.shared.chatViewController.isChatTextInputViewShown else { return }
                 self?.rootView.endEditing(true)
             }.disposed(by: disposeBag)
         

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/ORBCharacterChatManager.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/ORBCharacterChatManager.swift
@@ -26,19 +26,17 @@ final class ORBCharacterChatManager {
     
     //MARK: - UI Properties
     
-    var chatWindow = ORBCharacterChatWindow(windowScene: UIWindowScene.current)
+    private var chatWindow = ORBCharacterChatWindow(windowScene: UIWindowScene.current)
     var chatViewController: ORBCharacterChatViewController {
         chatWindow.rootViewController as! ORBCharacterChatViewController
     }
-    var characterChatBox: ORBCharacterChatBox { chatViewController.rootView.characterChatBox }
-    var userChatView: UIView { chatViewController.rootView.userChatView }
-    var endChatButton: UIButton { chatViewController.rootView.endChatButton }
+    private var characterChatBox: ORBCharacterChatBox { chatViewController.rootView.characterChatBox }
+    private var endChatButton: UIButton { chatViewController.rootView.endChatButton }
     
     //MARK: - Life Cycle
     
     private init() {
         characterChatBox.isHidden = true
-        userChatView.isHidden = true
         endChatButton.isHidden = true
     }
     
@@ -58,16 +56,11 @@ extension ORBCharacterChatManager {
     
     func startChat() {
         chatWindow.makeKeyAndVisible()
-        userChatView.isHidden = false
-        endChatButton.isHidden = false
-        self.chatViewController.rootView.userChatInputView.becomeFirstResponder()
+        self.chatViewController.startChat()
     }
     
     func endChat() {
-        chatViewController.hideUserChatInputView()
-        chatViewController.rootView.userChatInputView.resignFirstResponder()
-        chatViewController.rootView.userChatInputView.text = ""
-        chatViewController.rootView.userChatDisplayView.text = ""
+        chatViewController.endChat()
         hideCharacterChatBox()
     }
     

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/ORBCharacterChatManager.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/ORBCharacterChatManager.swift
@@ -56,7 +56,7 @@ extension ORBCharacterChatManager {
     
     func startChat() {
         chatWindow.makeKeyAndVisible()
-        self.chatViewController.startChat()
+        chatViewController.startChat()
     }
     
     func endChat() {

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/ViewControllers/ORBCharacterChatViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/ViewControllers/ORBCharacterChatViewController.swift
@@ -141,9 +141,7 @@ extension ORBCharacterChatViewController {
     //MARK: - Private Func
     
     private func setupChatTextActions() {
-        
-        // 채팅 전송 시(chatTextInputView에서 sendingText를 방출 시) 동작 구현
-        rootView.chatTextInputView.sendingTextRelay.subscribe(onNext: { [weak self] sendingText in
+        rootView.chatTextInputView.onSendingText.subscribe(onNext: { [weak self] sendingText in
             guard let self else { return }
             self.postCharacterChat(message: sendingText)
             // 캐릭터 응답 로티 뜨도록 구현
@@ -157,7 +155,7 @@ extension ORBCharacterChatViewController {
             self.rootView.chatTextDisplayView.display(text: sendingText.trimmingCharacters(in: .whitespacesAndNewlines))
         }).disposed(by: disposeBag)
         
-        rootView.chatTextInputView.inputTextRelay.subscribe(onNext: { [weak self] inputText in
+        rootView.chatTextInputView.onTextInput.subscribe(onNext: { [weak self] inputText in
             guard let self else { return }
             if !inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                 self.rootView.chatTextDisplayView.startDisplayLoading()

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/ViewControllers/ORBCharacterChatViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/ViewControllers/ORBCharacterChatViewController.swift
@@ -141,6 +141,15 @@ extension ORBCharacterChatViewController {
     //MARK: - Private Func
     
     private func setupChatTextActions() {
+        rootView.chatTextInputView.onTextInput.subscribe(onNext: { [weak self] inputText in
+            guard let self else { return }
+            if !inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                self.rootView.chatTextDisplayView.startDisplayLoading()
+            } else {
+                self.rootView.chatTextDisplayView.stopDisplayLoading()
+            }
+        }).disposed(by: disposeBag)
+        
         rootView.chatTextInputView.onSendingText.subscribe(onNext: { [weak self] sendingText in
             guard let self else { return }
             self.postCharacterChat(message: sendingText)
@@ -154,16 +163,6 @@ extension ORBCharacterChatViewController {
             self.showCharacterChatBox(isAutoDismiss: false)
             self.rootView.chatTextDisplayView.display(text: sendingText.trimmingCharacters(in: .whitespacesAndNewlines))
         }).disposed(by: disposeBag)
-        
-        rootView.chatTextInputView.onTextInput.subscribe(onNext: { [weak self] inputText in
-            guard let self else { return }
-            if !inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                self.rootView.chatTextDisplayView.startDisplayLoading()
-            } else {
-                self.rootView.chatTextDisplayView.stopDisplayLoading()
-            }
-        }).disposed(by: disposeBag)
-        
     }
     
     //MARK: - Func

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/ViewControllers/ORBCharacterChatViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/ViewControllers/ORBCharacterChatViewController.swift
@@ -322,6 +322,7 @@ extension ORBCharacterChatViewController {
     }
     
     func hideCharacterChatBox() {
+        let chatBoxHeight = characterChatBox.frame.height
         panGesture.isEnabled = false
         isCharacterChatBoxShown = false
         characterChatBoxPositionAnimator.stopAnimation(true)
@@ -329,8 +330,7 @@ extension ORBCharacterChatViewController {
             guard let self else { return }
             // pagGesture로 변경된 (세로)위치 원상복구
             self.characterChatBox.transform = CGAffineTransform.identity
-            self.rootView.characterChatBoxTopConstraint.constant
-            = -self.characterChatBox.frame.height
+            self.rootView.characterChatBoxTopConstraint.constant = -max(60, chatBoxHeight)
             self.rootView.layoutIfNeeded()
         }
         characterChatBoxPositionAnimator.addCompletion { [weak self] _ in

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/Views/ORBCharacterChatView.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/Views/ORBCharacterChatView.swift
@@ -16,21 +16,12 @@ final class ORBCharacterChatView: UIView {
     //MARK: - Properties
     
     lazy var characterChatBoxTopConstraint = characterChatBox.topAnchor.constraint(equalTo: topAnchor)
-    lazy var userChatViewBottomConstraint = userChatView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: 160)
-    lazy var userChatInputViewHeightConstraint = userChatInputView.heightAnchor.constraint(equalToConstant: 37)
-    lazy var userChatDisplayViewHeightConstraint = userChatDisplayView.heightAnchor.constraint(equalToConstant: 24)
     
     //MARK: - UI Properties
     
     let characterChatBox = ORBCharacterChatBox(mode: .withoutReplyButtonShrinked)
-    let userChatView = UIView()
-    
-    let meLabel = UILabel()
-    let loadingAnimationView = LottieAnimationView(name: "loading2")
-    let userChatDisplayView = UITextView()
-    let userChatInputView = UITextView()
-    let keyboardBackgroundView = UIView()
-    let sendButton = ShrinkableButton(shrinkScale: 0.9)
+    let chatTextInputView = ChatTextInputView()
+    let chatTextDisplayView = ChatTextDisplayView()
     let endChatButton = ShrinkableButton(shrinkScale: 0.93)
     
     override init(frame: CGRect) {
@@ -64,55 +55,19 @@ extension ORBCharacterChatView {
             make.height.greaterThanOrEqualTo(58)
         }
         
-        userChatViewBottomConstraint.isActive = true
-        userChatView.snp.makeConstraints { make in
-            make.horizontalEdges.equalToSuperview()
-        }
-        
-        meLabel.setContentHuggingPriority(.defaultHigh, for: .horizontal)
-        meLabel.snp.makeConstraints { make in
-            make.top.equalToSuperview().inset(16)
-            make.leading.equalToSuperview().inset(38)
-        }
-        
-        loadingAnimationView.snp.makeConstraints { make in
-            make.centerY.equalTo(meLabel)
-            make.leading.equalTo(meLabel).offset(4.2)
-            make.height.equalTo(50)
-            make.width.equalTo(100)
-        }
-        
-        userChatDisplayView.setContentHuggingPriority(.defaultLow, for: .horizontal)
-        userChatDisplayViewHeightConstraint.isActive = true
-        userChatDisplayView.snp.makeConstraints { make in
-            make.top.equalTo(meLabel)
-            make.leading.equalTo(meLabel.snp.trailing).offset(10)
-            make.trailing.equalToSuperview().inset(24)
-        }
-        
-        userChatInputViewHeightConstraint.isActive = true
-        userChatInputView.snp.makeConstraints { make in
-            make.top.equalTo(userChatDisplayView.snp.bottom).offset(12)
-            make.leading.equalToSuperview().inset(24)
-            make.bottom.equalToSuperview().inset(16)
-        }
-        
-        keyboardBackgroundView.snp.makeConstraints { make in
-            make.top.equalTo(userChatView.snp.bottom)
+        chatTextInputView.snp.makeConstraints { make in
             make.horizontalEdges.equalToSuperview()
             make.bottom.equalToSuperview()
         }
         
-        sendButton.snp.makeConstraints { make in
-            make.centerY.equalTo(userChatInputView)
-            make.leading.equalTo(userChatInputView.snp.trailing).offset(7)
-            make.trailing.equalToSuperview().inset(24)
-            make.size.equalTo(40)
+        chatTextDisplayView.snp.makeConstraints { make in
+            make.horizontalEdges.equalTo(chatTextInputView)
+            make.bottom.equalTo(chatTextInputView.snp.top)
         }
         
         endChatButton.snp.makeConstraints { make in
             make.trailing.equalToSuperview().inset(24)
-            make.bottom.equalTo(userChatView.snp.top).offset(-12)
+            make.bottom.equalTo(chatTextDisplayView.snp.top).offset(-12)
             make.width.equalTo(84)
             make.height.equalTo(36)
         }
@@ -121,8 +76,12 @@ extension ORBCharacterChatView {
     //MARK: - Private Func
     
     private func setupStyle() {
-        userChatView.do { view in
-            view.backgroundColor = .primary(.white)
+        chatTextInputView.do { view in
+            view.alpha = 0
+        }
+        
+        chatTextDisplayView.do { view in
+            view.alpha = 0
             view.roundCorners(cornerRadius: 20, maskedCorners: [.layerMinXMinYCorner, .layerMaxXMinYCorner])
             view.layer.shadowColor = UIColor.primary(.black).cgColor
             view.layer.shadowOffset = .zero
@@ -130,45 +89,7 @@ extension ORBCharacterChatView {
             view.layer.shadowRadius = 10
             view.layer.masksToBounds = false
         }
-        meLabel.do { label in
-            label.textColor = .main(.main2)
-            label.font = .pretendardFont(ofSize: 16, weight: .regular)
-            label.text = "나 :"
-            label.highlightText(targetText: " ", font: .pretendardFont(ofSize: 16, weight: .medium))
-            label.highlightText(targetText: "나", font: .pretendardFont(ofSize: 16, weight: .bold))
-            label.setLineHeight(percentage: 150)
-        }
-        loadingAnimationView.do { animationView in
-            animationView.isHidden = true
-            animationView.contentMode = .scaleAspectFit
-            animationView.loopMode = .loop
-        }
-        userChatDisplayView.do { textView in
-            textView.textColor = .main(.main2)
-            textView.font = .offroad(style: .iosText)
-            textView.backgroundColor = .clear
-            textView.isSelectable = false
-            textView.textContainerInset = .zero
-            textView.textContainer.lineFragmentPadding = 0
-        }
-        userChatInputView.do { textView in
-            textView.textColor = .main(.main2)
-            textView.font = .offroad(style: .iosText)
-            textView.backgroundColor = .neutral(.btnInactive)
-            textView.contentInset = .init(top: 9, left: 0, bottom: 9, right: 0)
-            textView.textContainerInset = .init(top: 0, left: 20, bottom: 0, right: 20)
-            textView.textContainer.lineFragmentPadding = 0
-            textView.showsVerticalScrollIndicator = false
-            textView.verticalScrollIndicatorInsets = .init(top: 4, left: 0, bottom: 4, right: 10)
-            textView.roundCorners(cornerRadius: 12)
-        }
-        keyboardBackgroundView.do { view in
-            view.backgroundColor = .primary(.white)
-            view.isHidden = true
-        }
-        sendButton.do { button in
-            button.setImage(.icnChatViewSendButton, for: .normal)
-        }
+        
         endChatButton.do { button in
             button.backgroundColor = .sub(.sub55)
             button.layer.borderColor = UIColor.sub(.sub).cgColor
@@ -182,8 +103,7 @@ extension ORBCharacterChatView {
     }
     
     private func setupHierarchy() {
-        userChatView.addSubviews(meLabel, userChatDisplayView, loadingAnimationView, userChatInputView, sendButton)
-        addSubviews(characterChatBox, userChatView, keyboardBackgroundView, endChatButton)
+        addSubviews(characterChatBox, chatTextDisplayView, chatTextInputView, endChatButton)
     }
     
 }

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/Views/ORBCharacterChatView.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/Views/ORBCharacterChatView.swift
@@ -62,7 +62,8 @@ extension ORBCharacterChatView {
         
         chatTextDisplayView.snp.makeConstraints { make in
             make.horizontalEdges.equalTo(chatTextInputView)
-            make.bottom.equalTo(chatTextInputView.snp.top)
+            // 두 뷰를 딱 붙여놓으니, 애니메이션 과정에서 경계선이 약간 보이는 문제가 있어 1포인트만큼 겹쳐놓았음.
+            make.bottom.equalTo(chatTextInputView.snp.top).offset(1)
         }
         
         endChatButton.snp.makeConstraints { make in

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/Views/ORBCharacterChatWindow.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/Views/ORBCharacterChatWindow.swift
@@ -22,9 +22,25 @@ class ORBCharacterChatWindow: UIWindow {
     
     override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
         let chatViewController = rootViewController as! ORBCharacterChatViewController
-        if chatViewController.rootView.characterChatBox.frame.contains(point) ||
-            chatViewController.rootView.userChatView.frame.contains(point) ||
-            chatViewController.rootView.endChatButton.frame.contains(point) {
+        let isCharacterChatBoxShown = chatViewController.isCharacterChatBoxShown
+        let isChatTextInputViewShown = chatViewController.isChatTextInputViewShown
+        let characterChatBox = chatViewController.rootView.characterChatBox
+        let chatTextInputView = chatViewController.rootView.chatTextInputView
+        let chatTextDisplayView = chatViewController.rootView.chatTextDisplayView
+        let endChatButton = chatViewController.rootView.endChatButton
+        
+        // 캐릭터 채팅 박스를 터치한 경우
+        let isChatBoxTouchAllowed = (isCharacterChatBoxShown && characterChatBox.frame.contains(point))
+        
+        // 사용자 채팅 입력 영역을 터치한 경우
+        let isTextInputViewTouchAllowed = (
+            isChatTextInputViewShown && (chatTextInputView.frame.contains(point) ||
+                                         chatTextDisplayView.frame.contains(point) ||
+                                         endChatButton.frame.contains(point))
+        )
+        
+        // 사용자가 지정된 영역을 터치했을 때만 터치 인식. 그 외에는 다음 window로 터치 이벤트 전달.
+        if isChatBoxTouchAllowed || isTextInputViewTouchAllowed {
             return super.hitTest(point, with: event)
         } else {
             return nil

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/ChatLog/ViewControllers/CharacterChatLogViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/ChatLog/ViewControllers/CharacterChatLogViewController.swift
@@ -144,9 +144,10 @@ extension CharacterChatLogViewController {
     @objc private func keyboardWillShow(notification: Notification) {
         rootView.layoutIfNeeded()
         rootView.setChatCollectionViewInset(inset: rootView.chatTextInputView.frame.height + 16)
-        UIView.animate(withDuration: 0.5) { [weak self] in
-            self?.scrollToFirstCell(at: .bottom, animated: false)
-        }
+        rootView.chatLogCollectionView.setContentOffset(
+            .init(x: 0, y: -(rootView.chatTextInputView.frame.height + 16)),
+            animated: false
+        )
     }
     
     @objc private func keyboardWillHide(notification: Notification) {

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/ChatLog/ViewControllers/CharacterChatLogViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/ChatLog/ViewControllers/CharacterChatLogViewController.swift
@@ -143,7 +143,13 @@ extension CharacterChatLogViewController {
     
     @objc private func keyboardWillShow(notification: Notification) {
         rootView.layoutIfNeeded()
+        // 키보드가 올라올 때는 두 가지 동작이 필요함.
+        // 1. collectionView의 inset을 추가해주어야 함.
+        // 2. collectionView의 스크롤 위치를 끝으로 이동 (채팅하기 버튼은 끝까지 스크롤했을 때에만 보이기 때문)
+        
+        // collectionView의 inset 추가
         rootView.setChatCollectionViewInset(inset: rootView.chatTextInputView.frame.height + 16)
+        // collectionView의 contentOffset을 끝으로 이동
         rootView.chatLogCollectionView.setContentOffset(
             .init(x: 0, y: -(rootView.chatTextInputView.frame.height + 16)),
             animated: false

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/ChatLog/ViewControllers/CharacterChatLogViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/ChatLog/ViewControllers/CharacterChatLogViewController.swift
@@ -288,7 +288,7 @@ extension CharacterChatLogViewController {
             self.rootView.chatTextInputView.startChat()
         }).disposed(by: disposeBag)
         
-        rootView.chatTextInputView.sendingTextRelay.subscribe(onNext: { [weak self] sendingText in
+        rootView.chatTextInputView.onSendingText.subscribe(onNext: { [weak self] sendingText in
             guard let self else { return }
             // 사용자 채팅 버블 추가
             self.sendChatBubble(isUserChat: true, text: sendingText, isLoading: false) {

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/ChatLog/ViewControllers/CharacterChatLogViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/ChatLog/ViewControllers/CharacterChatLogViewController.swift
@@ -154,6 +154,7 @@ extension CharacterChatLogViewController {
     }
     
     @objc private func tapGestureHandler(_ sender: UITapGestureRecognizer) {
+        showTabBar()
         rootView.chatTextInputView.endChat()
     }
     
@@ -275,6 +276,8 @@ extension CharacterChatLogViewController {
     private func bindData() {
         rootView.chatButton.rx.tap.bind(onNext: { [weak self] in
             guard let self else { return }
+            self.hideTabBar()
+            self.hideChatButton()
             self.rootView.chatTextInputView.startChat()
         }).disposed(by: disposeBag)
         
@@ -490,6 +493,21 @@ extension CharacterChatLogViewController {
         }
     }
     
+    private func hideTabBar() {
+        guard let tabBarController = tabBarController as? OffroadTabBarController else { return }
+        tabBarController.hideTabBarAnimation() {
+            self.additionalSafeAreaInsets.bottom -= tabBarController.tabBarHeight
+        }
+    }
+    
+    private func showTabBar() {
+        guard let tabBarController = tabBarController as? OffroadTabBarController else { return }
+        tabBarController.showTabBarAnimation() {
+            self.additionalSafeAreaInsets.bottom += tabBarController.tabBarHeight
+            tabBarController.enableTabBarInteraction()
+        }
+    }
+    
 }
 
 //MARK: - UIScrollViewDelegate
@@ -497,6 +515,7 @@ extension CharacterChatLogViewController {
 extension CharacterChatLogViewController: UIScrollViewDelegate {
     
     func scrollViewShouldScrollToTop(_ scrollView: UIScrollView) -> Bool {
+        showTabBar()
         rootView.chatTextInputView.endChat()
         isScrollingToTop = true
         // custom ScrollToTop 동작

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/ChatLog/ViewControllers/CharacterChatLogViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/ChatLog/ViewControllers/CharacterChatLogViewController.swift
@@ -145,7 +145,7 @@ extension CharacterChatLogViewController {
         rootView.layoutIfNeeded()
         rootView.setChatCollectionViewInset(inset: rootView.chatTextInputView.frame.height + 16)
         UIView.animate(withDuration: 0.5) { [weak self] in
-            self?.scrollToFirstCell(at: .top, animated: false)
+            self?.scrollToFirstCell(at: .bottom, animated: false)
         }
     }
     

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/ChatLog/ViewControllers/CharacterChatLogViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/ChatLog/ViewControllers/CharacterChatLogViewController.swift
@@ -37,11 +37,7 @@ class CharacterChatLogViewController: OffroadTabBarViewController {
     private var didGetAllChatLog: Bool = false
     private var isScrollingToTop: Bool = false
     
-    // userChatInputView의 textInputView의 height를 전달
-    private let userChatInputViewTextInputViewHeightRelay = PublishRelay<CGFloat>()
-    private let userChatInputViewHeightAnimator = UIViewPropertyAnimator(duration: 0.3, dampingRatio: 1)
     private let isCharacterResponding = BehaviorRelay<Bool>(value: false)
-//    private let isTextViewEmpty = BehaviorRelay<Bool>(value: true)
     private let patchChatReadRelay = PublishRelay<Int?>()
     
     /// 채팅 로그 뷰가 떠 있을 때 캐릭터 채팅 푸시 알림이 오면 캐릭터 채팅 내용을 전달
@@ -146,28 +142,15 @@ extension CharacterChatLogViewController {
     }
     
     @objc private func keyboardWillShow(notification: Notification) {
-        guard !isKeyboardShown else { return }
-        isKeyboardShown = true
+        rootView.layoutIfNeeded()
+        rootView.setChatCollectionViewInset(inset: rootView.chatTextInputView.frame.height + 16)
         UIView.animate(withDuration: 0.5) { [weak self] in
-            guard let self else { return }
-            rootView.chatLogCollectionView.contentInsetAdjustmentBehavior = .never
-            rootView.chatLogCollectionView.contentInset.top = rootView.chatTextInputView.frame.height + 16
-            self.scrollToFirstCell(at: .top, animated: false)
-            rootView.layoutIfNeeded()
+            self?.scrollToFirstCell(at: .top, animated: false)
         }
     }
     
     @objc private func keyboardWillHide(notification: Notification) {
-        guard isKeyboardShown else { return }
-        isKeyboardShown = false
-        UIView.animate(withDuration: 0.5) { [weak self] in
-            guard let self else { return }
-            rootView.chatLogCollectionView.contentInsetAdjustmentBehavior = .never
-            rootView.chatLogCollectionView.contentInset.top = 135 + rootView.safeAreaInsets.bottom
-            rootView.layoutIfNeeded()
-        }
-        
-        rootView.chatTextInputView.endChat()
+        rootView.setChatCollectionViewInset(inset: 135 + rootView.safeAreaInsets.bottom)
     }
     
     @objc private func tapGestureHandler(_ sender: UITapGestureRecognizer) {
@@ -290,13 +273,6 @@ extension CharacterChatLogViewController {
     }
     
     private func bindData() {
-        ORBCharacterChatManager.shared.shouldMakeKeyboardBackgroundTransparent
-            .subscribe(onNext: { [weak self] isTransparent in
-                guard let self else { return }
-                guard self.rootView.keyboardBackgroundView.frame.height > rootView.safeAreaInsets.bottom else { return }
-                self.rootView.keyboardBackgroundView.isHidden = isTransparent
-            }).disposed(by: disposeBag)
-        
         rootView.chatButton.rx.tap.bind(onNext: { [weak self] in
             guard let self else { return }
             self.rootView.chatTextInputView.startChat()

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/ChatLog/Views/CharacterChatLogView.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/ChatLog/Views/CharacterChatLogView.swift
@@ -25,8 +25,6 @@ class CharacterChatLogView: UIView {
     }
     
     lazy var chatButtonBottomConstraint = chatButton.bottomAnchor.constraint(equalTo: bottomAnchor)
-    lazy var userChatInputViewHeightConstraint = userChatInputView.heightAnchor.constraint(equalToConstant: 40)
-//    lazy var userChatViewBottomConstraint = userChatView.bottomAnchor.constraint(equalTo: keyboardLayoutGuide.topAnchor)
     
     //MARK: - UI Properties
     
@@ -39,13 +37,10 @@ class CharacterChatLogView: UIView {
     
     lazy var chatLogCollectionView = ScrollLoadingCollectionView(frame: .zero, collectionViewLayout: layout)
     let chatButton = ShrinkableButton(shrinkScale: 0.9)
-    
-    let userChatBoundsView = UIView()
-    let userChatView = UIView()
-    let userChatInputView = UITextView()
-    let sendButton = ShrinkableButton(shrinkScale: 0.9)
-    let loadingAnimationView = LottieAnimationView(name: "loading2")
     let keyboardBackgroundView = UIView().then { $0.backgroundColor = .primary(.white) }
+    
+    let chatTextInputView = ChatTextInputView()
+    
     
     //MARK: - Life Cycle
     
@@ -112,31 +107,14 @@ extension CharacterChatLogView {
             make.height.equalTo(40)
         }
         
-        userChatBoundsView.snp.makeConstraints { make in
-            make.horizontalEdges.equalToSuperview()
-            make.bottom.equalTo(keyboardLayoutGuide.snp.top)
-        }
-        
-        userChatView.snp.makeConstraints { make in
-            make.edges.equalToSuperview()
-        }
-        
-        userChatInputViewHeightConstraint.isActive = true
-        userChatInputView.snp.makeConstraints { make in
-            make.verticalEdges.equalToSuperview().inset(16)
-            make.leading.equalToSuperview().inset(24)
-        }
-        
-        sendButton.snp.makeConstraints { make in
-            make.centerY.equalTo(userChatInputView)
-            make.leading.equalTo(userChatInputView.snp.trailing).offset(7)
-            make.trailing.equalToSuperview().inset(24)
-            make.size.equalTo(40)
-        }
-        
         keyboardBackgroundView.snp.makeConstraints { make in
-            make.top.equalTo(userChatBoundsView.snp.bottom)
+            make.top.equalTo(keyboardLayoutGuide)
             make.horizontalEdges.bottom.equalToSuperview()
+        }
+        
+        chatTextInputView.snp.makeConstraints { make in
+            make.horizontalEdges.equalToSuperview()
+            make.bottom.equalToSuperview()
         }
     }
     
@@ -173,33 +151,12 @@ extension CharacterChatLogView {
             button.configuration?.baseForegroundColor = .primary(.white)
         }
         
-        userChatBoundsView.do { view in
-            view.isUserInteractionEnabled = true
-            view.bounds.origin.y = -(200)
-        }
+        keyboardBackgroundView.isHidden = true
         
-        userChatView.do { view in
-            view.backgroundColor = .primary(.white)
+        chatTextInputView.do { view in
+            view.isHidden = true
             view.roundCorners(cornerRadius: 18, maskedCorners: [.layerMinXMinYCorner, .layerMaxXMinYCorner])
         }
-        
-        userChatInputView.do { textView in
-            textView.textColor = .main(.main2)
-            textView.font = .offroad(style: .iosTextAuto)
-            textView.backgroundColor = .neutral(.btnInactive)
-            textView.contentInset = .init(top: 9, left: 0, bottom: 9, right: 0)
-            textView.textContainerInset = .init(top: 0, left: 20, bottom: 0, right: 20)
-            textView.textContainer.lineFragmentPadding = 0
-            textView.showsVerticalScrollIndicator = false
-            textView.verticalScrollIndicatorInsets = .init(top: 4, left: 0, bottom: 4, right: 10)
-            textView.roundCorners(cornerRadius: 12)
-        }
-        
-        sendButton.do { button in
-            button.setImage(.icnChatViewSendButton, for: .normal)
-        }
-        
-        keyboardBackgroundView.isHidden = true
     }
     
     private func setupHierarchy() {
@@ -210,12 +167,10 @@ extension CharacterChatLogView {
             customNavigationBar,
             chatLogCollectionView,
             chatButton,
-            userChatBoundsView,
-            keyboardBackgroundView
+            keyboardBackgroundView,
+            chatTextInputView
         )
         customNavigationBar.addSubviews(backButton, customNavigationTitleLabel)
-        userChatBoundsView.addSubview(userChatView)
-        userChatView.addSubviews(userChatInputView, sendButton)
     }
     
 }

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/ChatLog/Views/CharacterChatLogView.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/ChatLog/Views/CharacterChatLogView.swift
@@ -151,8 +151,7 @@ extension CharacterChatLogView {
             view.layer.shadowOffset = .zero
             view.layer.shadowOpacity = 0.1
             view.layer.shadowRadius = 10
-            view.layer.masksToBounds = false
-            
+            view.layer.masksToBounds = false   
         }
     }
     

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/ChatLog/Views/CharacterChatLogView.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/ChatLog/Views/CharacterChatLogView.swift
@@ -13,6 +13,7 @@ class CharacterChatLogView: UIView {
     
     //MARK: - Properties
     
+    private let collectionViewInsetAnimator = UIViewPropertyAnimator(duration: 0.5, dampingRatio: 1)
     private let verticalFlipTransform = CGAffineTransform(scaleX: 1, y: -1)
     
     private var layout: UICollectionViewLayout {
@@ -37,8 +38,6 @@ class CharacterChatLogView: UIView {
     
     lazy var chatLogCollectionView = ScrollLoadingCollectionView(frame: .zero, collectionViewLayout: layout)
     let chatButton = ShrinkableButton(shrinkScale: 0.9)
-    let keyboardBackgroundView = UIView().then { $0.backgroundColor = .primary(.white) }
-    
     let chatTextInputView = ChatTextInputView()
     
     
@@ -107,11 +106,6 @@ extension CharacterChatLogView {
             make.height.equalTo(40)
         }
         
-        keyboardBackgroundView.snp.makeConstraints { make in
-            make.top.equalTo(keyboardLayoutGuide)
-            make.horizontalEdges.bottom.equalToSuperview()
-        }
-        
         chatTextInputView.snp.makeConstraints { make in
             make.horizontalEdges.equalToSuperview()
             make.bottom.equalToSuperview()
@@ -135,7 +129,6 @@ extension CharacterChatLogView {
         chatLogCollectionView.do { collectionView in
             collectionView.backgroundColor = .clear
             collectionView.contentInsetAdjustmentBehavior = .never
-            collectionView.keyboardDismissMode = .onDrag
             collectionView.transform = verticalFlipTransform
         }
         
@@ -151,10 +144,8 @@ extension CharacterChatLogView {
             button.configuration?.baseForegroundColor = .primary(.white)
         }
         
-        keyboardBackgroundView.isHidden = true
-        
         chatTextInputView.do { view in
-            view.isHidden = true
+            view.alpha = 0
             view.roundCorners(cornerRadius: 18, maskedCorners: [.layerMinXMinYCorner, .layerMaxXMinYCorner])
         }
     }
@@ -167,10 +158,23 @@ extension CharacterChatLogView {
             customNavigationBar,
             chatLogCollectionView,
             chatButton,
-            keyboardBackgroundView,
             chatTextInputView
         )
         customNavigationBar.addSubviews(backButton, customNavigationTitleLabel)
+    }
+    
+    //MARK: - Func
+    
+    func setChatCollectionViewInset(inset: CGFloat, animated: Bool = true) {
+        collectionViewInsetAnimator.stopAnimation(true)
+        if animated {
+            collectionViewInsetAnimator.addAnimations { [weak self] in
+                self?.chatLogCollectionView.contentInset.top = inset
+            }
+            collectionViewInsetAnimator.startAnimation()
+        } else {
+            chatLogCollectionView.contentInset.top = inset
+        }
     }
     
 }

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/ChatLog/Views/CharacterChatLogView.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/ChatLog/Views/CharacterChatLogView.swift
@@ -147,6 +147,12 @@ extension CharacterChatLogView {
         chatTextInputView.do { view in
             view.alpha = 0
             view.roundCorners(cornerRadius: 18, maskedCorners: [.layerMinXMinYCorner, .layerMaxXMinYCorner])
+            view.layer.shadowColor = UIColor.primary(.black).cgColor
+            view.layer.shadowOffset = .zero
+            view.layer.shadowOpacity = 0.1
+            view.layer.shadowRadius = 10
+            view.layer.masksToBounds = false
+            
         }
     }
     

--- a/Offroad-iOS/Offroad-iOS/Presentation/MyPage/Coupon/ViewController/CouponDetailViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/MyPage/Coupon/ViewController/CouponDetailViewController.swift
@@ -182,7 +182,7 @@ extension CouponDetailViewController {
 extension CouponDetailViewController: UITextFieldDelegate {
     
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
-        if ORBCharacterChatManager.shared.chatViewController.isUserChatInputViewShown {
+        if ORBCharacterChatManager.shared.chatViewController.isChatTextInputViewShown {
             return false
         } else {
             return true

--- a/Offroad-iOS/Offroad-iOS/Presentation/TabBar/ViewControllers/OffroadTabBarController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/TabBar/ViewControllers/OffroadTabBarController.swift
@@ -176,7 +176,7 @@ extension OffroadTabBarController {
     
     // MARK: - Func
     
-    func hideTabBarAnimation(delayFactor: CGFloat = 0) {
+    func hideTabBarAnimation(delayFactor: CGFloat = 0, completion: (() -> Void)? = nil) {
         isTabBarShown = false
         disableTabBarInteraction()
         view.layoutIfNeeded()
@@ -186,11 +186,12 @@ extension OffroadTabBarController {
         }, delayFactor: delayFactor)
         hideTabBarAnimator.addCompletion { _ in
             self.tabBar.isHidden = true
+            completion?()
         }
         hideTabBarAnimator.startAnimation()
     }
     
-    func showTabBarAnimation(delayFactor: CGFloat = 0) {
+    func showTabBarAnimation(delayFactor: CGFloat = 0, completion: (() -> Void)? = nil) {
         guard !isTabBarShown else { return }
         disableTabBarInteraction()
         if tabBar.isHidden {
@@ -205,6 +206,7 @@ extension OffroadTabBarController {
         showTabBarAnimator.addCompletion { [weak self] _ in
             guard let self else { return }
             self.isTabBarShown = true
+            completion?()
         }
         showTabBarAnimator.startAnimation()
     }


### PR DESCRIPTION
### 🌴 작업한 브랜치
- #463 


### ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->

### 사용자가 채팅할 때 입력창의 기능을 분리하였습니다. 
<img src="https://github.com/user-attachments/assets/c6bcff09-97fe-4345-befc-d038422abf9a" width=250>


기존 코드에서 채팅 시(홈 화면에서 채팅, 채팅 로그 둘 다) 우리 앱이 갖는 중요 문제점이 있다고 느꼈습니다. 
- 첫 번째는 사용자가 채팅하고자 해도 키보드가 올라오지 않을 때(아이폰 미러링이나, 아이패드에서 애플펜슬을 이용한 입력 등) 채팅 입력창이 화면에 나타나지 않는다는 문제였습니다.

  |홈 화면에서 입력창이 생기지 않는 상황|채팅 로그에서 입력창이 뜨지 않는 상황|
  |:------:|:---:|
  |   <img src="https://github.com/user-attachments/assets/cf5bae84-c442-442a-baa5-c8a3f8cdf2b8" width=150>   |  <img src="https://github.com/user-attachments/assets/a97f962e-5e42-49b7-a44a-f7777b009af8" width=150>  |

- 두 번째는 외부적으로 드러나는 문제는 아니지만, 채팅 입력창의 코드가 불필요하게 복잡하고 반복된다는 점이었습니다. 
특히 채팅창에 글씨가 입력될 때나 전송될 때 적용되는 애니메이션 코드는 거의 하드코딩을 하다시피하여 코드가 불필요하게 복잡해지고 반복된다고 느꼈습니다. 

 특히 두번째 문제가 근본적으로 해결이 필요하다고 느꼈습니다. 왜냐하면 현재 코드의 유지보수도 어렵고 3차 스프린트에서 추가될 '오브의 추천소' 기능에서도 비슷한 UI가 구현될 가능성이 높기 때문입니다. (그러면 또 비슷한 코드가 반복되겠지요.) 그리고 두 번째 문제를 해결하면 첫 번째 문제의 해결도 자연스레 따라올 것이라 생각했습니다. 결과부터 말씀드리자면 두 번째 문제를 해결하면서 이 브랜치에서 첫번째 문제도 같이 해결하였습니다.
단적인 예를 들어보겠습니다. 기존 코드에서 `ORBCharacterChatViewController.swift` 파일에서는 함수들을 두 부분으로 나누어 관리하고 있었습니다. 채팅창 입력 관련 함수와 채팅 박스 관련 함수를 분리하여 관리하고 있었는데요(#440 브랜치에서 해당 작업을 진행했었습니다.), 이 중 채팅창 입력 관련 함수의 코드가 120줄이었습니다. 그리고 뷰에 해당하는 ORBCharacterChatView.swift 파일에서 관련 코드는 92줄이었습니다.. 
이 코드들은 채팅 로그 뷰에서도 거의 반복되었고, 문제가 생겼을 때 이를 추적하기 어려웠다고 느꼈습니다. 
반복되는 코드들을 하나로 묶어줄 필요가 있었습니다. 

### 이를 위해서 채팅 입력창 코드를 분리하였습니다.
사실 모듈화를 하여 의존성을 완전히 분리하는 것이 목표였지만, 지금 당장 모듈화를 적용하기에는 힘들기 때문에 코드를 분리하는 정도로 구현하였으며, 추후 모듈화 가능성을 염두하여 pulblic, private 등의 접근제어자를 설정하였습니다. 
채팅 입력창 역할을 하는 타입인 `ChatTextInputView`, 홈 화면에서 채팅 시 사용자가 보낸 메시지를 띄울 역할을 하는 타입인 `ChatTextDisplayView` 를 만들었으며, 외부에서 접근할 수 있는 속성과 메서드를 제한하여 의존성을 최대한 낮추고 재사용성을 높이고자 하였습니다. 
추가된 파일은 `Global/Components/Chat` 의 경로에 추가하였습니다. 
외부에서 바라볼 때 `ChatTextInputView`와 `ChatTextDisplayView`의 구성은 다음과 같습니다.

``` swift
public class ChatTextInputView: UIView {
  
  var onTextInput: Observable<String> { get }
  var onSendingText: Observable<String> { get }
  var isSendingAllowed: Bool
  
  init() { }
  
  func startChat() { }
  func endChat(erase: Bool, completion: (() -> Void)?) { }
  
}
```

``` swift
public class ChatTextDisplayView: UIView {
  
  init() { }
  
  func display(text: String) { }
  func startDisplayLoading() { }
  func stopDisplayLoading() { }
  func show(animated: Bool) { }
  func hide(erase: Bool = false, animated: Bool, [comple](completion: (() -> Void)?) { }
  
}
```

위에서 정의된 속성과 메서드들을 이용하여 다른 곳에서 채팅창 입력 기능을 사용하고자 할 경우 이 타입들을 사용할 수 있습니다. 
비슷한 기능을 하는 데 디자인이 달라진다거나 할 경우, protocol로 추상화하여 사용할 수도 있을 것입니다. (현재는 여러 곳에서 다양한 모습으로 쓰이는 것은 아니기 때문에, 프로토콜을 만들지는 않았습니다.)

### 결과
- 반복되는 코드를 줄이고, 유지보수성을 높였습니다.
다음은 `ORBCharacterChatView`에서 채팅 입력창 관련 코드를 `ChatTextInputView`와 `ChatTextDisplayView`로 대체했을 때의 차이를 나타낸 것입니다.
<img src="https://github.com/user-attachments/assets/eb1b72a6-fc79-47b1-ab0b-e6b82fb53e22" width=500>

위 이미지의 우측에 표시된 부분에서 볼 수 있듯, 상당한 양의 코드를 줄일 수 있었음을 확인할 수 있습니다. 다른 타입에서도 마찬가지입니다.
유지보수에도 용이합니다. 채팅창에 새로운 동작을 넣거나 문제가 생겨서 이를 수정하고자 할 경우, 기존처럼 500줄이 넘는 뷰컨트롤러에서 하나씩 메서드들을 뒤져가며 찾을 필요가 없습니다. 채팅 입력창과 관련한 동작은 별도로 분리하였기 때문에, 해당 코드를 확인하면 됩니다. 

 기존에 구현되었던 뷰에서는 채팅 입력창의 각 UI 배치를 하나하나 직접 설정하여 UI 배치를 수정하기에도 까다로움이 있었는데요, 
기능을 분리한 후에는 UI 배치도 훨씬 용이해져서 `UIKeyboardLayoutGuide`를 적극적으로 사용할 수 있었고, 이를 통해 위에서 언급한 첫 번째 문제도 해결할 수 있었습니다. (이로 인해 #434 이슈는 닫도록 하겠습니다.)

### 기타
이처럼 기능을 별도로 분리하는 것이 훨씬 낫다고 느꼈습니다. 뷰컨트롤러가 필요 이상으로 비대해지는 것을 막을 수도 있고, 유지보수도 간편해지며, 불필요한 코드의 반복도 줄일 수 있습니다. 향후 구현되는 기능들 역시 코드 간 의존성을 염두에 두고 작업을 진행하면 훨씬 좋을 것 같다고 생각했습니다. 이렇게 할 경우, 추후 도입할지도 모르는 코드의 모듈화 시 훨씬 수월하게 작업할 수 있으리라 생각합니다.
<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### ❗️PR Point
<!-- 부족했던 점 혹은 개선하고 싶은 방향이 있다면 얘기해주세요 -->

- 코드 컨벤션 제안
`ChatTextInputView`와 `ChatTextDisplayView`에서 extension을 통해 메서드들을 관리할 때 외부 접근을 최소화한 코드들의 관리를 편하게 하기 위해 private extension과 public extension을 분리해보았습니다. 그러나 이는 코드 컨벤션과 다른 부분이 있는 것으로 생각하기 때문에, 파트원들의 의견을 받습니다.
 
  현재는 한 extension 내에서 private func 과 internal func 을 모두 관리하는데요, 향후 코드의 모듈화를 쉽게 하고, 유지보수를 쉽게 하기 위해 함수의 접근제어 수준에 따라 extension을 분리하여 코드를 작성하는 방안도 같이 도입하면 어떨지 제안드립니다.

- 공통적으로 사용되는 코드 변경
`OffroadTabBarController`의 코드 일부가 변경되었습니다.
탭바를 나타내는 애니메이션이 끝난 이후에 동작을 추가할 필요성이 생겨서 `OffroadTabBarController` 타입의 `showTabBarAnimation(delayFactor:)` 메서드에 completion 매개변수를 추가하였습니다. 
기존 코드에서 충돌이 일어나지 않도록 completion 메서드의 기본값으로 nil을 할당하였으며, tabBar가 나타난 후의 동작을 구현하고자 하는 경우 해당 콜백 함수를 이용할 수 있습니다. 

<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->

|뷰|설명|
|:------:|:---:|
|        |     |


- Resolved: #463 
