### PR TITLE
[Refactor] #466 - 장소 목록 뷰에서 컬렉션 뷰 기능 분리

### DIFF
--- a/Offroad-iOS/Offroad-iOS.xcodeproj/project.pbxproj
+++ b/Offroad-iOS/Offroad-iOS.xcodeproj/project.pbxproj
@@ -385,6 +385,8 @@
 		4EC3EC952CA91A0C008139BE /* PlaceListCollectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EC3EC942CA91A0C008139BE /* PlaceListCollectionViewController.swift */; };
 		4EC4A1ED2D24380700A8C130 /* CustomIntensityBlurView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EC4A1EC2D24380700A8C130 /* CustomIntensityBlurView.swift */; };
 		4EC4A1FE2D246BB700A8C130 /* ORBAlertViewCouponRedemptionFailure.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EC4A1FD2D246BB700A8C130 /* ORBAlertViewCouponRedemptionFailure.swift */; };
+		4EC611632D5F167300B09E23 /* PlaceListCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EC611622D5F167300B09E23 /* PlaceListCollectionView.swift */; };
+		4EC611642D5F167300B09E23 /* PlaceListCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EC611622D5F167300B09E23 /* PlaceListCollectionView.swift */; };
 		4EC6F0A62CF4747400895A87 /* UIScrollView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EC6F0A52CF4747400895A87 /* UIScrollView+.swift */; };
 		4ECCC95E2CC80088002B9C4F /* ORBToastView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ECCC95D2CC80088002B9C4F /* ORBToastView.swift */; };
 		4ECEEA6E2CB2C15E0029369A /* ORBTabBarShapeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ECEEA6D2CB2C15E0029369A /* ORBTabBarShapeView.swift */; };
@@ -695,6 +697,7 @@
 		4EC3EC942CA91A0C008139BE /* PlaceListCollectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaceListCollectionViewController.swift; sourceTree = "<group>"; };
 		4EC4A1EC2D24380700A8C130 /* CustomIntensityBlurView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomIntensityBlurView.swift; sourceTree = "<group>"; };
 		4EC4A1FD2D246BB700A8C130 /* ORBAlertViewCouponRedemptionFailure.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ORBAlertViewCouponRedemptionFailure.swift; sourceTree = "<group>"; };
+		4EC611622D5F167300B09E23 /* PlaceListCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaceListCollectionView.swift; sourceTree = "<group>"; };
 		4EC6F0A52CF4747400895A87 /* UIScrollView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIScrollView+.swift"; sourceTree = "<group>"; };
 		4ECCC95D2CC80088002B9C4F /* ORBToastView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ORBToastView.swift; sourceTree = "<group>"; };
 		4ECEEA6D2CB2C15E0029369A /* ORBTabBarShapeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ORBTabBarShapeView.swift; sourceTree = "<group>"; };
@@ -1426,6 +1429,7 @@
 			children = (
 				4E08B9582C5DF0B20082EFB8 /* PlaceListView.swift */,
 				4E08B9612C5E78EB0082EFB8 /* PlaceCollectionViewCell.swift */,
+				4EC611622D5F167300B09E23 /* PlaceListCollectionView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -3222,6 +3226,7 @@
 				D0E796632C4553F0005B47A5 /* RefreshTokenResponseDTO.swift in Sources */,
 				D00A48622C633947008B286A /* SettingView.swift in Sources */,
 				4E46E5FD2CBA483D000A1EEE /* UIViewController+.swift in Sources */,
+				4EC611632D5F167300B09E23 /* PlaceListCollectionView.swift in Sources */,
 				D064669C2C86FCE800CF10FD /* DeleteAccountView.swift in Sources */,
 				D0E7960A2C4522CF005B47A5 /* NetworkService.swift in Sources */,
 				D00A48772C634530008B286A /* SettingBaseView.swift in Sources */,
@@ -3524,6 +3529,7 @@
 				4E4F31B22D4718F400C3B2FF /* ORBAlertBackgroundView.swift in Sources */,
 				4E4F31B32D4718F400C3B2FF /* CouponRedemptionResponseDTO.swift in Sources */,
 				4E4F31B42D4718F400C3B2FF /* AuthAPI.swift in Sources */,
+				4EC611642D5F167300B09E23 /* PlaceListCollectionView.swift in Sources */,
 				4E4F31B52D4718F400C3B2FF /* CharacterChoosingResponseDTO.swift in Sources */,
 				4E4F31B62D4718F400C3B2FF /* FontLiterals.swift in Sources */,
 				4E4F31B72D4718F400C3B2FF /* UIScrollView+.swift in Sources */,

--- a/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/Loading/ScrollLoadingCollectionView.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/Loading/ScrollLoadingCollectionView.swift
@@ -9,7 +9,7 @@ import UIKit
 
 import Lottie
 
-final class ScrollLoadingCollectionView: EmptyStateCollectionView, ScrollLoading {
+class ScrollLoadingCollectionView: EmptyStateCollectionView, ScrollLoading {
     
     var topLoadingAnimationView: Lottie.LottieAnimationView = LottieAnimationView(name: "loading1")
     var leftLoadingAnimationView: Lottie.LottieAnimationView = LottieAnimationView(name: "loading1")

--- a/Offroad-iOS/Offroad-iOS/Presentation/PlaceList/ViewControllers/PlaceListCollectionViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/PlaceList/ViewControllers/PlaceListCollectionViewController.swift
@@ -5,28 +5,122 @@
 //  Created by 김민성 on 9/29/24.
 //
 
+import CoreLocation
 import UIKit
 
+import RxSwift
+import RxCocoa
+
 ///  장소 목록 뷰의 PageViewController에 보여질 view controller
-class PlaceListCollectionViewController: UIViewController {
+class PlaceListCollectionViewController: UICollectionViewController {
     
-    //MARK: - UI Properties
+    //MARK: - Properties
     
-    private let collectionView: UICollectionView
+    /// 마지막 cell이 화면에 보여질 때 이벤트를 방출하는 `Observable` 스트림.
+    var lastCellWillBeDisplayed: Observable<Void> { return lastCellWillShowRelay.asObservable() }
+    var placeListCollectionView: PlaceListCollectionView { collectionView as! PlaceListCollectionView }
+    
+    //MARK: - Private Properties
+    
+    private let lastCellWillShowRelay: PublishRelay<Void> = .init()
+    private let cellSelectionOperationQueue = OperationQueue()
+    
+    private var source: [RegisteredPlaceInfo] = []
+    private var referenceCoordinate: CLLocationCoordinate2D
+    private var showsVisitCount: Bool
     
     //MARK: - Life Cycle
     
-    init(collectionView: UICollectionView) {
-        self.collectionView = collectionView
+    init(place: CLLocationCoordinate2D, showVisitCount: Bool) {
+        self.referenceCoordinate = place
+        self.showsVisitCount = showVisitCount
         super.init(nibName: nil, bundle: nil)
+        
+        collectionView = PlaceListCollectionView()
     }
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
     
-    override func loadView() {
-        view = collectionView
-    }
+}
 
+extension PlaceListCollectionViewController {
+    
+    /// collection view의 목록 마지막에 새 아이템들을 추가.
+    /// - Parameter newPlaces: 추가될 장소 목록
+    ///
+    /// 주의!) 반드시 메인쓰레드에서만 호출할 것
+    func appendNewItems(newPlaces: [RegisteredPlaceInfo]) {
+        guard !newPlaces.isEmpty else { return }
+        
+        let newIndexPaths: [IndexPath] = (0..<newPlaces.count).map { [weak self] in
+            guard let self else { return [] }
+            return IndexPath(item: self.source.count + $0, section: 0)
+        }
+        source.append(contentsOf: newPlaces)
+        /*
+         MARK: iOS 17 버전의 시뮬레이터에서 collectionView에 insertItems를 적용하니 Invalid Batch Updates 에러가 발생하는 것을 확인하였음.
+         앱의 자연스러운 동작을 위해서는 insertItems를 사용하는 것이 좋으니 iOS 18에서는 insertItems를 사용하되,
+         iOS 17까지의 버전에서는 에러를 막기 위해 reloadData()를 사용.
+         당장 문제의 원인을 찾지는 못했으나 지속해서 찾아볼 예정.
+         */
+        if #available(iOS 18, *) {
+            collectionView.insertItems(at: newIndexPaths)
+        } else {
+            collectionView.reloadData()
+        }
+    }
+    
+}
+
+//MARK: - UICollectionViewDataSource
+
+extension PlaceListCollectionViewController {
+    
+    public override func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return source.count
+    }
+    
+    public override func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        guard let cell = collectionView.dequeueReusableCell(
+            withReuseIdentifier: PlaceCollectionViewCell.className,
+            for: indexPath
+        ) as? PlaceCollectionViewCell else { fatalError("cannot dequeue cell") }
+        cell.configureCell(with: source[indexPath.item], showingVisitingCount: showsVisitCount)
+        return cell
+    }
+    
+}
+
+extension PlaceListCollectionViewController {
+    
+    public override func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool {
+        let animator = UIViewPropertyAnimator(duration: 0.3, dampingRatio: 1)
+        animator.addAnimations {
+            if collectionView.indexPathsForSelectedItems?.contains(indexPath) ?? false {
+                collectionView.deselectItem(at: indexPath, animated: false)
+            } else {
+                collectionView.selectItem(at: indexPath, animated: false, scrollPosition: UICollectionView.ScrollPosition())
+            }
+            collectionView.performBatchUpdates(nil)
+        }
+        
+        let animationOperation = BlockOperation {
+            DispatchQueue.main.async { animator.startAnimation() }
+        }
+        
+        cellSelectionOperationQueue.addOperation(animationOperation)
+        return false
+    }
+    
+    public override func collectionView(
+        _ collectionView: UICollectionView,
+        willDisplay cell: UICollectionViewCell,
+        forItemAt indexPath: IndexPath
+    ) {
+        let isLastCell: Bool = (indexPath.section == 0) && (indexPath.item == source.count - 1)
+        if isLastCell { lastCellWillShowRelay.accept(()) }
+    }
+    
 }

--- a/Offroad-iOS/Offroad-iOS/Presentation/PlaceList/ViewControllers/PlaceListCollectionViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/PlaceList/ViewControllers/PlaceListCollectionViewController.swift
@@ -60,10 +60,8 @@ extension PlaceListCollectionViewController {
         }
         source.append(contentsOf: newPlaces)
         /*
-         MARK: iOS 17 버전의 시뮬레이터에서 collectionView에 insertItems를 적용하니 Invalid Batch Updates 에러가 발생하는 것을 확인하였음.
-         앱의 자연스러운 동작을 위해서는 insertItems를 사용하는 것이 좋으니 iOS 18에서는 insertItems를 사용하되,
-         iOS 17까지의 버전에서는 에러를 막기 위해 reloadData()를 사용.
-         당장 문제의 원인을 찾지는 못했으나 지속해서 찾아볼 예정.
+         iOS 17 버전의 시뮬레이터에서 collectionView에 insertItems를 사용하니 Invalid Batch Updates 에러가 발생하여,
+         iOS 17까지의 버전에서는 혹시 모를 에러를 막기 위해 reloadData() 사용.
          */
         if #available(iOS 18, *) {
             collectionView.insertItems(at: newIndexPaths)

--- a/Offroad-iOS/Offroad-iOS/Presentation/PlaceList/Views/PlaceListCollectionView.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/PlaceList/Views/PlaceListCollectionView.swift
@@ -1,0 +1,8 @@
+//
+//  PlaceListCollectionView.swift
+//  Offroad-iOS
+//
+//  Created by 김민성 on 2/14/25.
+//
+
+import Foundation

--- a/Offroad-iOS/Offroad-iOS/Presentation/PlaceList/Views/PlaceListCollectionView.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/PlaceList/Views/PlaceListCollectionView.swift
@@ -5,4 +5,61 @@
 //  Created by 김민성 on 2/14/25.
 //
 
-import Foundation
+import CoreLocation
+import UIKit
+
+import RxSwift
+import RxCocoa
+
+class PlaceListCollectionView: ScrollLoadingCollectionView {
+    
+    //MARK: - Life Cycle
+    
+    init() {
+        let collectionViewHorizontalInset: CGFloat = 24
+        let collectionViewVerticalInset: CGFloat = 20
+        let itemWidth = floor(UIScreen.current.bounds.width - collectionViewHorizontalInset * 2)
+        
+        let flowLayout = UICollectionViewFlowLayout().then { flowLayout in
+            flowLayout.scrollDirection = .vertical
+            flowLayout.sectionInset = .init(
+                top: collectionViewVerticalInset,
+                left: collectionViewHorizontalInset,
+                bottom: 40,
+                right: collectionViewHorizontalInset
+            )
+            flowLayout.minimumLineSpacing = 16
+            flowLayout.minimumInteritemSpacing = 100
+            flowLayout.estimatedItemSize = CGSize(width: itemWidth, height: 125)
+        }
+        
+        super.init(frame: .zero, collectionViewLayout: flowLayout)
+        
+        setupStyle()
+        registerCells()
+    }
+    
+    @MainActor required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+}
+
+//MARK: - Private Extension
+
+private extension PlaceListCollectionView {
+    
+    //MARK: - Private Func
+    
+    func setupStyle() {
+        backgroundColor = .primary(.listBg)
+        indicatorStyle = .black
+        contentInsetAdjustmentBehavior = .never
+        scrollIndicatorInsets = .zero
+    }
+    
+    func registerCells() {
+        register(PlaceCollectionViewCell.self, forCellWithReuseIdentifier: PlaceCollectionViewCell.className)
+    }
+    
+}

--- a/Offroad-iOS/Offroad-iOS/Presentation/PlaceList/Views/PlaceListView.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/PlaceList/Views/PlaceListView.swift
@@ -22,9 +22,6 @@ class PlaceListView: UIView {
     private let separator = UIView()
     let pageViewController = UIPageViewController(transitionStyle: .scroll, navigationOrientation: .horizontal)
     
-    var unvisitedPlacesCollectionView: ScrollLoadingCollectionView!
-    var allPlacesCollectionView: ScrollLoadingCollectionView!
-    
     private var layoutMaker: UICollectionViewFlowLayout {
         let collectionViewHorizontalInset: CGFloat = 24
         let collectionViewVerticalInset: CGFloat = 20
@@ -81,10 +78,10 @@ extension PlaceListView {
         customBackButton.do { button in
             var configuration = UIButton.Configuration.plain()
             configuration.titleTextAttributesTransformer = transformer
-            // 지금은 SFSymbol 사용, 추후 변경 예정
-            configuration.image = .init(systemName: "chevron.left")?.withTintColor(.main(.main2))
+            configuration.image = .backBarButton
             configuration.baseForegroundColor = .main(.main2)
-            configuration.imagePadding = 10
+            configuration.imagePadding = 0
+            configuration.contentInsets = .zero
             configuration.title = "탐험"
             
             button.configuration = configuration
@@ -99,18 +96,6 @@ extension PlaceListView {
         separator.do { view in
             view.backgroundColor = .grayscale(.gray100)
         }
-        
-        unvisitedPlacesCollectionView = ScrollLoadingCollectionView(frame: .zero, collectionViewLayout: layoutMaker)
-        unvisitedPlacesCollectionView.backgroundColor = .primary(.listBg)
-        unvisitedPlacesCollectionView.indicatorStyle = .black
-        unvisitedPlacesCollectionView.setEmptyStateMessage(EmptyCaseMessage.unvisitedPlaceList)
-        unvisitedPlacesCollectionView.contentInsetAdjustmentBehavior = .never
-        
-        allPlacesCollectionView = ScrollLoadingCollectionView(frame: .zero, collectionViewLayout: layoutMaker)
-        allPlacesCollectionView.backgroundColor = .primary(.listBg)
-        allPlacesCollectionView.indicatorStyle = .black
-        allPlacesCollectionView.setEmptyStateMessage(EmptyCaseMessage.placeList)
-        allPlacesCollectionView.contentInsetAdjustmentBehavior = .never
     }
     
     private func setupHierarchy() {


### PR DESCRIPTION
### 🌴 작업한 브랜치
- #466 


### ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->
장소 목록 뷰에서 각 컬렉션뷰의 역할을 분리하였습니다.
현재 `PlaceListViewController`에서는 한 개의 pageViewController와 두 개의 (collectionView를 띄우는) viewController 모두를 관리하고 있습니다. 
이때 pageViewController나 collectionView의 dataSource 및 delegate를 모두 한 곳에서 도맡아 관리하기 때문에 코드가 복잡해진다고 생각했습니다.
장소 목록 뷰의 뷰컨트롤러(PlaceListViewController)에서는 pageViewController만을 관리하고, 이 pageViewController에 들어가는 뷰컨트롤러 타입은 별도로 만들어서 따로 관리하는 게 더 효율적이라고 판단하였습니다.
이를 위해 `PlaceListCollectionViewController`를 대폭 수정하였고, `PlaceListCollectionView` 타입을 추가하였습니다.

- 새로 추가된 `PlaceListCollectionView`는 장소 목록 뷰에서 보여줄 collectionView 자체에 해당합니다. 이 collectionView의 레이아웃과 기본적인 디자인을 이 타입에서 구현합니다.
- `PlaceListCollectionViewController`의 타입은 원래 `UIViewController`였지만, `UICollectionViewController` 타입으로 변경하였습니다.
이로 인해 `PlaceListCollectionViewController`는 `PlaceListCollectionView`의 dataSource와 delegate를 담당합니다. (`UICollectionViewController`에서 기본으로 지원합니다.)

무한스크롤 시
`PlaceListViewController` 에서는 새 데이터를 불러와야하는 시점을 구독하여 이때 새 장소 데이터를 서버에 요청하는 역할을 합니다. 
새 데이터를 불러온 후에 추가된 데이터를 컬렉션뷰에 반영하는 것은 기존의 `PlaceListViewController`가 아닌 `PlaceListCollectionViewController`에서 진행합니다.
<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### ❗️PR Point
<!-- 부족했던 점 혹은 개선하고 싶은 방향이 있다면 얘기해주세요 -->

<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->
외관상 변경된 부분은 없습니다.
|뷰|설명|
|:------:|:---:|
|        |     |


- Resolved: #466 
