### PR TITLE
[Feat] #465 - 일기 시간 뷰 UI 구현

### DIFF
--- a/Offroad-iOS/Offroad-iOS.xcodeproj/project.pbxproj
+++ b/Offroad-iOS/Offroad-iOS.xcodeproj/project.pbxproj
@@ -489,8 +489,6 @@
 		D03C83622C620AF100F3094D /* MyPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D03C83612C620AF100F3094D /* MyPageView.swift */; };
 		D05B70D22D63257800A1E206 /* DiaryTimeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D05B70D02D63257000A1E206 /* DiaryTimeView.swift */; };
 		D05B70D52D63286800A1E206 /* DiaryTimeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D05B70D32D63285F00A1E206 /* DiaryTimeViewController.swift */; };
-		D05B70D62D63B69F00A1E206 /* DiaryTimeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D05B70D02D63257000A1E206 /* DiaryTimeView.swift */; };
-		D05B70D72D63B6A300A1E206 /* DiaryTimeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D05B70D32D63285F00A1E206 /* DiaryTimeViewController.swift */; };
 		D05C31DC2CDB4441004761A7 /* ShareableImageProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = D05C31DB2CDB4440004761A7 /* ShareableImageProvider.swift */; };
 		D05C31DF2CDEB574004761A7 /* AppUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = D05C31DE2CDEB55A004761A7 /* AppUtility.swift */; };
 		D0600BD82CE50AE600D8F1D6 /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = D0600BD72CE50AE600D8F1D6 /* FirebaseAnalytics */; };
@@ -3371,7 +3369,6 @@
 				D0E796202C4532A6005B47A5 /* ErrorResponseDTO.swift in Sources */,
 				D0E796332C453615005B47A5 /* NicknameCheckResponseDTO.swift in Sources */,
 				D0EAF21F2C3B02B700566543 /* SplashView.swift in Sources */,
-				D05B70D72D63B6A300A1E206 /* DiaryTimeViewController.swift in Sources */,
 				4EFCDFE12C92BD93006DEBB6 /* ORBAlertType.swift in Sources */,
 				4E99007E2CDBCD46007EEFF7 /* ORBCharacterChatManager.swift in Sources */,
 				4EF833EC2CC40CC200D94314 /* ORBAlertViewAcquiredEmblem.swift in Sources */,
@@ -3463,7 +3460,6 @@
 				D0EAF2242C3B7D7100566543 /* LoginView.swift in Sources */,
 				8792D0112C3DA1C9002051AC /* BirthView.swift in Sources */,
 				D00A488C2C7830F3008B286A /* TermsConsentPopupView.swift in Sources */,
-				D05B70D62D63B69F00A1E206 /* DiaryTimeView.swift in Sources */,
 				4E9900802CDBCD88007EEFF7 /* ORBCharacterChatViewController.swift in Sources */,
 				8792D0242C3F0843002051AC /* ChoosingCharacterCell.swift in Sources */,
 				4E08B95F2C5E53C10082EFB8 /* ORBSegmentedControlButton.swift in Sources */,

--- a/Offroad-iOS/Offroad-iOS.xcodeproj/project.pbxproj
+++ b/Offroad-iOS/Offroad-iOS.xcodeproj/project.pbxproj
@@ -485,6 +485,10 @@
 		D018BB112C4054D20048B6DF /* TitleModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D018BB102C4054D20048B6DF /* TitleModel.swift */; };
 		D03C835E2C61E44700F3094D /* TokenIntercepter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D03C835D2C61E44700F3094D /* TokenIntercepter.swift */; };
 		D03C83622C620AF100F3094D /* MyPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D03C83612C620AF100F3094D /* MyPageView.swift */; };
+		D05B70D22D63257800A1E206 /* DiaryTimeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D05B70D02D63257000A1E206 /* DiaryTimeView.swift */; };
+		D05B70D52D63286800A1E206 /* DiaryTimeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D05B70D32D63285F00A1E206 /* DiaryTimeViewController.swift */; };
+		D05B70D62D63B69F00A1E206 /* DiaryTimeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D05B70D02D63257000A1E206 /* DiaryTimeView.swift */; };
+		D05B70D72D63B6A300A1E206 /* DiaryTimeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D05B70D32D63285F00A1E206 /* DiaryTimeViewController.swift */; };
 		D05C31DC2CDB4441004761A7 /* ShareableImageProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = D05C31DB2CDB4440004761A7 /* ShareableImageProvider.swift */; };
 		D05C31DF2CDEB574004761A7 /* AppUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = D05C31DE2CDEB55A004761A7 /* AppUtility.swift */; };
 		D0600BD82CE50AE600D8F1D6 /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = D0600BD72CE50AE600D8F1D6 /* FirebaseAnalytics */; };
@@ -797,6 +801,8 @@
 		D018BB1B2C43E4740048B6DF /* Offroad-iOS.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Offroad-iOS.entitlements"; sourceTree = "<group>"; };
 		D03C835D2C61E44700F3094D /* TokenIntercepter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenIntercepter.swift; sourceTree = "<group>"; };
 		D03C83612C620AF100F3094D /* MyPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageView.swift; sourceTree = "<group>"; };
+		D05B70D02D63257000A1E206 /* DiaryTimeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryTimeView.swift; sourceTree = "<group>"; };
+		D05B70D32D63285F00A1E206 /* DiaryTimeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryTimeViewController.swift; sourceTree = "<group>"; };
 		D05C31DB2CDB4440004761A7 /* ShareableImageProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareableImageProvider.swift; sourceTree = "<group>"; };
 		D05C31DE2CDEB55A004761A7 /* AppUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUtility.swift; sourceTree = "<group>"; };
 		D0600BE12CE6192300D8F1D6 /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
@@ -1337,6 +1343,7 @@
 				D00A48602C633927008B286A /* View */,
 				D00A485F2C63391F008B286A /* ViewController */,
 				4E03947C2C2AA842007F0517 /* Notice */,
+				D05B70CD2D63236100A1E206 /* DiaryTime */,
 				4E0394802C2AA936007F0517 /* MarketingConsent */,
 				D0E9378E2CF6FC880061782D /* CustomerInquiry  */,
 				4E0394812C2AA969007F0517 /* Logout */,
@@ -2288,6 +2295,31 @@
 				D03C83612C620AF100F3094D /* MyPageView.swift */,
 			);
 			path = View;
+			sourceTree = "<group>";
+		};
+		D05B70CD2D63236100A1E206 /* DiaryTime */ = {
+			isa = PBXGroup;
+			children = (
+				D05B70CE2D63253100A1E206 /* View */,
+				D05B70CF2D63253700A1E206 /* ViewController */,
+			);
+			path = DiaryTime;
+			sourceTree = "<group>";
+		};
+		D05B70CE2D63253100A1E206 /* View */ = {
+			isa = PBXGroup;
+			children = (
+				D05B70D02D63257000A1E206 /* DiaryTimeView.swift */,
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
+		D05B70CF2D63253700A1E206 /* ViewController */ = {
+			isa = PBXGroup;
+			children = (
+				D05B70D32D63285F00A1E206 /* DiaryTimeViewController.swift */,
+			);
+			path = ViewController;
 			sourceTree = "<group>";
 		};
 		D0600BE32CE61DCD00D8F1D6 /* PushNotification */ = {
@@ -3330,6 +3362,7 @@
 				D0E796202C4532A6005B47A5 /* ErrorResponseDTO.swift in Sources */,
 				D0E796332C453615005B47A5 /* NicknameCheckResponseDTO.swift in Sources */,
 				D0EAF21F2C3B02B700566543 /* SplashView.swift in Sources */,
+				D05B70D72D63B6A300A1E206 /* DiaryTimeViewController.swift in Sources */,
 				4EFCDFE12C92BD93006DEBB6 /* ORBAlertType.swift in Sources */,
 				4E99007E2CDBCD46007EEFF7 /* ORBCharacterChatManager.swift in Sources */,
 				4EF833EC2CC40CC200D94314 /* ORBAlertViewAcquiredEmblem.swift in Sources */,
@@ -3421,6 +3454,7 @@
 				D0EAF2242C3B7D7100566543 /* LoginView.swift in Sources */,
 				8792D0112C3DA1C9002051AC /* BirthView.swift in Sources */,
 				D00A488C2C7830F3008B286A /* TermsConsentPopupView.swift in Sources */,
+				D05B70D62D63B69F00A1E206 /* DiaryTimeView.swift in Sources */,
 				4E9900802CDBCD88007EEFF7 /* ORBCharacterChatViewController.swift in Sources */,
 				8792D0242C3F0843002051AC /* ChoosingCharacterCell.swift in Sources */,
 				4E08B95F2C5E53C10082EFB8 /* ORBSegmentedControlButton.swift in Sources */,
@@ -3610,6 +3644,7 @@
 				4E4F31E32D4718F400C3B2FF /* ORBCharacterChatManager.swift in Sources */,
 				4E4F31E42D4718F400C3B2FF /* ORBAlertViewAcquiredEmblem.swift in Sources */,
 				4E4F31E52D4718F400C3B2FF /* CouponCell.swift in Sources */,
+				D05B70D52D63286800A1E206 /* DiaryTimeViewController.swift in Sources */,
 				4E4F31E62D4718F400C3B2FF /* NetworkMonitoringManager.swift in Sources */,
 				4E4F31E72D4718F400C3B2FF /* ShareableImageProvider.swift in Sources */,
 				4E4F31E82D4718F400C3B2FF /* CharacterAPI.swift in Sources */,
@@ -3718,6 +3753,7 @@
 				4E4F324E2D4718F400C3B2FF /* QuestListAPI.swift in Sources */,
 				4E4F324F2D4718F400C3B2FF /* TermsConsentViewController.swift in Sources */,
 				4E4F32502D4718F400C3B2FF /* EmblemPopupViewController.swift in Sources */,
+				D05B70D22D63257800A1E206 /* DiaryTimeView.swift in Sources */,
 				4E4F32512D4718F400C3B2FF /* PlaceService.swift in Sources */,
 				4E4F32522D4718F400C3B2FF /* CharacterListViewModel.swift in Sources */,
 				4E4F32532D4718F400C3B2FF /* ORBAlertController.swift in Sources */,

--- a/Offroad-iOS/Offroad-iOS.xcodeproj/project.pbxproj
+++ b/Offroad-iOS/Offroad-iOS.xcodeproj/project.pbxproj
@@ -533,6 +533,8 @@
 		D06D26E22C400C3800E79F25 /* TitleCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D06D26E12C400C3800E79F25 /* TitleCollectionViewCell.swift */; };
 		D0930BB72D6A4C64002A9DCA /* ORBAlertViewMessageOnly.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0930BB62D6A4C64002A9DCA /* ORBAlertViewMessageOnly.swift */; };
 		D0930BB82D6A4C64002A9DCA /* ORBAlertViewMessageOnly.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0930BB62D6A4C64002A9DCA /* ORBAlertViewMessageOnly.swift */; };
+		D09A196F2D70589900B07FC2 /* TimePeriod.swift in Sources */ = {isa = PBXBuildFile; fileRef = D09A196E2D70589500B07FC2 /* TimePeriod.swift */; };
+		D09A19702D7058D500B07FC2 /* TimePeriod.swift in Sources */ = {isa = PBXBuildFile; fileRef = D09A196E2D70589500B07FC2 /* TimePeriod.swift */; };
 		D0B81AA42C472B9500C44ED9 /* CharacterChoosingResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B81AA32C472B9500C44ED9 /* CharacterChoosingResponseDTO.swift */; };
 		D0BD451F2CC77C3200128E74 /* MyPageCustomButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0BD451E2CC77C3200128E74 /* MyPageCustomButton.swift */; };
 		D0C6FD132CE6561400517480 /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = D0C6FD122CE6561400517480 /* FirebaseMessaging */; };
@@ -846,6 +848,7 @@
 		D06D26DD2C3FE21B00E79F25 /* TitlePopupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitlePopupView.swift; sourceTree = "<group>"; };
 		D06D26E12C400C3800E79F25 /* TitleCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleCollectionViewCell.swift; sourceTree = "<group>"; };
 		D0930BB62D6A4C64002A9DCA /* ORBAlertViewMessageOnly.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ORBAlertViewMessageOnly.swift; sourceTree = "<group>"; };
+		D09A196E2D70589500B07FC2 /* TimePeriod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimePeriod.swift; sourceTree = "<group>"; };
 		D0B81AA32C472B9500C44ED9 /* CharacterChoosingResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CharacterChoosingResponseDTO.swift; sourceTree = "<group>"; };
 		D0BD451E2CC77C3200128E74 /* MyPageCustomButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageCustomButton.swift; sourceTree = "<group>"; };
 		D0C6FD092CE6551C00517480 /* NotificationServiceExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = NotificationServiceExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -2309,6 +2312,7 @@
 		D05B70CD2D63236100A1E206 /* DiaryTime */ = {
 			isa = PBXGroup;
 			children = (
+				D09A196D2D70589000B07FC2 /* Enum */,
 				D05B70CE2D63253100A1E206 /* View */,
 				D05B70CF2D63253700A1E206 /* ViewController */,
 			);
@@ -2498,6 +2502,14 @@
 				D06D26E12C400C3800E79F25 /* TitleCollectionViewCell.swift */,
 			);
 			path = Cell;
+			sourceTree = "<group>";
+		};
+		D09A196D2D70589000B07FC2 /* Enum */ = {
+			isa = PBXGroup;
+			children = (
+				D09A196E2D70589500B07FC2 /* TimePeriod.swift */,
+			);
+			path = Enum;
 			sourceTree = "<group>";
 		};
 		D0BD451D2CC77C2300128E74 /* Component */ = {
@@ -3354,6 +3366,7 @@
 				4E1E94112C39870700A7B08A /* ColorLiterals.swift in Sources */,
 				D0E796012C45222D005B47A5 /* BaseTargetType.swift in Sources */,
 				D0E7964A2C4539CE005B47A5 /* RegisteredPlaceRequestDTO.swift in Sources */,
+				D09A19702D7058D500B07FC2 /* TimePeriod.swift in Sources */,
 				D0E796222C45334D005B47A5 /* ProfileAPI.swift in Sources */,
 				D0E796592C455100005B47A5 /* EmblemAPI.swift in Sources */,
 				D00A48992C7F04CF008B286A /* TermsListTableViewCell.swift in Sources */,
@@ -3695,6 +3708,7 @@
 				4E4F32072D4718F400C3B2FF /* CharacterService.swift in Sources */,
 				4E4F32082D4718F400C3B2FF /* CouponListViewController.swift in Sources */,
 				4E4F32092D4718F400C3B2FF /* CharacterChatPostResponseDTO.swift in Sources */,
+				D09A196F2D70589900B07FC2 /* TimePeriod.swift in Sources */,
 				4E4F320A2D4718F400C3B2FF /* UIImage+.swift in Sources */,
 				4E4F320B2D4718F400C3B2FF /* ProfileService.swift in Sources */,
 				4E4F320C2D4718F400C3B2FF /* CharacterDetailViewModel.swift in Sources */,

--- a/Offroad-iOS/Offroad-iOS.xcodeproj/project.pbxproj
+++ b/Offroad-iOS/Offroad-iOS.xcodeproj/project.pbxproj
@@ -469,6 +469,8 @@
 		D004F8582CA12B1500D5A2CD /* NoticeAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = D004F8572CA12B1000D5A2CD /* NoticeAPI.swift */; };
 		D004F85A2CA12B2200D5A2CD /* NoticeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D004F8592CA12B1C00D5A2CD /* NoticeService.swift */; };
 		D004F8CF2CB4DDE600D5A2CD /* KakaoAuthManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D004F8CE2CB4DDD800D5A2CD /* KakaoAuthManager.swift */; };
+		D006EA312D6DB3C4004D3D95 /* MyPageScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D006EA302D6DB3BC004D3D95 /* MyPageScrollView.swift */; };
+		D006EA322D6DB3C4004D3D95 /* MyPageScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D006EA302D6DB3BC004D3D95 /* MyPageScrollView.swift */; };
 		D00A48622C633947008B286A /* SettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D00A48612C633947008B286A /* SettingView.swift */; };
 		D00A48642C633959008B286A /* SettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D00A48632C633959008B286A /* SettingViewController.swift */; };
 		D00A486A2C633EF2008B286A /* SettingBaseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D00A48692C633EF2008B286A /* SettingBaseModel.swift */; };
@@ -785,6 +787,7 @@
 		D004F8572CA12B1000D5A2CD /* NoticeAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeAPI.swift; sourceTree = "<group>"; };
 		D004F8592CA12B1C00D5A2CD /* NoticeService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeService.swift; sourceTree = "<group>"; };
 		D004F8CE2CB4DDD800D5A2CD /* KakaoAuthManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KakaoAuthManager.swift; sourceTree = "<group>"; };
+		D006EA302D6DB3BC004D3D95 /* MyPageScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageScrollView.swift; sourceTree = "<group>"; };
 		D00A48612C633947008B286A /* SettingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingView.swift; sourceTree = "<group>"; };
 		D00A48632C633959008B286A /* SettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingViewController.swift; sourceTree = "<group>"; };
 		D00A48692C633EF2008B286A /* SettingBaseModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingBaseModel.swift; sourceTree = "<group>"; };
@@ -2500,6 +2503,7 @@
 		D0BD451D2CC77C2300128E74 /* Component */ = {
 			isa = PBXGroup;
 			children = (
+				D006EA302D6DB3BC004D3D95 /* MyPageScrollView.swift */,
 				D0BD451E2CC77C3200128E74 /* MyPageCustomButton.swift */,
 			);
 			path = Component;
@@ -3391,6 +3395,7 @@
 				4E46E5F92CB99944000A1EEE /* ORBToastWindow.swift in Sources */,
 				4EEA82FC2CE3907C0062F0DE /* CharacterChatLogView.swift in Sources */,
 				4E37B6CF2C456FBF007358DA /* UITabBar+.swift in Sources */,
+				D006EA322D6DB3C4004D3D95 /* MyPageScrollView.swift in Sources */,
 				4E0394E12C2AC059007F0517 /* NSObject+.swift in Sources */,
 				D0E796502C453B47005B47A5 /* AdventureService.swift in Sources */,
 				4E08B95B2C5E4F860082EFB8 /* ORBSegmentedControl.swift in Sources */,
@@ -3601,6 +3606,7 @@
 				4E4F31B32D4718F400C3B2FF /* CouponRedemptionResponseDTO.swift in Sources */,
 				4E4F31B42D4718F400C3B2FF /* AuthAPI.swift in Sources */,
 				4EC611642D5F167300B09E23 /* PlaceListCollectionView.swift in Sources */,
+				D006EA312D6DB3C4004D3D95 /* MyPageScrollView.swift in Sources */,
 				4E4F31B52D4718F400C3B2FF /* CharacterChoosingResponseDTO.swift in Sources */,
 				4E4F31B62D4718F400C3B2FF /* FontLiterals.swift in Sources */,
 				4E4F31B72D4718F400C3B2FF /* UIScrollView+.swift in Sources */,

--- a/Offroad-iOS/Offroad-iOS.xcodeproj/project.pbxproj
+++ b/Offroad-iOS/Offroad-iOS.xcodeproj/project.pbxproj
@@ -531,6 +531,8 @@
 		D06D26DA2C3FE1C700E79F25 /* TitlePopupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D06D26D92C3FE1C700E79F25 /* TitlePopupViewController.swift */; };
 		D06D26DE2C3FE21B00E79F25 /* TitlePopupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D06D26DD2C3FE21B00E79F25 /* TitlePopupView.swift */; };
 		D06D26E22C400C3800E79F25 /* TitleCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D06D26E12C400C3800E79F25 /* TitleCollectionViewCell.swift */; };
+		D0930BB72D6A4C64002A9DCA /* ORBAlertViewMessageOnly.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0930BB62D6A4C64002A9DCA /* ORBAlertViewMessageOnly.swift */; };
+		D0930BB82D6A4C64002A9DCA /* ORBAlertViewMessageOnly.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0930BB62D6A4C64002A9DCA /* ORBAlertViewMessageOnly.swift */; };
 		D0B81AA42C472B9500C44ED9 /* CharacterChoosingResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B81AA32C472B9500C44ED9 /* CharacterChoosingResponseDTO.swift */; };
 		D0BD451F2CC77C3200128E74 /* MyPageCustomButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0BD451E2CC77C3200128E74 /* MyPageCustomButton.swift */; };
 		D0C6FD132CE6561400517480 /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = D0C6FD122CE6561400517480 /* FirebaseMessaging */; };
@@ -842,6 +844,7 @@
 		D06D26D92C3FE1C700E79F25 /* TitlePopupViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitlePopupViewController.swift; sourceTree = "<group>"; };
 		D06D26DD2C3FE21B00E79F25 /* TitlePopupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitlePopupView.swift; sourceTree = "<group>"; };
 		D06D26E12C400C3800E79F25 /* TitleCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleCollectionViewCell.swift; sourceTree = "<group>"; };
+		D0930BB62D6A4C64002A9DCA /* ORBAlertViewMessageOnly.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ORBAlertViewMessageOnly.swift; sourceTree = "<group>"; };
 		D0B81AA32C472B9500C44ED9 /* CharacterChoosingResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CharacterChoosingResponseDTO.swift; sourceTree = "<group>"; };
 		D0BD451E2CC77C3200128E74 /* MyPageCustomButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageCustomButton.swift; sourceTree = "<group>"; };
 		D0C6FD092CE6551C00517480 /* NotificationServiceExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = NotificationServiceExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1918,6 +1921,7 @@
 			children = (
 				4EF6B03C2CC3EA9800066640 /* ORBAlertBaseView.swift */,
 				4EF6B0372CC3E7A900066640 /* ORBAlertViewNormal.swift */,
+				D0930BB62D6A4C64002A9DCA /* ORBAlertViewMessageOnly.swift */,
 				4EC4A1FD2D246BB700A8C130 /* ORBAlertViewCouponRedemptionFailure.swift */,
 				4EF6B03E2CC3EEFE00066640 /* ORBAlertViewTextField.swift */,
 				4EF6B0402CC3F1B900066640 /* ORBAlertViewTextFieldWithSubMessage.swift */,
@@ -3477,6 +3481,7 @@
 				4E393C9A2C48C9A6003403EC /* QuestResultViewController.swift in Sources */,
 				4E416CE82C45DBE200CF6AB4 /* ORBPlaceCategory.swift in Sources */,
 				D0EAF21B2C3B026500566543 /* SplashViewController.swift in Sources */,
+				D0930BB72D6A4C64002A9DCA /* ORBAlertViewMessageOnly.swift in Sources */,
 				4EFA808B2C3E79E800876D05 /* ORBMapListButton.swift in Sources */,
 				4E58FC002C7DFE78002A951B /* QuestListAPI.swift in Sources */,
 				D00A48962C783988008B286A /* TermsConsentViewController.swift in Sources */,
@@ -3676,6 +3681,7 @@
 				4E4F31FC2D4718F400C3B2FF /* BirthViewController.swift in Sources */,
 				4E4F31FD2D4718F400C3B2FF /* ORBAlertViewTextFieldWithSubMessage.swift in Sources */,
 				4E4F31FE2D4718F400C3B2FF /* LoadingView.swift in Sources */,
+				D0930BB82D6A4C64002A9DCA /* ORBAlertViewMessageOnly.swift in Sources */,
 				4E4F31FF2D4718F400C3B2FF /* KeychainManager.swift in Sources */,
 				4E4F32002D4718F400C3B2FF /* NoticeService.swift in Sources */,
 				4E4F32012D4718F400C3B2FF /* ORBPopup.swift in Sources */,

--- a/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/Alert/AlertView/ORBAlertViewMessageOnly.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/Alert/AlertView/ORBAlertViewMessageOnly.swift
@@ -1,0 +1,51 @@
+//
+//  ORBAlertViewMessageOnly.swift
+//  Offroad-iOS
+//
+//  Created by 조혜린 on 2/23/25.
+//
+
+import UIKit
+
+final class ORBAlertViewMessageOnly: ORBAlertBaseView, ORBAlertViewBaseUI {
+    
+    let type: ORBAlertType = .messageOnly
+    let contentView = UIView()
+    lazy var contentStackView: UIView = UIStackView(
+        arrangedSubviews: [messageLabel, buttonStackView]
+    ).then { stackView in
+        stackView.spacing = 24
+        stackView.axis = .vertical
+        stackView.alignment = .fill
+        stackView.distribution = .fill
+    }
+    
+    override func setupHierarchy() {
+        super.setupHierarchy()
+        addSubviews(contentView, closeButton)
+        contentView.addSubview(contentStackView)
+    }
+    
+    override func setupLayout() {
+        super.setupLayout()
+        
+        closeButton.snp.makeConstraints { make in
+            make.top.trailing.equalToSuperview().inset(12)
+            make.size.equalTo(44)
+        }
+        
+        contentView.snp.makeConstraints { make in
+            make.top.equalToSuperview().inset(topInset)
+            make.leading.equalToSuperview().inset(leftInset)
+            make.trailing.equalToSuperview().inset(rightInset)
+            make.bottom.equalToSuperview().inset(bottomInset)
+            make.height.greaterThanOrEqualTo(116)
+        }
+        
+        contentStackView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
+        
+        titleLabel.setContentHuggingPriority(.defaultHigh, for: .vertical)
+    }
+}

--- a/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/Alert/AlertView/ORBAlertViewNormal.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/Alert/AlertView/ORBAlertViewNormal.swift
@@ -41,7 +41,7 @@ final class ORBAlertViewNormal: ORBAlertBaseView, ORBAlertViewBaseUI {
             make.leading.equalToSuperview().inset(leftInset)
             make.trailing.equalToSuperview().inset(rightInset)
             make.bottom.equalToSuperview().inset(bottomInset)
-            make.height.greaterThanOrEqualTo(182)
+            make.height.greaterThanOrEqualTo(116)
         }
         
         contentStackView.snp.makeConstraints { make in
@@ -53,8 +53,11 @@ final class ORBAlertViewNormal: ORBAlertBaseView, ORBAlertViewBaseUI {
         spacerView2.setContentHuggingPriority(.init(0), for: .vertical)
         spacerView1.setContentCompressionResistancePriority(.init(999), for: .vertical)
         spacerView2.setContentCompressionResistancePriority(.init(999), for: .vertical)
+        spacerView1.snp.makeConstraints { make in
+            make.height.equalTo(12)
+        }
         spacerView2.snp.makeConstraints { make in
-            make.height.equalTo(spacerView1)
+            make.height.equalTo(24)
         }
     }
     

--- a/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/Alert/ORBAlertBackgroundView.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/Alert/ORBAlertBackgroundView.swift
@@ -65,7 +65,7 @@ extension ORBAlertBackgroundView {
     private func setupLayout() {
         alertView.snp.makeConstraints { make in
             make.horizontalEdges.equalToSuperview().inset(22.5)
-            make.height.greaterThanOrEqualTo(238)
+            make.height.greaterThanOrEqualTo(172)
         }
         alertViewCenterYCosntraint.isActive = true
     }

--- a/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/Alert/ORBAlertBackgroundView.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/Alert/ORBAlertBackgroundView.swift
@@ -28,6 +28,8 @@ internal class ORBAlertBackgroundView: UIView {
         switch type {
         case .normal:
             self.alertView = ORBAlertViewNormal()
+        case .messageOnly:
+            self.alertView = ORBAlertViewMessageOnly()
         case .couponRedemptionFailure:
             self.alertView = ORBAlertViewCouponRedemptionFailure()
         case .textField:

--- a/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/Alert/ORBAlertType.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/Alert/ORBAlertType.swift
@@ -14,6 +14,11 @@ enum ORBAlertType {
     case normal
     
     /**
+     제목 없이 설명, 버튼만 갖는 형태
+     */
+    case messageOnly
+    
+    /**
      텍스트 입력 창이 들어가는 형태
      text field의 위치는 button 바로 상단에 위치하며,
      text field의 위치를 다른 곳에 배치하고 싶을 경우,

--- a/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/Alert/Protocols/ORBAlertViewBaseUI.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/Alert/Protocols/ORBAlertViewBaseUI.swift
@@ -29,7 +29,7 @@ extension ORBAlertViewBaseUI {
     
     var topInset: CGFloat {
         switch type {
-        case .normal, .couponRedemptionFailure, .textField, .textFieldWithSubMessage, .custom:
+        case .normal, .messageOnly, .couponRedemptionFailure, .textField, .textFieldWithSubMessage, .custom:
             28
         case .scrollableContent, .explorationResult, .acquiredEmblem:
             38
@@ -38,7 +38,7 @@ extension ORBAlertViewBaseUI {
     
     var leftInset: CGFloat {
         switch type {
-        case .normal, .couponRedemptionFailure, .textField, .textFieldWithSubMessage, .scrollableContent, .explorationResult, .custom:
+        case .normal, .messageOnly, .couponRedemptionFailure, .textField, .textFieldWithSubMessage, .scrollableContent, .explorationResult, .custom:
             46
         case .acquiredEmblem:
             24
@@ -47,7 +47,7 @@ extension ORBAlertViewBaseUI {
     
     var rightInset: CGFloat {
         switch type {
-        case .normal, .couponRedemptionFailure, .textField, .textFieldWithSubMessage, .scrollableContent, .explorationResult, .custom:
+        case .normal, .messageOnly, .couponRedemptionFailure, .textField, .textFieldWithSubMessage, .scrollableContent, .explorationResult, .custom:
             46
         case .acquiredEmblem:
             24
@@ -56,7 +56,7 @@ extension ORBAlertViewBaseUI {
     
     var bottomInset: CGFloat {
         switch type {
-        case .normal, .couponRedemptionFailure, .textField, .textFieldWithSubMessage, .custom:
+        case .normal, .messageOnly, .couponRedemptionFailure, .textField, .textFieldWithSubMessage, .custom:
             28
         case .scrollableContent, .explorationResult:
             38

--- a/Offroad-iOS/Offroad-iOS/Global/Literals/StringLiterals.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Literals/StringLiterals.swift
@@ -32,11 +32,16 @@ struct AlertMessage {
     static let locationServicesDisabledMessage = "모험가님의 위치를 찾을 수 없어요.\n탐험을 위해서 위치 기능을 활성화해주세요."
     static let locationReducedAccuracyMessage = "모험가님의 정확한 위치를 찾을 수 없어요.\n탐험을 위해서 정확한 위치 접근 권한을 허용해주세요."
     static let completeQuestsTitle = "퀘스트 성공 !"
+    static let diaryTimeSettingMessage = "매일 이 시간에 일기를 받으시겠어요?"
+    static let diaryTimeUnsavedExitMessage = "일기 시간 설정을 저장하지 않고\n나가시겠어요?"
     static func completeSingleQuestMessage(questName: String) -> String {
         "퀘스트 '\(questName)'을(를) 클리어했어요! 마이페이지에서 보상을 확인해보세요."
     }
     static func completeMultipleQuestsMessage(firstQuestName: String, questCount: Int) -> String {
         "퀘스트 '\(firstQuestName)' 외 \(questCount - 1)개를 클리어했어요! 마이페이지에서 보상을 확인해보세요."
+    }
+    static func diaryTimeSettinTitle(selectedTimePeriod: TimePeriod, selectedTime: Int) -> String {
+        "\(selectedTimePeriod == .am ? "오전" : "오후") \(selectedTime)시"
     }
 }
 

--- a/Offroad-iOS/Offroad-iOS/Global/Resources/Assets.xcassets/MyPage/btn_diary.imageset/Contents.json
+++ b/Offroad-iOS/Offroad-iOS/Global/Resources/Assets.xcassets/MyPage/btn_diary.imageset/Contents.json
@@ -1,0 +1,15 @@
+{
+  "images" : [
+    {
+      "filename" : "btn_diary.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
+  }
+}

--- a/Offroad-iOS/Offroad-iOS/Global/Resources/Assets.xcassets/MyPage/btn_diary.imageset/btn_diary.svg
+++ b/Offroad-iOS/Offroad-iOS/Global/Resources/Assets.xcassets/MyPage/btn_diary.imageset/btn_diary.svg
@@ -1,0 +1,32 @@
+<svg width="345" height="138" viewBox="0 0 345 138" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="345" height="138" rx="10" fill="#F7FFD8"/>
+<g opacity="0.5">
+<rect x="200.062" y="25.8828" width="29.4292" height="90.4883" rx="5" fill="#D9D9D9"/>
+<rect x="200.062" y="25.8828" width="29.4292" height="90.4883" rx="5" fill="#D3F38B"/>
+</g>
+<rect x="170.633" y="41.6406" width="29.4292" height="74.7305" rx="5" fill="#D9D9D9"/>
+<rect x="170.633" y="41.6406" width="29.4292" height="74.7305" rx="5" fill="#D3F38B"/>
+<rect x="255.562" y="29.2539" width="26.0708" height="87.1172" rx="5" fill="#D9D9D9"/>
+<rect x="255.562" y="29.2539" width="26.0708" height="87.1172" rx="5" fill="url(#paint0_linear_174_569)"/>
+<g opacity="0.7">
+<rect x="229.491" y="29.2539" width="26.0708" height="87.1172" rx="5" fill="#D9D9D9"/>
+<rect x="229.491" y="29.2539" width="26.0708" height="87.1172" rx="5" fill="url(#paint1_linear_174_569)"/>
+</g>
+<rect x="280.363" y="41.6367" width="21.915" height="80.7305" rx="5" transform="rotate(-19.1862 280.363 41.6367)" fill="#B2E058"/>
+<rect x="170.633" y="50.6367" width="29.4292" height="10.0977" fill="#E5FFA9"/>
+<rect x="170.633" y="96.1367" width="29.4292" height="10.0977" fill="#E5FFA9"/>
+<rect x="283.101" y="49.7266" width="21.9752" height="10.0977" transform="rotate(-19.1862 283.101 49.7266)" fill="#E5FFA9"/>
+<rect x="300.974" y="100.863" width="21.9497" height="10.0977" transform="rotate(-19.1862 300.974 100.863)" fill="#E5FFA9"/>
+<path d="M200.062 30.8828C200.062 28.1214 202.301 25.8828 205.062 25.8828H224.491C227.253 25.8828 229.491 28.1214 229.491 30.8828V43.8164H200.062V30.8828Z" fill="#CEF283"/>
+<path d="M200.062 111.371C200.062 114.133 202.301 116.371 205.062 116.371H224.491C227.253 116.371 229.491 114.133 229.491 111.371V98.4375H200.062V111.371Z" fill="#CEF283"/>
+<defs>
+<linearGradient id="paint0_linear_174_569" x1="281.633" y1="72.8125" x2="255.562" y2="72.8125" gradientUnits="userSpaceOnUse">
+<stop stop-color="#C7EF78"/>
+<stop offset="1" stop-color="#BCE66B"/>
+</linearGradient>
+<linearGradient id="paint1_linear_174_569" x1="255.562" y1="72.8125" x2="229.491" y2="72.8125" gradientUnits="userSpaceOnUse">
+<stop stop-color="#C7EF78"/>
+<stop offset="1" stop-color="#BCE66B"/>
+</linearGradient>
+</defs>
+</svg>

--- a/Offroad-iOS/Offroad-iOS/Global/Resources/Assets.xcassets/Setting/img_clock.imageset/Contents.json
+++ b/Offroad-iOS/Offroad-iOS/Global/Resources/Assets.xcassets/Setting/img_clock.imageset/Contents.json
@@ -1,0 +1,15 @@
+{
+  "images" : [
+    {
+      "filename" : "img_clock.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
+  }
+}

--- a/Offroad-iOS/Offroad-iOS/Global/Resources/Assets.xcassets/Setting/img_clock.imageset/img_clock.svg
+++ b/Offroad-iOS/Offroad-iOS/Global/Resources/Assets.xcassets/Setting/img_clock.imageset/img_clock.svg
@@ -1,0 +1,13 @@
+<svg width="24" height="25" viewBox="0 0 24 25" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_12775_76788)">
+<circle cx="12" cy="12.916" r="12" fill="#817FE0"/>
+<circle cx="12.001" cy="12.916" r="9.50488" fill="#C0BFED"/>
+<path d="M12.0508 12.917V5.77148" stroke="#817FE0" stroke-width="2" stroke-linecap="round"/>
+<path d="M12.0508 12.916L8.375 9.24023" stroke="#5E59FF" stroke-width="2" stroke-linecap="round"/>
+</g>
+<defs>
+<clipPath id="clip0_12775_76788">
+<rect width="24" height="24" fill="white" transform="translate(0 0.916016)"/>
+</clipPath>
+</defs>
+</svg>

--- a/Offroad-iOS/Offroad-iOS/Presentation/MyPage/Component/MyPageScrollView.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/MyPage/Component/MyPageScrollView.swift
@@ -1,0 +1,17 @@
+//
+//  MyPageScrollView.swift
+//  Offroad-iOS
+//
+//  Created by 조혜린 on 2/25/25.
+//
+
+import UIKit
+
+final class MyPageScrollView: UIScrollView {
+  override func touchesShouldCancel(in view: UIView) -> Bool {
+    if view is UIButton {
+      return true
+    }
+    return super.touchesShouldCancel(in: view)
+  }
+}

--- a/Offroad-iOS/Offroad-iOS/Presentation/MyPage/Settings/DiaryTime/Enum/TimePeriod.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/MyPage/Settings/DiaryTime/Enum/TimePeriod.swift
@@ -1,0 +1,11 @@
+//
+//  TimePeriod.swift
+//  Offroad-iOS
+//
+//  Created by 조혜린 on 2/27/25.
+//
+
+enum TimePeriod: String, CaseIterable {
+    case am = "AM"
+    case pm = "PM"
+}

--- a/Offroad-iOS/Offroad-iOS/Presentation/MyPage/Settings/DiaryTime/View/DiaryTimeView.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/MyPage/Settings/DiaryTime/View/DiaryTimeView.swift
@@ -27,7 +27,7 @@ final class DiaryTimeView: UIView {
     private let checkCircleImageView = UIImageView(image: UIImage(resource: .iconCheckCircle))
     private let descriptionLabel1 = UILabel()
     private let descriptionLabel2 = UILabel()
-    private let completeButton = ShrinkableButton()
+    let completeButton = ShrinkableButton()
     
     // MARK: - Life Cycle
     

--- a/Offroad-iOS/Offroad-iOS/Presentation/MyPage/Settings/DiaryTime/View/DiaryTimeView.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/MyPage/Settings/DiaryTime/View/DiaryTimeView.swift
@@ -1,0 +1,217 @@
+//
+//  DiaryTimeView.swift
+//  Offroad-iOS
+//
+//  Created by 조혜린 on 2/17/25.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class DiaryTimeView: UIView {
+    
+    //MARK: - UI Properties
+    
+    let customBackButton = NavigationPopButton()
+    private let borderView = UIView()
+    private let titleLabel = UILabel()
+    private let titleImageView = UIImageView(frame: CGRect(origin: .init(), size: CGSize(width: 24, height: 24)))
+    private let diaryTimeImageView = UIImageView()
+    private let questionLabel = UILabel()
+    let timePickerView = UIPickerView()
+    private let highlightedRowView = UIView()
+    private let colonLabel = UILabel()
+    private let descriptionStackView = UIStackView()
+    private let checkCircleImageView = UIImageView(image: UIImage(resource: .iconCheckCircle))
+    private let descriptionLabel1 = UILabel()
+    private let descriptionLabel2 = UILabel()
+    private let completeButton = ShrinkableButton()
+    
+    // MARK: - Life Cycle
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setupHierarchy()
+        setupStyle()
+        setupLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+extension DiaryTimeView {
+    
+    // MARK: - Layout
+    
+    private func setupStyle() {
+        backgroundColor = .main(.main1)
+        
+        customBackButton.do {
+            $0.configureButtonTitle(titleString: "설정")
+        }
+        
+        borderView.do {
+            $0.backgroundColor = .grayscale(.gray100)
+        }
+        
+        titleImageView.do {
+            $0.image = .imgClock
+        }
+        
+        titleLabel.do {
+            $0.text = "일기 시간"
+            $0.font = .offroad(style: .iosTextTitle)
+            $0.textColor = .main(.main2)
+            $0.textAlignment = .center
+        }
+        
+        diaryTimeImageView.do {
+            $0.backgroundColor = .gray
+            $0.roundCorners(cornerRadius: 10)
+            $0.contentMode = .scaleAspectFit
+        }
+        
+        questionLabel.do {
+            $0.text = "매일 몇 시에 일기를 받아볼까요?"
+            $0.font = .offroad(style: .iosText)
+            $0.textColor = .main(.main2)
+            $0.textAlignment = .center
+            $0.setLineHeight(percentage: 150)
+        }
+        
+        highlightedRowView.do {
+            $0.backgroundColor = .primary(.listBg)
+            $0.roundCorners(cornerRadius: 8)
+        }
+        
+        colonLabel.do {
+            $0.text = ":"
+            $0.font = .offroad(style: .iosTextTitle)
+            $0.textColor = .main(.main2)
+        }
+        
+        descriptionStackView.do {
+            $0.axis = .horizontal
+            $0.spacing = 6
+            $0.alignment = .center
+        }
+        
+        descriptionLabel1.do {
+            $0.text = "시간을 설정하면,"
+            $0.font = .offroad(style: .iosBoxMedi)
+            $0.textColor = .sub(.sub2)
+            $0.textAlignment = .center
+            $0.setLineHeight(percentage: 160)
+        }
+        
+        descriptionLabel2.do {
+            $0.text = "최소 12시간 후에 일기를 받을 수 있어요."
+            $0.font = .offroad(style: .iosBoxMedi)
+            $0.textColor = .sub(.sub2)
+            $0.textAlignment = .center
+            $0.setLineHeight(percentage: 160)
+        }
+        
+        completeButton.do {
+            $0.setTitle("완료", for: .normal)
+            $0.setBackgroundColor(.main(.main2), for: .normal)
+            $0.titleLabel?.font = UIFont.offroad(style: .iosText)
+            $0.setTitleColor(UIColor.main(.main1), for: .normal)
+            $0.roundCorners(cornerRadius: 5)
+        }
+    }
+    
+    private func setupHierarchy() {
+        addSubviews(
+            customBackButton,
+            titleLabel,
+            titleImageView,
+            borderView,
+            diaryTimeImageView,
+            questionLabel,
+            highlightedRowView,
+            colonLabel,
+            timePickerView,
+            descriptionStackView,
+            descriptionLabel2,
+            completeButton
+        )
+        
+        descriptionStackView.addArrangedSubviews(checkCircleImageView, descriptionLabel1)
+    }
+    
+    private func setupLayout() {
+        customBackButton.snp.makeConstraints {
+            $0.top.equalTo(safeAreaLayoutGuide).inset(12)
+            $0.leading.equalToSuperview().inset(12)
+        }
+        
+        titleLabel.snp.makeConstraints {
+            $0.top.equalTo(safeAreaLayoutGuide).inset(98)
+            $0.leading.equalToSuperview().inset(24)
+        }
+        
+        titleImageView.snp.makeConstraints {
+            $0.centerY.equalTo(titleLabel.snp.centerY)
+            $0.leading.equalTo(titleLabel.snp.trailing).offset(8)
+        }
+        
+        borderView.snp.makeConstraints {
+            $0.top.equalTo(titleLabel.snp.bottom).offset(24)
+            $0.horizontalEdges.equalToSuperview()
+            $0.height.equalTo(1)
+        }
+        
+        diaryTimeImageView.snp.makeConstraints {
+            $0.top.equalTo(borderView.snp.bottom).offset(30)
+            $0.centerX.equalToSuperview()
+            $0.horizontalEdges.equalToSuperview().inset(81)
+        }
+        
+        questionLabel.snp.makeConstraints {
+            $0.top.equalTo(diaryTimeImageView.snp.bottom).offset(24)
+            $0.horizontalEdges.equalToSuperview()
+        }
+        
+        highlightedRowView.snp.makeConstraints {
+            $0.center.equalTo(timePickerView.snp.center)
+            $0.horizontalEdges.equalToSuperview().inset(10)
+            $0.height.equalTo(34)
+        }
+        
+        colonLabel.snp.makeConstraints {
+            $0.centerX.equalTo(timePickerView.snp.centerX).offset(-32)
+            $0.centerY.equalTo(timePickerView.snp.centerY).offset(-2)
+        }
+        
+        timePickerView.snp.makeConstraints {
+            $0.top.equalTo(questionLabel.snp.bottom).offset(10)
+            $0.horizontalEdges.equalToSuperview()
+            $0.height.equalTo(125)
+        }
+        
+        descriptionStackView.snp.makeConstraints {
+            $0.top.equalTo(timePickerView.snp.bottom).offset(35)
+            $0.centerX.equalToSuperview()
+            $0.height.equalTo(22)
+        }
+        
+        descriptionLabel2.snp.makeConstraints {
+            $0.top.equalTo(descriptionStackView.snp.bottom)
+            $0.centerX.equalToSuperview()
+            $0.height.equalTo(22)
+        }
+         
+        completeButton.snp.makeConstraints {
+            $0.top.equalTo(descriptionLabel2.snp.bottom).offset(36)
+            $0.bottom.equalToSuperview().inset(45)
+            $0.horizontalEdges.equalToSuperview().inset(24)
+            $0.height.equalTo(54)
+        }
+    }
+}

--- a/Offroad-iOS/Offroad-iOS/Presentation/MyPage/Settings/DiaryTime/View/DiaryTimeView.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/MyPage/Settings/DiaryTime/View/DiaryTimeView.swift
@@ -185,7 +185,7 @@ extension DiaryTimeView {
         }
         
         colonLabel.snp.makeConstraints {
-            $0.centerX.equalTo(timePickerView.snp.centerX).offset(-32)
+            $0.centerX.equalTo(timePickerView.snp.centerX).offset(-31)
             $0.centerY.equalTo(timePickerView.snp.centerY).offset(-2)
         }
         

--- a/Offroad-iOS/Offroad-iOS/Presentation/MyPage/Settings/DiaryTime/ViewController/DiaryTimeViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/MyPage/Settings/DiaryTime/ViewController/DiaryTimeViewController.swift
@@ -16,8 +16,6 @@ final class DiaryTimeViewController: UIViewController {
     private let times = (1...12).map { $0 }
     private let timePeriods = ["AM", "PM"]
     
-    private var selectedTime = Int()
-
     // MARK: - Life Cycle
     
     override func loadView() {

--- a/Offroad-iOS/Offroad-iOS/Presentation/MyPage/Settings/DiaryTime/ViewController/DiaryTimeViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/MyPage/Settings/DiaryTime/ViewController/DiaryTimeViewController.swift
@@ -13,8 +13,8 @@ final class DiaryTimeViewController: UIViewController {
     
     private let rootView = DiaryTimeView()
     
-    private let times = (1...12).map { $0 }
-    private let timePeriods = ["AM", "PM"]
+    private let times = Array(1...12)
+    private let timePeriods = TimePeriod.allCases
     
     // MARK: - Life Cycle
     
@@ -64,7 +64,7 @@ private extension DiaryTimeViewController {
     }
     
     func showExitAlertView() {
-        let alertController = ORBAlertController(message: "일기 시간 설정을 저장하지 않고\n나가시겠어요?", type: .messageOnly)
+        let alertController = ORBAlertController(message: AlertMessage.diaryTimeUnsavedExitMessage, type: .messageOnly)
         alertController.configureMessageLabel{ label in
             label.setLineHeight(percentage: 150)
         }
@@ -97,7 +97,7 @@ private extension DiaryTimeViewController {
 //        let selectedTimeResult = selectedTimePeriod == "AM" ? convertedTime : convertedTime + 12
 //        print(selectedTimeResult)
 
-        let alertController = ORBAlertController(title: "\(selectedTimePeriod == "AM" ? "오전" : "오후") \(selectedTime)시", message: "매일 이 시간에 일기를 받으시겠어요?", type: .normal)
+        let alertController = ORBAlertController(title: AlertMessage.diaryTimeSettinTitle(selectedTimePeriod: selectedTimePeriod, selectedTime: selectedTime), message: AlertMessage.diaryTimeSettingMessage, type: .normal)
         alertController.configureMessageLabel{ label in
             label.setLineHeight(percentage: 150)
         }
@@ -154,7 +154,7 @@ extension DiaryTimeViewController: UIPickerViewDelegate {
         if component == 0  {
             label.text = "\(times[row])        00"
         } else {
-            label.text = timePeriods[row]
+            label.text = timePeriods[row].rawValue
         }
         
         return label

--- a/Offroad-iOS/Offroad-iOS/Presentation/MyPage/Settings/DiaryTime/ViewController/DiaryTimeViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/MyPage/Settings/DiaryTime/ViewController/DiaryTimeViewController.swift
@@ -48,19 +48,18 @@ private extension DiaryTimeViewController {
     func setupDelegate() {
         rootView.timePickerView.delegate = self
         rootView.timePickerView.dataSource = self
+        
+        if let navigationController = self.navigationController {
+            navigationController.interactivePopGestureRecognizer?.delegate = self
+        }
     }
     
     func setupTarget() {
         rootView.customBackButton.addTarget(self, action: #selector(backButtonTapped), for: .touchUpInside)
         rootView.completeButton.addTarget(self, action: #selector(completeTapped), for: .touchUpInside)
     }
-}
     
-@objc private extension DiaryTimeViewController {
-
-    // MARK: - @objc Method
-    
-    func backButtonTapped() {
+    func showExitAlertView() {
         let alertController = ORBAlertController(message: "일기 시간 설정을 저장하지 않고\n나가시겠어요?", type: .messageOnly)
         alertController.configureMessageLabel{ label in
             label.setLineHeight(percentage: 150)
@@ -72,7 +71,17 @@ private extension DiaryTimeViewController {
         }
         alertController.addAction(cancelAction)
         alertController.addAction(okAction)
+        
         present(alertController, animated: true)
+    }
+}
+    
+@objc private extension DiaryTimeViewController {
+
+    // MARK: - @objc Method
+    
+    func backButtonTapped() {
+        showExitAlertView()
     }
     
     func completeTapped() {
@@ -94,6 +103,13 @@ private extension DiaryTimeViewController {
         alertController.addAction(cancelAction)
         alertController.addAction(okAction)
         present(alertController, animated: true)
+    }
+}
+
+extension DiaryTimeViewController: UIGestureRecognizerDelegate {
+    func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        showExitAlertView()
+        return false
     }
 }
 

--- a/Offroad-iOS/Offroad-iOS/Presentation/MyPage/Settings/DiaryTime/ViewController/DiaryTimeViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/MyPage/Settings/DiaryTime/ViewController/DiaryTimeViewController.swift
@@ -39,6 +39,12 @@ final class DiaryTimeViewController: UIViewController {
     override func viewWillLayoutSubviews() {
         rootView.timePickerView.subviews[1].isHidden = true
     }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        
+        navigationController?.interactivePopGestureRecognizer?.delegate = nil
+    }
 }
 
 private extension DiaryTimeViewController {
@@ -49,9 +55,7 @@ private extension DiaryTimeViewController {
         rootView.timePickerView.delegate = self
         rootView.timePickerView.dataSource = self
         
-        if let navigationController = self.navigationController {
-            navigationController.interactivePopGestureRecognizer?.delegate = self
-        }
+        navigationController?.interactivePopGestureRecognizer?.delegate = self
     }
     
     func setupTarget() {

--- a/Offroad-iOS/Offroad-iOS/Presentation/MyPage/Settings/DiaryTime/ViewController/DiaryTimeViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/MyPage/Settings/DiaryTime/ViewController/DiaryTimeViewController.swift
@@ -62,7 +62,18 @@ private extension DiaryTimeViewController {
     // MARK: - @objc Method
     
     func backButtonTapped() {
-        navigationController?.popViewController(animated: true)
+        let alertController = ORBAlertController(message: "일기 시간 설정을 저장하지 않고\n나가시겠어요?", type: .messageOnly)
+        alertController.configureMessageLabel{ label in
+            label.setLineHeight(percentage: 150)
+        }
+        alertController.xButton.isHidden = true
+        let cancelAction = ORBAlertAction(title: "아니요", style: .cancel) { _ in return }
+        let okAction = ORBAlertAction(title: "네", style: .default) { _ in
+            self.navigationController?.popViewController(animated: true)
+        }
+        alertController.addAction(cancelAction)
+        alertController.addAction(okAction)
+        present(alertController, animated: true)
     }
 }
 

--- a/Offroad-iOS/Offroad-iOS/Presentation/MyPage/Settings/DiaryTime/ViewController/DiaryTimeViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/MyPage/Settings/DiaryTime/ViewController/DiaryTimeViewController.swift
@@ -15,6 +15,8 @@ final class DiaryTimeViewController: UIViewController {
     
     private let timeStrings = (1...12).map { "\($0)" }
     private let timePeriods = ["AM", "PM"]
+    
+    private var selectedTime = Int()
 
     // MARK: - Life Cycle
     
@@ -41,22 +43,25 @@ final class DiaryTimeViewController: UIViewController {
     }
 }
 
-extension DiaryTimeViewController {
+private extension DiaryTimeViewController {
     
     // MARK: - Private Method
     
-    private func setupDelegate() {
+    func setupDelegate() {
         rootView.timePickerView.delegate = self
         rootView.timePickerView.dataSource = self
     }
     
-    private func setupTarget() {
+    func setupTarget() {
         rootView.customBackButton.addTarget(self, action: #selector(backButtonTapped), for: .touchUpInside)
     }
+}
     
+@objc private extension DiaryTimeViewController {
+
     // MARK: - @objc Method
     
-    @objc private func backButtonTapped() {
+    func backButtonTapped() {
         navigationController?.popViewController(animated: true)
     }
 }

--- a/Offroad-iOS/Offroad-iOS/Presentation/MyPage/Settings/DiaryTime/ViewController/DiaryTimeViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/MyPage/Settings/DiaryTime/ViewController/DiaryTimeViewController.swift
@@ -13,7 +13,7 @@ final class DiaryTimeViewController: UIViewController {
     
     private let rootView = DiaryTimeView()
     
-    private let timeStrings = (1...12).map { "\($0)" }
+    private let times = (1...12).map { $0 }
     private let timePeriods = ["AM", "PM"]
     
     private var selectedTime = Int()
@@ -54,6 +54,7 @@ private extension DiaryTimeViewController {
     
     func setupTarget() {
         rootView.customBackButton.addTarget(self, action: #selector(backButtonTapped), for: .touchUpInside)
+        rootView.completeButton.addTarget(self, action: #selector(completeTapped), for: .touchUpInside)
     }
 }
     
@@ -75,6 +76,27 @@ private extension DiaryTimeViewController {
         alertController.addAction(okAction)
         present(alertController, animated: true)
     }
+    
+    func completeTapped() {
+        let selectedTime = times[rootView.timePickerView.selectedRow(inComponent: 0)]
+        let selectedTimePeriod = timePeriods[rootView.timePickerView.selectedRow(inComponent: 1)]
+        
+//        서버 통신 시에 전송할 값
+//        let convertedTime = selectedTime == 12 ? 0 : selectedTime
+//        let selectedTimeResult = selectedTimePeriod == "AM" ? convertedTime : convertedTime + 12
+//        print(selectedTimeResult)
+
+        let alertController = ORBAlertController(title: "\(selectedTimePeriod == "AM" ? "오전" : "오후") \(selectedTime)시", message: "매일 이 시간에 일기를 받으시겠어요?", type: .normal)
+        alertController.configureMessageLabel{ label in
+            label.setLineHeight(percentage: 150)
+        }
+        alertController.xButton.isHidden = true
+        let cancelAction = ORBAlertAction(title: "아니요", style: .cancel) { _ in return }
+        let okAction = ORBAlertAction(title: "네", style: .default) { _ in return }
+        alertController.addAction(cancelAction)
+        alertController.addAction(okAction)
+        present(alertController, animated: true)
+    }
 }
 
 extension DiaryTimeViewController: UIPickerViewDataSource {
@@ -84,7 +106,7 @@ extension DiaryTimeViewController: UIPickerViewDataSource {
     
     func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
         if component == 0 {
-            return timeStrings.count
+            return times.count
         } else {
             return timePeriods.count
         }
@@ -112,7 +134,7 @@ extension DiaryTimeViewController: UIPickerViewDelegate {
         }
         
         if component == 0  {
-            label.text = "\(timeStrings[row])        00"
+            label.text = "\(times[row])        00"
         } else {
             label.text = timePeriods[row]
         }

--- a/Offroad-iOS/Offroad-iOS/Presentation/MyPage/Settings/DiaryTime/ViewController/DiaryTimeViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/MyPage/Settings/DiaryTime/ViewController/DiaryTimeViewController.swift
@@ -1,0 +1,118 @@
+//
+//  DiaryTimeViewController.swift
+//  Offroad-iOS
+//
+//  Created by 조혜린 on 2/17/25.
+//
+
+import UIKit
+
+final class DiaryTimeViewController: UIViewController {
+    
+    // MARK: - Properties
+    
+    private let rootView = DiaryTimeView()
+    
+    private let timeStrings = (1...12).map { "\($0)" }
+    private let timePeriods = ["AM", "PM"]
+
+    // MARK: - Life Cycle
+    
+    override func loadView() {
+        view = rootView
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        setupDelegate()
+        setupTarget()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        guard let offroadTabBarController = self.tabBarController as? OffroadTabBarController else { return }
+        offroadTabBarController.hideTabBarAnimation()
+    }
+    
+    override func viewWillLayoutSubviews() {
+        rootView.timePickerView.subviews[1].isHidden = true
+    }
+}
+
+extension DiaryTimeViewController {
+    
+    // MARK: - Private Method
+    
+    private func setupDelegate() {
+        rootView.timePickerView.delegate = self
+        rootView.timePickerView.dataSource = self
+    }
+    
+    private func setupTarget() {
+        rootView.customBackButton.addTarget(self, action: #selector(backButtonTapped), for: .touchUpInside)
+    }
+    
+    // MARK: - @objc Method
+    
+    @objc private func backButtonTapped() {
+        navigationController?.popViewController(animated: true)
+    }
+}
+
+extension DiaryTimeViewController: UIPickerViewDataSource {
+    func numberOfComponents(in pickerView: UIPickerView) -> Int {
+        return 2
+    }
+    
+    func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
+        if component == 0 {
+            return timeStrings.count
+        } else {
+            return timePeriods.count
+        }
+    }
+    
+    func pickerView(_ pickerView: UIPickerView, rowHeightForComponent component: Int) -> CGFloat {
+        return 34
+    }
+}
+ 
+extension DiaryTimeViewController: UIPickerViewDelegate {
+    func pickerView(_ pickerView: UIPickerView, viewForRow row: Int, forComponent component: Int, reusing view: UIView?) -> UIView {
+        
+        let label = UILabel()
+        label.textAlignment = .right
+        
+        let selectedRow = pickerView.selectedRow(inComponent: component)
+                
+        if row == selectedRow {
+            label.font = .offroad(style: .iosTextTitle)
+            label.textColor = .main(.main2)
+        } else {
+            label.font = UIFont.pretendardFont(ofSize: 22, weight: .regular)
+            label.textColor = .grayscale(.gray300)
+        }
+        
+        if component == 0  {
+            label.text = "\(timeStrings[row])        00"
+        } else {
+            label.text = timePeriods[row]
+        }
+        
+        return label
+    }
+
+    func pickerView(_ pickerView: UIPickerView, widthForComponent component: Int) -> CGFloat {
+        if component == 0 {
+            return 100
+        } else {
+            return 60
+        }
+    }
+    
+    func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
+        pickerView.reloadComponent(component)
+    }
+}

--- a/Offroad-iOS/Offroad-iOS/Presentation/MyPage/Settings/Model/SettingBaseModel.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/MyPage/Settings/Model/SettingBaseModel.swift
@@ -10,6 +10,19 @@ struct SettingBaseModel {
 }
 
 extension SettingBaseModel {
+#if DevTarget
+    static let settingListModel: [SettingBaseModel] = [
+        SettingBaseModel(listString: "공지사항"),
+        SettingBaseModel(listString: "일기 시간"),
+        SettingBaseModel(listString: "플레이 가이드"),
+        SettingBaseModel(listString: "서비스 이용약관"),
+        SettingBaseModel(listString: "개인정보처리방침"),
+        SettingBaseModel(listString: "마케팅 수신동의"),
+        SettingBaseModel(listString: "고객 문의"),
+        SettingBaseModel(listString: "로그아웃"),
+        SettingBaseModel(listString: "회원 탈퇴")
+    ]
+#else
     static let settingListModel: [SettingBaseModel] = [
         SettingBaseModel(listString: "공지사항"),
         SettingBaseModel(listString: "플레이 가이드"),
@@ -20,6 +33,7 @@ extension SettingBaseModel {
         SettingBaseModel(listString: "로그아웃"),
         SettingBaseModel(listString: "회원 탈퇴")
     ]
+#endif
     
     static let settingNoticeModel: [SettingBaseModel] = [
         SettingBaseModel(listString: "[중요] 오프로드가 여러분의 의견을 듣습니다."),

--- a/Offroad-iOS/Offroad-iOS/Presentation/MyPage/Settings/ViewController/SettingViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/MyPage/Settings/ViewController/SettingViewController.swift
@@ -91,7 +91,7 @@ extension SettingViewController: UICollectionViewDelegateFlowLayout {
             let diaryTimeViewController = DiaryTimeViewController()
             self.navigationController?.pushViewController(diaryTimeViewController, animated: true)
         case 2, 3, 4:
-            let redirectionURL = NSURL(string: redirectionURLStrings[indexPath.item - 1])
+            let redirectionURL = NSURL(string: redirectionURLStrings[indexPath.item - 2])
             let safariViewController = SFSafariViewController(url: (redirectionURL ?? NSURL()) as URL)
             self.present(safariViewController, animated: true, completion: nil)
         case 5:

--- a/Offroad-iOS/Offroad-iOS/Presentation/MyPage/Settings/ViewController/SettingViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/MyPage/Settings/ViewController/SettingViewController.swift
@@ -81,6 +81,38 @@ extension SettingViewController: UICollectionViewDataSource {
 //MARK: - UICollectionViewDelegateFlowLayout
 
 extension SettingViewController: UICollectionViewDelegateFlowLayout {
+    #if DevTarget
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        switch indexPath.item {
+        case 0:
+            let noticeViewController = NoticeViewController()
+            self.navigationController?.pushViewController(noticeViewController, animated: true)
+        case 1:
+            let diaryTimeViewController = DiaryTimeViewController()
+            self.navigationController?.pushViewController(diaryTimeViewController, animated: true)
+        case 2, 3, 4:
+            let redirectionURL = NSURL(string: redirectionURLStrings[indexPath.item - 1])
+            let safariViewController = SFSafariViewController(url: (redirectionURL ?? NSURL()) as URL)
+            self.present(safariViewController, animated: true, completion: nil)
+        case 5:
+            let marketingConsentViewController = MarketingConsentViewController()
+            marketingConsentViewController.modalPresentationStyle = .overCurrentContext
+            self.present(marketingConsentViewController, animated: false)
+        case 6:
+            let customerInquiryViewController = CustomerInquiryViewController()
+            self.navigationController?.pushViewController(customerInquiryViewController, animated: true)
+        case 7:
+            let logoutViewController = LogoutViewController()
+            logoutViewController.modalPresentationStyle = .overCurrentContext
+            self.present(logoutViewController, animated: false)
+        case 8:
+            let deleteAccountViewController = DeleteAccountViewController()
+            deleteAccountViewController.modalPresentationStyle = .overCurrentContext
+            self.present(deleteAccountViewController, animated: false)
+        default: break
+        }
+    }
+    #else
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         switch indexPath.item {
         case 0:
@@ -108,4 +140,5 @@ extension SettingViewController: UICollectionViewDelegateFlowLayout {
         default: break
         }
     }
+    #endif
 }

--- a/Offroad-iOS/Offroad-iOS/Presentation/MyPage/View/MyPageView.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/MyPage/View/MyPageView.swift
@@ -212,7 +212,7 @@ extension MyPageView {
     
     private func setupLayout() {
         myPageScrollView.snp.makeConstraints {
-            $0.edges.equalTo(safeAreaLayoutGuide)
+            $0.edges.equalToSuperview()
         }
         
         myPageContentView.snp.makeConstraints {

--- a/Offroad-iOS/Offroad-iOS/Presentation/MyPage/View/MyPageView.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/MyPage/View/MyPageView.swift
@@ -35,6 +35,7 @@ final class MyPageView: UIView {
     private let completedQuestsCountLabel = UILabel()
     private let visitedPlacesCountLabel = UILabel()
     private let dividerView = UIView()
+    let diaryButton = MyPageCustomButton(titleString: "일기", backgroundImage: .btnDiary)
     let characterButton = MyPageCustomButton(titleString: "획득 캐릭터", backgroundImage: .btnCharacter)
     let couponButton = MyPageCustomButton(titleString: "획득 쿠폰", backgroundImage: .btnCoupon)
     let titleButton = MyPageCustomButton(titleString: "획득 칭호", backgroundImage: .btnTitle)
@@ -154,7 +155,7 @@ extension MyPageView {
             $0.backgroundColor = .primary(.stroke)
         }
         
-        [characterButton, couponButton, titleButton, settingButton].forEach {
+        [diaryButton, characterButton, couponButton, titleButton, settingButton].forEach {
             $0.roundCorners(cornerRadius: 10)
         }
         
@@ -201,7 +202,11 @@ extension MyPageView {
         
         horizontalStackView1.addArrangedSubviews(characterButton, couponButton)
         horizontalStackView2.addArrangedSubviews(titleButton, settingButton)
+        #if DevTarget
+        verticalStackView.addArrangedSubviews(diaryButton, horizontalStackView1, horizontalStackView2)
+        #else
         verticalStackView.addArrangedSubviews(horizontalStackView1, horizontalStackView2)
+        #endif
     }
     
     private func setupLayout() {
@@ -280,7 +285,11 @@ extension MyPageView {
         verticalStackView.snp.makeConstraints {
             $0.top.equalTo(questPlaceBackgroundView.snp.bottom).offset(18)
             $0.horizontalEdges.equalToSuperview().inset(24)
+            #if DevTarget
+            $0.height.equalTo((backgroundViewWidth - 24) * 444 / 345)
+            #else
             $0.height.equalTo((backgroundViewWidth - 24) * 291 / 345)
+            #endif
         }
     }
     

--- a/Offroad-iOS/Offroad-iOS/Presentation/MyPage/View/MyPageView.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/MyPage/View/MyPageView.swift
@@ -18,7 +18,7 @@ final class MyPageView: UIView {
 
     //MARK: - UI Properties
     
-    private let myPageScrollView = UIScrollView()
+    private let myPageScrollView = MyPageScrollView()
     private let myPageContentView = UIView()
     private let nicknameLabel = UILabel()
     private let descriptionLabel = UILabel()
@@ -70,6 +70,7 @@ extension MyPageView {
             $0.backgroundColor = .clear
             $0.showsVerticalScrollIndicator = false
             $0.delaysContentTouches = false
+            $0.canCancelContentTouches = true
         }
         
         myPageContentView.do {


### PR DESCRIPTION
### 🌴 작업한 브랜치
- #465


### ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->
- 일기 시간 설정 뷰의 UI를 구현했습니다.
- 마이 페이지에서 일기 버튼이 보이도록 추가했습니다.(일기 시간 설정 뷰와는 무관합니다.)
  `MyPageCustomButton`이 `ShrinkableButton`을 상속하도록 변경하면서, 마이 페이지 내부에서 스크롤을 할 때 버튼의 바로 위에서 스크롤을 할 시 원활하게 동작하지 않는 문제를 해결하기 위해서 `MyPageScrollView`를 생성하였습니다.
  `touchesShouldCancel`를 조작하여 UIButton에서 true를 반환하도록 설정해준 코드만 추가해주었습니다.

  ```
  final class MyPageScrollView: UIScrollView {
    override func touchesShouldCancel(in view: UIView) -> Bool {
      if view is UIButton {
        return true
      }
      return super.touchesShouldCancel(in: view)
    }
  }
  ```
- ORBAlertController 관련 코드를 일부 수정했습니다.(채널톡 사전 공유한 부분)

### 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->

|일기 시간 뷰|마이 페이지|
|:------:|:---:|
|<img src = "https://github.com/user-attachments/assets/3df7f61d-88d9-4b87-bc87-1e1d9f1c21ea" width ="250">|<img src = "https://github.com/user-attachments/assets/e4b22ec9-e130-48aa-a1d5-489c9459fd13" width ="250">|

- Resolved: #465
