### PR TITLE
[Fix] #470 - 빈 채팅 로그에서 채팅하기 버튼이 보이지 않는 문제 해결

### DIFF
--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/ChatLog/ViewControllers/CharacterChatLogViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/ChatLog/ViewControllers/CharacterChatLogViewController.swift
@@ -117,6 +117,7 @@ class CharacterChatLogViewController: OffroadTabBarViewController {
         rootView.backgroundView.isHidden = false
         guard let tabBarController = tabBarController as? OffroadTabBarController else { return }
         tabBarController.enableTabBarInteraction()
+        showChatButton()
     }
     
     override func viewWillDisappear(_ animated: Bool) {
@@ -284,7 +285,6 @@ extension CharacterChatLogViewController {
         rootView.chatButton.rx.tap.bind(onNext: { [weak self] in
             guard let self else { return }
             self.hideTabBar()
-            self.hideChatButton()
             self.rootView.chatTextInputView.startChat()
         }).disposed(by: disposeBag)
         


### PR DESCRIPTION
### 🌴 작업한 브랜치
- #470 


### ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->
채팅 로그에서 채팅 내역이 없을 시 '채팅하기' 버튼이 보이지 않는 문제가 발견되어, 이를 해결하였습니다.
또한, 기존에는 채팅하기 버튼을 누르면 채팅하기 버튼이 숨겨졌는데, 
숨겨질 경우, 채팅 내용이 없으면 버튼이 다시 나타나지 않는 문제가 발견되어 채팅 버튼을 눌러도 숨겨지지 않도록 하였습니다.
<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### ❗️PR Point
<!-- 부족했던 점 혹은 개선하고 싶은 방향이 있다면 얘기해주세요 -->

<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->

|뷰|설명|
|:------:|:---:|
|     <img src="https://github.com/user-attachments/assets/00daa4d7-b7ec-429e-b1ae-bb2961d2538e" width=200>   |  <img src="https://github.com/user-attachments/assets/d711f171-71a2-4165-9e2b-219593039cad" width=200>   |


- Resolved: #470
