### PR TITLE
[Feat] #477 - 일기 캘린더 pickerView 구현

### DIFF
--- a/Offroad-iOS/Offroad-iOS.xcodeproj/project.pbxproj
+++ b/Offroad-iOS/Offroad-iOS.xcodeproj/project.pbxproj
@@ -547,6 +547,7 @@
 		D0CA20732D7F4BC200FDF7F4 /* DiaryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0CA20722D7F4BB900FDF7F4 /* DiaryViewModel.swift */; };
 		D0CA20822D7FE06B00FDF7F4 /* MonthPickerModalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0CA20812D7FE05A00FDF7F4 /* MonthPickerModalView.swift */; };
 		D0CA20842D7FE08200FDF7F4 /* MonthPickerModalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0CA20832D7FE07F00FDF7F4 /* MonthPickerModalViewController.swift */; };
+		D0CA20872D8018FA00FDF7F4 /* MyDiaryManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0CA20862D8018F400FDF7F4 /* MyDiaryManager.swift */; };
 		D0CF2E042D772570000334B5 /* Info_Dev.plist in Resources */ = {isa = PBXBuildFile; fileRef = D0CF2E032D772570000334B5 /* Info_Dev.plist */; };
 		D0CF2E052D772570000334B5 /* Info_Dev.plist in Resources */ = {isa = PBXBuildFile; fileRef = D0CF2E032D772570000334B5 /* Info_Dev.plist */; };
 		D0CF2E1D2D77EC96000334B5 /* GuideCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0CF2E1C2D77EC95000334B5 /* GuideCollectionViewCell.swift */; };
@@ -872,6 +873,7 @@
 		D0CA20722D7F4BB900FDF7F4 /* DiaryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryViewModel.swift; sourceTree = "<group>"; };
 		D0CA20812D7FE05A00FDF7F4 /* MonthPickerModalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonthPickerModalView.swift; sourceTree = "<group>"; };
 		D0CA20832D7FE07F00FDF7F4 /* MonthPickerModalViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonthPickerModalViewController.swift; sourceTree = "<group>"; };
+		D0CA20862D8018F400FDF7F4 /* MyDiaryManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyDiaryManager.swift; sourceTree = "<group>"; };
 		D0CF2E032D772570000334B5 /* Info_Dev.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info_Dev.plist; sourceTree = "<group>"; };
 		D0CF2E1C2D77EC95000334B5 /* GuideCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuideCollectionViewCell.swift; sourceTree = "<group>"; };
 		D0E6BE8F2CED2815006CDAA8 /* PushNotificationRedirectModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationRedirectModel.swift; sourceTree = "<group>"; };
@@ -2327,6 +2329,7 @@
 		D02232002D762DBA00DA6968 /* Diary */ = {
 			isa = PBXGroup;
 			children = (
+				D0CA20852D8018E700FDF7F4 /* MyDiaryManager */,
 				D0CF2E1A2D77EC5C000334B5 /* Cell */,
 				D0CA20802D7FE04F00FDF7F4 /* Modal */,
 				D02232022D762DD100DA6968 /* View */,
@@ -2589,6 +2592,14 @@
 				D0CA20812D7FE05A00FDF7F4 /* MonthPickerModalView.swift */,
 			);
 			path = Modal;
+			sourceTree = "<group>";
+		};
+		D0CA20852D8018E700FDF7F4 /* MyDiaryManager */ = {
+			isa = PBXGroup;
+			children = (
+				D0CA20862D8018F400FDF7F4 /* MyDiaryManager.swift */,
+			);
+			path = MyDiaryManager;
 			sourceTree = "<group>";
 		};
 		D0CF2E1A2D77EC5C000334B5 /* Cell */ = {
@@ -3809,6 +3820,7 @@
 				4E4F320F2D4718F400C3B2FF /* CustomerInquiryView.swift in Sources */,
 				4E4F32102D4718F400C3B2FF /* CollectedTitleModel.swift in Sources */,
 				4E4F32112D4718F400C3B2FF /* HomeViewController.swift in Sources */,
+				D0CA20872D8018FA00FDF7F4 /* MyDiaryManager.swift in Sources */,
 				4E4F32122D4718F400C3B2FF /* ORBAlertViewCouponRedemptionFailure.swift in Sources */,
 				4E4F32132D4718F400C3B2FF /* ChangeEmblemResponseDTO.swift in Sources */,
 				4E4F32142D4718F400C3B2FF /* ORBNMFMarker.swift in Sources */,

--- a/Offroad-iOS/Offroad-iOS.xcodeproj/project.pbxproj
+++ b/Offroad-iOS/Offroad-iOS.xcodeproj/project.pbxproj
@@ -545,6 +545,8 @@
 		D0CA206C2D7DCF5900FDF7F4 /* FSCalendar in Frameworks */ = {isa = PBXBuildFile; productRef = D0CA206B2D7DCF5900FDF7F4 /* FSCalendar */; };
 		D0CA206E2D7E005100FDF7F4 /* CustomDiaryCalendarCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0CA206D2D7E004A00FDF7F4 /* CustomDiaryCalendarCell.swift */; };
 		D0CA20732D7F4BC200FDF7F4 /* DiaryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0CA20722D7F4BB900FDF7F4 /* DiaryViewModel.swift */; };
+		D0CA20822D7FE06B00FDF7F4 /* MonthPickerModalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0CA20812D7FE05A00FDF7F4 /* MonthPickerModalView.swift */; };
+		D0CA20842D7FE08200FDF7F4 /* MonthPickerModalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0CA20832D7FE07F00FDF7F4 /* MonthPickerModalViewController.swift */; };
 		D0CF2E042D772570000334B5 /* Info_Dev.plist in Resources */ = {isa = PBXBuildFile; fileRef = D0CF2E032D772570000334B5 /* Info_Dev.plist */; };
 		D0CF2E052D772570000334B5 /* Info_Dev.plist in Resources */ = {isa = PBXBuildFile; fileRef = D0CF2E032D772570000334B5 /* Info_Dev.plist */; };
 		D0CF2E1D2D77EC96000334B5 /* GuideCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0CF2E1C2D77EC95000334B5 /* GuideCollectionViewCell.swift */; };
@@ -868,6 +870,8 @@
 		D0C6FD142CE6633500517480 /* NotificationServiceExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = NotificationServiceExtension.entitlements; sourceTree = "<group>"; };
 		D0CA206D2D7E004A00FDF7F4 /* CustomDiaryCalendarCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomDiaryCalendarCell.swift; sourceTree = "<group>"; };
 		D0CA20722D7F4BB900FDF7F4 /* DiaryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryViewModel.swift; sourceTree = "<group>"; };
+		D0CA20812D7FE05A00FDF7F4 /* MonthPickerModalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonthPickerModalView.swift; sourceTree = "<group>"; };
+		D0CA20832D7FE07F00FDF7F4 /* MonthPickerModalViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonthPickerModalViewController.swift; sourceTree = "<group>"; };
 		D0CF2E032D772570000334B5 /* Info_Dev.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info_Dev.plist; sourceTree = "<group>"; };
 		D0CF2E1C2D77EC95000334B5 /* GuideCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuideCollectionViewCell.swift; sourceTree = "<group>"; };
 		D0E6BE8F2CED2815006CDAA8 /* PushNotificationRedirectModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationRedirectModel.swift; sourceTree = "<group>"; };
@@ -2324,6 +2328,7 @@
 			isa = PBXGroup;
 			children = (
 				D0CF2E1A2D77EC5C000334B5 /* Cell */,
+				D0CA20802D7FE04F00FDF7F4 /* Modal */,
 				D02232022D762DD100DA6968 /* View */,
 				D02232012D762DCB00DA6968 /* ViewController */,
 				D0CA20712D7F4BA900FDF7F4 /* ViewModel */,
@@ -2336,6 +2341,7 @@
 			children = (
 				D02232032D762DD800DA6968 /* DiaryViewController.swift */,
 				D022320D2D76CCEE00DA6968 /* DiaryGuideViewController.swift */,
+				D0CA20832D7FE07F00FDF7F4 /* MonthPickerModalViewController.swift */,
 			);
 			path = ViewController;
 			sourceTree = "<group>";
@@ -2575,6 +2581,14 @@
 				D0CA20722D7F4BB900FDF7F4 /* DiaryViewModel.swift */,
 			);
 			path = ViewModel;
+			sourceTree = "<group>";
+		};
+		D0CA20802D7FE04F00FDF7F4 /* Modal */ = {
+			isa = PBXGroup;
+			children = (
+				D0CA20812D7FE05A00FDF7F4 /* MonthPickerModalView.swift */,
+			);
+			path = Modal;
 			sourceTree = "<group>";
 		};
 		D0CF2E1A2D77EC5C000334B5 /* Cell */ = {
@@ -3624,6 +3638,7 @@
 				D0CA20732D7F4BC200FDF7F4 /* DiaryViewModel.swift in Sources */,
 				4E4F31782D4718F400C3B2FF /* TitlePopupViewController.swift in Sources */,
 				4E4F31792D4718F400C3B2FF /* LottieAnimationView+.swift in Sources */,
+				D0CA20842D7FE08200FDF7F4 /* MonthPickerModalViewController.swift in Sources */,
 				4E4F317A2D4718F400C3B2FF /* ORBCharacterChatView.swift in Sources */,
 				4E4F317B2D4718F400C3B2FF /* AdventuresQRAuthenticationResponseDTO.swift in Sources */,
 				4E4F317C2D4718F400C3B2FF /* QuestListResponseDTO.swift in Sources */,
@@ -3703,6 +3718,7 @@
 				4E4F31BA2D4718F400C3B2FF /* UIColor+.swift in Sources */,
 				4E4F31BB2D4718F400C3B2FF /* AppleAuthManager.swift in Sources */,
 				4E4F31BC2D4718F400C3B2FF /* UILabel+.swift in Sources */,
+				D0CA20822D7FE06B00FDF7F4 /* MonthPickerModalView.swift in Sources */,
 				4E4F31BD2D4718F400C3B2FF /* NavigationPopButton.swift in Sources */,
 				4E4F31BE2D4718F400C3B2FF /* EmblemInfoResponseDTO.swift in Sources */,
 				4E4F31BF2D4718F400C3B2FF /* ORBCharacterChatWindow.swift in Sources */,

--- a/Offroad-iOS/Offroad-iOS/Presentation/Diary/Modal/MonthPickerModalView.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Diary/Modal/MonthPickerModalView.swift
@@ -1,0 +1,81 @@
+//
+//  MonthPickerModelView.swift
+//  Offroad-iOS
+//
+//  Created by 조혜린 on 3/11/25.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class MonthPickerModalView: UIView {
+    
+    //MARK: - UI Properties
+    
+    let monthPickerView = UIPickerView()
+    private let highlightedRowView = UIView()
+    let completeButton = ShrinkableButton()
+    
+    // MARK: - Life Cycle
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setupHierarchy()
+        setupStyle()
+        setupLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+private extension MonthPickerModalView {
+    
+    // MARK: - Layout
+    
+    func setupStyle() {
+        backgroundColor = .primary(.white)
+        roundCorners(cornerRadius: 20, maskedCorners: [.layerMinXMaxYCorner, .layerMaxXMaxYCorner])
+        
+        highlightedRowView.do {
+            $0.backgroundColor = .primary(.listBg)
+            $0.roundCorners(cornerRadius: 8)
+        }
+        
+        completeButton.do {
+            $0.setTitle("완료", for: .normal)
+            $0.titleLabel?.font = UIFont.offroad(style: .iosTooltipTitle)
+            $0.setTitleColor(UIColor.sub(.sub), for: .normal)
+        }
+    }
+    
+    func setupHierarchy() {
+        addSubviews(
+            highlightedRowView,
+            monthPickerView,
+            completeButton
+        )
+    }
+    
+    func setupLayout() {
+        highlightedRowView.snp.makeConstraints {
+            $0.center.equalTo(monthPickerView.snp.center)
+            $0.horizontalEdges.equalToSuperview().inset(10)
+            $0.height.equalTo(34)
+        }
+        
+        monthPickerView.snp.makeConstraints {
+            $0.horizontalEdges.equalToSuperview()
+            $0.verticalEdges.equalToSuperview().inset(60)
+        }
+         
+        completeButton.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(26)
+            $0.trailing.equalToSuperview().inset(34)
+        }
+    }
+}

--- a/Offroad-iOS/Offroad-iOS/Presentation/Diary/MyDiaryManager/MyDiaryManager.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Diary/MyDiaryManager/MyDiaryManager.swift
@@ -13,7 +13,7 @@ import RxRelay
 enum DateType {
     case minimum
     case maximum
-    case current
+    case currentPage
 }
 
 final class MyDiaryManager {
@@ -25,7 +25,7 @@ final class MyDiaryManager {
     var disposeBag = DisposeBag()
     var minimumDate = Date()
     var maximumDate = Date()
-    var currentDate = Date()
+    var currentPageDate = Date()
 
     let updateCalenderCurrentPage = PublishRelay<Date>()
     
@@ -46,8 +46,8 @@ extension MyDiaryManager {
             return (calendar.component(.year, from: minimumDate), calendar.component(.month, from: minimumDate))
         case .maximum:
             return (calendar.component(.year, from: maximumDate), calendar.component(.month, from: maximumDate))
-        case .current:
-            return (calendar.component(.year, from: currentDate), calendar.component(.month, from: currentDate))
+        case .currentPage:
+            return (calendar.component(.year, from: currentPageDate), calendar.component(.month, from: currentPageDate))
         }
     }
 }

--- a/Offroad-iOS/Offroad-iOS/Presentation/Diary/MyDiaryManager/MyDiaryManager.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Diary/MyDiaryManager/MyDiaryManager.swift
@@ -39,7 +39,7 @@ extension MyDiaryManager {
     //MARK: - Func
     
     func fetchYearMonthValue(dateType: DateType) -> (year: Int, month: Int) {
-        let calendar = Calendar.current
+        let calendar = Calendar(identifier: .gregorian)
 
         switch dateType {
         case .minimum:

--- a/Offroad-iOS/Offroad-iOS/Presentation/Diary/MyDiaryManager/MyDiaryManager.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Diary/MyDiaryManager/MyDiaryManager.swift
@@ -13,7 +13,7 @@ import RxRelay
 enum DateType {
     case minimum
     case maximum
-    case custom
+    case current
 }
 
 final class MyDiaryManager {
@@ -25,6 +25,7 @@ final class MyDiaryManager {
     var disposeBag = DisposeBag()
     var minimumDate = Date()
     var maximumDate = Date()
+    var currentDate = Date()
 
     let updateCalenderCurrentPage = PublishRelay<Date>()
     
@@ -37,7 +38,7 @@ extension MyDiaryManager {
     
     //MARK: - Func
     
-    func fetchYearMonthValue(dateType: DateType, targetDate: Date? = nil) -> (year: Int, month: Int) {
+    func fetchYearMonthValue(dateType: DateType) -> (year: Int, month: Int) {
         let calendar = Calendar.current
 
         switch dateType {
@@ -45,12 +46,8 @@ extension MyDiaryManager {
             return (calendar.component(.year, from: minimumDate), calendar.component(.month, from: minimumDate))
         case .maximum:
             return (calendar.component(.year, from: maximumDate), calendar.component(.month, from: maximumDate))
-        case .custom:
-            if let targetDate {
-                return (calendar.component(.year, from: targetDate), calendar.component(.month, from: targetDate))
-            } else {
-                return (Int(), Int())
-            }
+        case .current:
+            return (calendar.component(.year, from: currentDate), calendar.component(.month, from: currentDate))
         }
     }
 }

--- a/Offroad-iOS/Offroad-iOS/Presentation/Diary/MyDiaryManager/MyDiaryManager.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Diary/MyDiaryManager/MyDiaryManager.swift
@@ -10,6 +10,12 @@ import Foundation
 import RxSwift
 import RxRelay
 
+enum DateType {
+    case minimum
+    case maximum
+    case custom
+}
+
 final class MyDiaryManager {
     
     //MARK: - Properties
@@ -25,4 +31,26 @@ final class MyDiaryManager {
     //MARK: - Life Cycle
     
     private init() { }
+}
+
+extension MyDiaryManager {
+    
+    //MARK: - Func
+    
+    func fetchYearMonthValue(dateType: DateType, targetDate: Date? = nil) -> (year: Int, month: Int) {
+        let calendar = Calendar.current
+
+        switch dateType {
+        case .minimum:
+            return (calendar.component(.year, from: minimumDate), calendar.component(.month, from: minimumDate))
+        case .maximum:
+            return (calendar.component(.year, from: maximumDate), calendar.component(.month, from: maximumDate))
+        case .custom:
+            if let targetDate {
+                return (calendar.component(.year, from: targetDate), calendar.component(.month, from: targetDate))
+            } else {
+                return (Int(), Int())
+            }
+        }
+    }
 }

--- a/Offroad-iOS/Offroad-iOS/Presentation/Diary/MyDiaryManager/MyDiaryManager.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Diary/MyDiaryManager/MyDiaryManager.swift
@@ -1,0 +1,28 @@
+//
+//  MyDiaryManager.swift
+//  Offroad-iOS
+//
+//  Created by 조혜린 on 3/11/25.
+//
+
+import Foundation
+
+import RxSwift
+import RxRelay
+
+final class MyDiaryManager {
+    
+    //MARK: - Properties
+    
+    static let shared = MyDiaryManager()
+    
+    var disposeBag = DisposeBag()
+    var minimumDate = Date()
+    var maximumDate = Date()
+
+    let updateCalenderCurrentPage = PublishRelay<Date>()
+    
+    //MARK: - Life Cycle
+    
+    private init() { }
+}

--- a/Offroad-iOS/Offroad-iOS/Presentation/Diary/MyDiaryManager/MyDiaryManager.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Diary/MyDiaryManager/MyDiaryManager.swift
@@ -24,7 +24,7 @@ final class MyDiaryManager {
     
     var disposeBag = DisposeBag()
     var minimumDate = Date()
-    var maximumDate = Date()
+    private(set) var maximumDate = Date()
     var currentPageDate = Date()
 
     let updateCalenderCurrentPage = PublishRelay<Date>()

--- a/Offroad-iOS/Offroad-iOS/Presentation/Diary/View/DiaryView.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Diary/View/DiaryView.swift
@@ -22,7 +22,7 @@ final class DiaryView: UIView {
     private let titleImageView = UIImageView(frame: CGRect(origin: .init(), size: CGSize(width: 24, height: 24)))
     let guideButton = UIButton()
     private let diaryBackgroundView = UIView()
-    let monthButton = UIButton()
+    let monthButton = ShrinkableButton()
     let leftArrowButton = UIButton()
     let rightArrowButton = UIButton()
     private let arrowButtonStackView = UIStackView()

--- a/Offroad-iOS/Offroad-iOS/Presentation/Diary/ViewController/DiaryViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Diary/ViewController/DiaryViewController.swift
@@ -132,7 +132,7 @@ private extension DiaryViewController {
             if #available(iOS 16.0, *) {
                 sheet.detents = [
                     .custom { _ in
-                        return 305
+                        return 284
                     }
                 ]
             } else {

--- a/Offroad-iOS/Offroad-iOS/Presentation/Diary/ViewController/DiaryViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Diary/ViewController/DiaryViewController.swift
@@ -87,7 +87,7 @@ private extension DiaryViewController {
     func bindData() {
         MyDiaryManager.shared.updateCalenderCurrentPage
             .bind { date in
-                self.rootView.diaryCalender.setCurrentPage(date, animated: true)
+                self.rootView.diaryCalender.setCurrentPage(date, animated: false)
             }
             .disposed(by: disposeBag)
     }
@@ -188,7 +188,6 @@ extension DiaryViewController: FSCalendarDelegateAppearance {
         rootView.monthButton.setTitle("\(currentYear)년 \(currentMonth)월", for: .normal)
         rootView.leftArrowButton.alpha = viewModel.canMoveMonth(.previous) ? 1 : 0
         rootView.rightArrowButton.alpha = viewModel.canMoveMonth(.next) ? 1 : 0
-        rootView.diaryCalender.reloadData()
     }
 }
 

--- a/Offroad-iOS/Offroad-iOS/Presentation/Diary/ViewController/DiaryViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Diary/ViewController/DiaryViewController.swift
@@ -147,8 +147,8 @@ private extension DiaryViewController {
         var dateComponents = DateComponents()
         dateComponents.month = sender == rootView.rightArrowButton ? 1 : -1
         
-        MyDiaryManager.shared.currentDate = Calendar(identifier: .gregorian).date(byAdding: dateComponents, to: MyDiaryManager.shared.currentDate)!
-        rootView.diaryCalender.setCurrentPage(MyDiaryManager.shared.currentDate, animated: true)
+        MyDiaryManager.shared.currentPageDate = Calendar(identifier: .gregorian).date(byAdding: dateComponents, to: MyDiaryManager.shared.currentPageDate)!
+        rootView.diaryCalender.setCurrentPage(MyDiaryManager.shared.currentPageDate, animated: true)
     }
 }
 
@@ -181,11 +181,11 @@ extension DiaryViewController: FSCalendarDelegateAppearance {
 
     func calendarCurrentPageDidChange(_ calendar: FSCalendar) {
         let currentPageDate = calendar.currentPage
-        MyDiaryManager.shared.currentDate = currentPageDate
+        MyDiaryManager.shared.currentPageDate = currentPageDate
         
-        let (currentYear, currentMonth) = MyDiaryManager.shared.fetchYearMonthValue(dateType: .current)
+        let (currentPageYear, currentPageMonth) = MyDiaryManager.shared.fetchYearMonthValue(dateType: .currentPage)
 
-        rootView.monthButton.setTitle("\(currentYear)년 \(currentMonth)월", for: .normal)
+        rootView.monthButton.setTitle("\(currentPageYear)년 \(currentPageMonth)월", for: .normal)
         rootView.leftArrowButton.alpha = viewModel.canMoveMonth(.previous) ? 1 : 0
         rootView.rightArrowButton.alpha = viewModel.canMoveMonth(.next) ? 1 : 0
     }

--- a/Offroad-iOS/Offroad-iOS/Presentation/Diary/ViewController/DiaryViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Diary/ViewController/DiaryViewController.swift
@@ -87,8 +87,7 @@ private extension DiaryViewController {
     func bindData() {
         MyDiaryManager.shared.updateCalenderCurrentPage
             .bind { date in
-                self.viewModel.currentPage = date
-                self.rootView.diaryCalender.setCurrentPage(self.viewModel.currentPage, animated: true)
+                self.rootView.diaryCalender.setCurrentPage(date, animated: true)
             }
             .disposed(by: disposeBag)
     }
@@ -148,8 +147,8 @@ private extension DiaryViewController {
         var dateComponents = DateComponents()
         dateComponents.month = sender == rootView.rightArrowButton ? 1 : -1
         
-        viewModel.currentPage = Calendar.current.date(byAdding: dateComponents, to: viewModel.currentPage)!
-        rootView.diaryCalender.setCurrentPage(viewModel.currentPage, animated: true)
+        MyDiaryManager.shared.currentDate = Calendar.current.date(byAdding: dateComponents, to: MyDiaryManager.shared.currentDate)!
+        rootView.diaryCalender.setCurrentPage(MyDiaryManager.shared.currentDate, animated: true)
     }
 }
 
@@ -182,9 +181,9 @@ extension DiaryViewController: FSCalendarDelegateAppearance {
 
     func calendarCurrentPageDidChange(_ calendar: FSCalendar) {
         let currentPageDate = calendar.currentPage
-        viewModel.currentPage = currentPageDate
+        MyDiaryManager.shared.currentDate = currentPageDate
         
-        let (currentYear, currentMonth) = MyDiaryManager.shared.fetchYearMonthValue(dateType: .custom, targetDate: currentPageDate)
+        let (currentYear, currentMonth) = MyDiaryManager.shared.fetchYearMonthValue(dateType: .current)
 
         rootView.monthButton.setTitle("\(currentYear)년 \(currentMonth)월", for: .normal)
         rootView.leftArrowButton.alpha = viewModel.canMoveMonth(.previous) ? 1 : 0

--- a/Offroad-iOS/Offroad-iOS/Presentation/Diary/ViewController/DiaryViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Diary/ViewController/DiaryViewController.swift
@@ -147,7 +147,7 @@ private extension DiaryViewController {
         var dateComponents = DateComponents()
         dateComponents.month = sender == rootView.rightArrowButton ? 1 : -1
         
-        MyDiaryManager.shared.currentDate = Calendar.current.date(byAdding: dateComponents, to: MyDiaryManager.shared.currentDate)!
+        MyDiaryManager.shared.currentDate = Calendar(identifier: .gregorian).date(byAdding: dateComponents, to: MyDiaryManager.shared.currentDate)!
         rootView.diaryCalender.setCurrentPage(MyDiaryManager.shared.currentDate, animated: true)
     }
 }

--- a/Offroad-iOS/Offroad-iOS/Presentation/Diary/ViewController/DiaryViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Diary/ViewController/DiaryViewController.swift
@@ -182,10 +182,11 @@ extension DiaryViewController: FSCalendarDelegateAppearance {
 
     func calendarCurrentPageDidChange(_ calendar: FSCalendar) {
         let currentPageDate = calendar.currentPage
-        let calendar = Calendar.current
         viewModel.currentPage = currentPageDate
+        
+        let (currentYear, currentMonth) = MyDiaryManager.shared.fetchYearMonthValue(dateType: .custom, targetDate: currentPageDate)
 
-        rootView.monthButton.setTitle("\(calendar.component(.year, from: currentPageDate))년 \(calendar.component(.month, from: currentPageDate))월", for: .normal)
+        rootView.monthButton.setTitle("\(currentYear)년 \(currentMonth)월", for: .normal)
         rootView.leftArrowButton.alpha = viewModel.canMoveMonth(.previous) ? 1 : 0
         rootView.rightArrowButton.alpha = viewModel.canMoveMonth(.next) ? 1 : 0
         rootView.diaryCalender.reloadData()

--- a/Offroad-iOS/Offroad-iOS/Presentation/Diary/ViewController/MonthPickerModalViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Diary/ViewController/MonthPickerModalViewController.swift
@@ -1,0 +1,144 @@
+//
+//  MonthPickerModelViewController.swift
+//  Offroad-iOS
+//
+//  Created by 조혜린 on 3/11/25.
+//
+
+import UIKit
+
+import RxSwift
+
+final class MonthPickerModalViewController: UIViewController {
+    
+    // MARK: - Properties
+    
+    private let rootView = MonthPickerModalView()
+    
+    private let currentYear = 2025
+    private let currentMonth = 3
+    
+    private let minimumYear = 2024
+    private let minimumMonth = 11
+    
+    private lazy var years = Array(minimumYear...currentYear)
+    private let months = Array(1...12)
+    
+    // MARK: - Life Cycle
+    
+    override func loadView() {
+        view = rootView
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        setupDelegate()
+        setupTarget()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        guard let offroadTabBarController = self.tabBarController as? OffroadTabBarController else { return }
+        offroadTabBarController.hideTabBarAnimation()
+    }
+    
+    override func viewWillLayoutSubviews() {
+        rootView.monthPickerView.subviews[1].isHidden = true
+    }
+}
+
+private extension MonthPickerModalViewController {
+    
+    // MARK: - Private Method
+    
+    func setupDelegate() {
+        rootView.monthPickerView.delegate = self
+        rootView.monthPickerView.dataSource = self
+    }
+    
+    func setupTarget() {
+        rootView.completeButton.addTarget(self, action: #selector(completeTapped), for: .touchUpInside)
+    }
+}
+
+extension MonthPickerModalViewController {
+    
+    // MARK: - Func
+    
+    func setupCustomBackButton(buttonTitle: String) {
+    }
+}
+    
+@objc private extension MonthPickerModalViewController {
+
+    // MARK: - @objc Method
+    
+    func completeTapped() {
+        var dateComponents = DateComponents()
+        dateComponents.year = years[rootView.monthPickerView.selectedRow(inComponent: 0)]
+        dateComponents.month = months[rootView.monthPickerView.selectedRow(inComponent: 1)]
+        
+        let selectedDate = Calendar.current.date(from: dateComponents)!
+        MyDiaryManager.shared.updateCalenderCurrentPage.accept(selectedDate)
+        
+        dismiss(animated: true)
+    }
+}
+
+extension MonthPickerModalViewController: UIPickerViewDataSource {
+    func numberOfComponents(in pickerView: UIPickerView) -> Int {
+        return 2
+    }
+    
+    func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
+        if component == 0 {
+            return years.count
+        } else {
+            return months.count
+        }
+    }
+    
+    func pickerView(_ pickerView: UIPickerView, rowHeightForComponent component: Int) -> CGFloat {
+        return 34
+    }
+}
+ 
+extension MonthPickerModalViewController: UIPickerViewDelegate {
+    func pickerView(_ pickerView: UIPickerView, viewForRow row: Int, forComponent component: Int, reusing view: UIView?) -> UIView {
+        
+        let label = UILabel()
+        label.textAlignment = .left
+
+        let selectedRow = pickerView.selectedRow(inComponent: component)
+                
+        if row == selectedRow {
+            label.font = .offroad(style: .iosTextTitle)
+            label.textColor = .main(.main2)
+        } else {
+            label.font = UIFont.pretendardFont(ofSize: 22, weight: .regular)
+            label.textColor = .grayscale(.gray300)
+        }
+        
+        if component == 0  {
+            label.text = "\(years[row])년"
+        } else {
+            label.text = "\(months[row])월"
+        }
+        
+        return label
+    }
+
+    func pickerView(_ pickerView: UIPickerView, widthForComponent component: Int) -> CGFloat {
+        if component == 0 {
+            return 90
+        } else {
+            return 50
+        }
+    }
+    
+    func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
+        pickerView.reloadComponent(component)
+    }
+}

--- a/Offroad-iOS/Offroad-iOS/Presentation/Diary/ViewController/MonthPickerModalViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Diary/ViewController/MonthPickerModalViewController.swift
@@ -19,6 +19,9 @@ final class MonthPickerModalViewController: UIViewController {
     private let (maxYear, maxMonth) = MyDiaryManager.shared.fetchYearMonthValue(dateType: .maximum)
     private let (currentYear, currentMonth) = MyDiaryManager.shared.fetchYearMonthValue(dateType: .current)
     
+    private lazy var selectedYear = currentYear
+    private lazy var selectedMonth = currentMonth
+
     private lazy var years = Array(minYear...maxYear)
     private lazy var months: [Int] = {
         if currentYear == maxYear {
@@ -41,7 +44,7 @@ final class MonthPickerModalViewController: UIViewController {
         
         setupDelegate()
         setupTarget()
-        setInitialSelectedRow()
+        setupPickerView()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -69,9 +72,12 @@ private extension MonthPickerModalViewController {
         rootView.completeButton.addTarget(self, action: #selector(completeTapped), for: .touchUpInside)
     }
     
-    func setInitialSelectedRow() {        
+    func setupPickerView() {
         let selectedYearRow = years.firstIndex(of: currentYear)!
         let selectedMonthRow = months.firstIndex(of: currentMonth)!
+        
+        selectedYear = years[selectedYearRow]
+        selectedMonth = months[selectedMonthRow]
         
         DispatchQueue.main.async {
             self.rootView.monthPickerView.selectRow(selectedYearRow, inComponent: 0, animated: false)
@@ -87,8 +93,8 @@ private extension MonthPickerModalViewController {
     
     func completeTapped() {
         var dateComponents = DateComponents()
-        dateComponents.year = years[rootView.monthPickerView.selectedRow(inComponent: 0)]
-        dateComponents.month = months[rootView.monthPickerView.selectedRow(inComponent: 1)]
+        dateComponents.year = selectedYear
+        dateComponents.month = selectedMonth
         
         let selectedDate = Calendar.current.date(from: dateComponents)!
         MyDiaryManager.shared.updateCalenderCurrentPage.accept(selectedDate)
@@ -149,15 +155,26 @@ extension MonthPickerModalViewController: UIPickerViewDelegate {
     }
     
     func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
+
         if component == 0 {
+            selectedYear = years[row]
+
             if years[row] == maxYear {
                 months = Array(1...maxMonth)
+                pickerView.reloadComponent(1)
+                pickerView.selectRow(months.firstIndex(of: selectedMonth) ?? maxMonth - 1, inComponent: 1, animated: false)
             } else if years[row] == minYear {
                 months = Array(minMonth...12)
+                pickerView.reloadComponent(1)
+                pickerView.selectRow(months.firstIndex(of: selectedMonth) ?? 0, inComponent: 1, animated: false)
             } else {
                 months = Array(1...12)
+                pickerView.reloadComponent(1)
+                pickerView.selectRow(months.firstIndex(of: selectedMonth) ?? 0, inComponent: 1, animated: false)
             }
-            pickerView.reloadComponent(1)
+            selectedMonth = months[pickerView.selectedRow(inComponent: 1)]
+        } else {
+            selectedMonth = months[row]
         }
         pickerView.reloadComponent(component)
     }

--- a/Offroad-iOS/Offroad-iOS/Presentation/Diary/ViewController/MonthPickerModalViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Diary/ViewController/MonthPickerModalViewController.swift
@@ -82,7 +82,6 @@ private extension MonthPickerModalViewController {
         DispatchQueue.main.async {
             self.rootView.monthPickerView.selectRow(selectedYearRow, inComponent: 0, animated: false)
             self.rootView.monthPickerView.selectRow(selectedMonthRow, inComponent: 1, animated: false)
-            self.rootView.monthPickerView.reloadAllComponents()
         }
     }
 }
@@ -126,21 +125,25 @@ extension MonthPickerModalViewController: UIPickerViewDelegate {
         
         let label = UILabel()
         label.textAlignment = .left
-
-        let selectedRow = pickerView.selectedRow(inComponent: component)
-                
-        if row == selectedRow {
-            label.font = .offroad(style: .iosTextTitle)
-            label.textColor = .main(.main2)
-        } else {
-            label.font = UIFont.pretendardFont(ofSize: 22, weight: .regular)
-            label.textColor = .grayscale(.gray300)
-        }
         
         if component == 0  {
             label.text = "\(years[row])년"
+            if years[row] == selectedYear {
+                label.font = .offroad(style: .iosTextTitle)
+                label.textColor = .main(.main2)
+            } else {
+                label.font = UIFont.pretendardFont(ofSize: 22, weight: .regular)
+                label.textColor = .grayscale(.gray300)
+            }
         } else {
             label.text = "\(months[row])월"
+            if months[row] == selectedMonth {
+                label.font = .offroad(style: .iosTextTitle)
+                label.textColor = .main(.main2)
+            } else {
+                label.font = UIFont.pretendardFont(ofSize: 22, weight: .regular)
+                label.textColor = .grayscale(.gray300)
+            }
         }
         
         return label

--- a/Offroad-iOS/Offroad-iOS/Presentation/Diary/ViewController/MonthPickerModalViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Diary/ViewController/MonthPickerModalViewController.swift
@@ -47,13 +47,6 @@ final class MonthPickerModalViewController: UIViewController {
         setupPickerView()
     }
     
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        
-        guard let offroadTabBarController = self.tabBarController as? OffroadTabBarController else { return }
-        offroadTabBarController.hideTabBarAnimation()
-    }
-    
     override func viewWillLayoutSubviews() {
         rootView.monthPickerView.subviews[1].isHidden = true
     }

--- a/Offroad-iOS/Offroad-iOS/Presentation/Diary/ViewController/MonthPickerModalViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Diary/ViewController/MonthPickerModalViewController.swift
@@ -17,16 +17,16 @@ final class MonthPickerModalViewController: UIViewController {
     
     private let (minYear, minMonth) = MyDiaryManager.shared.fetchYearMonthValue(dateType: .minimum)
     private let (maxYear, maxMonth) = MyDiaryManager.shared.fetchYearMonthValue(dateType: .maximum)
-    private let (currentYear, currentMonth) = MyDiaryManager.shared.fetchYearMonthValue(dateType: .current)
+    private let (currentPageYear, currentPageMonth) = MyDiaryManager.shared.fetchYearMonthValue(dateType: .currentPage)
     
-    private lazy var selectedYear = currentYear
-    private lazy var selectedMonth = currentMonth
+    private lazy var selectedYear = currentPageYear
+    private lazy var selectedMonth = currentPageMonth
 
     private lazy var years = Array(minYear...maxYear)
     private lazy var months: [Int] = {
-        if currentYear == maxYear {
+        if currentPageYear == maxYear {
             return Array(1...maxMonth)
-        } else if currentYear == minYear {
+        } else if currentPageYear == minYear {
             return Array(minMonth...12)
         } else {
             return Array(1...12)
@@ -66,8 +66,8 @@ private extension MonthPickerModalViewController {
     }
     
     func setupPickerView() {
-        let selectedYearRow = years.firstIndex(of: currentYear)!
-        let selectedMonthRow = months.firstIndex(of: currentMonth)!
+        let selectedYearRow = years.firstIndex(of: currentPageYear)!
+        let selectedMonthRow = months.firstIndex(of: currentPageMonth)!
         
         selectedYear = years[selectedYearRow]
         selectedMonth = months[selectedMonthRow]

--- a/Offroad-iOS/Offroad-iOS/Presentation/Diary/ViewController/MonthPickerModalViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Diary/ViewController/MonthPickerModalViewController.swift
@@ -88,8 +88,9 @@ private extension MonthPickerModalViewController {
         dateComponents.year = selectedYear
         dateComponents.month = selectedMonth
         
-        let selectedDate = Calendar(identifier: .gregorian).date(from: dateComponents)!
-        MyDiaryManager.shared.updateCalenderCurrentPage.accept(selectedDate)
+        if let selectedDate = Calendar(identifier: .gregorian).date(from: dateComponents) {
+            MyDiaryManager.shared.updateCalenderCurrentPage.accept(selectedDate)
+        }
         
         dismiss(animated: true)
     }

--- a/Offroad-iOS/Offroad-iOS/Presentation/Diary/ViewController/MonthPickerModalViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Diary/ViewController/MonthPickerModalViewController.swift
@@ -15,13 +15,10 @@ final class MonthPickerModalViewController: UIViewController {
     
     private let rootView = MonthPickerModalView()
     
-    private let currentYear = 2025
-    private let currentMonth = 3
+    private let (minYear, minMonth) = MyDiaryManager.shared.fetchYearMonthValue(dateType: .minimum)
+    private let (maxYear, maxMonth) = MyDiaryManager.shared.fetchYearMonthValue(dateType: .maximum)
     
-    private let minimumYear = 2024
-    private let minimumMonth = 11
-    
-    private lazy var years = Array(minimumYear...currentYear)
+    private lazy var years = Array(minYear...maxYear)
     private let months = Array(1...12)
     
     // MARK: - Life Cycle
@@ -35,6 +32,7 @@ final class MonthPickerModalViewController: UIViewController {
         
         setupDelegate()
         setupTarget()
+        setInitialSelectedRow()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -61,13 +59,18 @@ private extension MonthPickerModalViewController {
     func setupTarget() {
         rootView.completeButton.addTarget(self, action: #selector(completeTapped), for: .touchUpInside)
     }
-}
-
-extension MonthPickerModalViewController {
     
-    // MARK: - Func
-    
-    func setupCustomBackButton(buttonTitle: String) {
+    func setInitialSelectedRow() {
+        let (currentYear, currentMonth) =        MyDiaryManager.shared.fetchYearMonthValue(dateType: .current)
+        
+        let selectedYearRow = years.firstIndex(of: currentYear)!
+        let selectedMonthRow = months.firstIndex(of: currentMonth)!
+        
+        DispatchQueue.main.async {
+            self.rootView.monthPickerView.selectRow(selectedYearRow, inComponent: 0, animated: false)
+            self.rootView.monthPickerView.selectRow(selectedMonthRow, inComponent: 1, animated: false)
+            self.rootView.monthPickerView.reloadAllComponents()
+        }
     }
 }
     

--- a/Offroad-iOS/Offroad-iOS/Presentation/Diary/ViewController/MonthPickerModalViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Diary/ViewController/MonthPickerModalViewController.swift
@@ -17,9 +17,18 @@ final class MonthPickerModalViewController: UIViewController {
     
     private let (minYear, minMonth) = MyDiaryManager.shared.fetchYearMonthValue(dateType: .minimum)
     private let (maxYear, maxMonth) = MyDiaryManager.shared.fetchYearMonthValue(dateType: .maximum)
+    private let (currentYear, currentMonth) = MyDiaryManager.shared.fetchYearMonthValue(dateType: .current)
     
     private lazy var years = Array(minYear...maxYear)
-    private let months = Array(1...12)
+    private lazy var months: [Int] = {
+        if currentYear == maxYear {
+            return Array(1...maxMonth)
+        } else if currentYear == minYear {
+            return Array(minMonth...12)
+        } else {
+            return Array(1...12)
+        }
+    }()
     
     // MARK: - Life Cycle
     
@@ -60,9 +69,7 @@ private extension MonthPickerModalViewController {
         rootView.completeButton.addTarget(self, action: #selector(completeTapped), for: .touchUpInside)
     }
     
-    func setInitialSelectedRow() {
-        let (currentYear, currentMonth) =        MyDiaryManager.shared.fetchYearMonthValue(dateType: .current)
-        
+    func setInitialSelectedRow() {        
         let selectedYearRow = years.firstIndex(of: currentYear)!
         let selectedMonthRow = months.firstIndex(of: currentMonth)!
         
@@ -142,6 +149,16 @@ extension MonthPickerModalViewController: UIPickerViewDelegate {
     }
     
     func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
+        if component == 0 {
+            if years[row] == maxYear {
+                months = Array(1...maxMonth)
+            } else if years[row] == minYear {
+                months = Array(minMonth...12)
+            } else {
+                months = Array(1...12)
+            }
+            pickerView.reloadComponent(1)
+        }
         pickerView.reloadComponent(component)
     }
 }

--- a/Offroad-iOS/Offroad-iOS/Presentation/Diary/ViewController/MonthPickerModalViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Diary/ViewController/MonthPickerModalViewController.swift
@@ -173,9 +173,10 @@ extension MonthPickerModalViewController: UIPickerViewDelegate {
                 pickerView.selectRow(months.firstIndex(of: selectedMonth) ?? 0, inComponent: 1, animated: false)
             }
             selectedMonth = months[pickerView.selectedRow(inComponent: 1)]
+            pickerView.reloadAllComponents()
         } else {
             selectedMonth = months[row]
+            pickerView.reloadComponent(component)
         }
-        pickerView.reloadComponent(component)
     }
 }

--- a/Offroad-iOS/Offroad-iOS/Presentation/Diary/ViewController/MonthPickerModalViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Diary/ViewController/MonthPickerModalViewController.swift
@@ -88,7 +88,7 @@ private extension MonthPickerModalViewController {
         dateComponents.year = selectedYear
         dateComponents.month = selectedMonth
         
-        let selectedDate = Calendar.current.date(from: dateComponents)!
+        let selectedDate = Calendar(identifier: .gregorian).date(from: dateComponents)!
         MyDiaryManager.shared.updateCalenderCurrentPage.accept(selectedDate)
         
         dismiss(animated: true)

--- a/Offroad-iOS/Offroad-iOS/Presentation/Diary/ViewModel/DiaryViewModel.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Diary/ViewModel/DiaryViewModel.swift
@@ -39,8 +39,8 @@ extension DiaryViewModel {
     func fetchMinimumDate() {
         //임시(서버에서 불러와서 설정할 예정)
         var dateComponents = DateComponents()
-        dateComponents.year = 2024
-        dateComponents.month = 11
+        dateComponents.year = 2022
+        dateComponents.month = 2
         
         MyDiaryManager.shared.minimumDate = calendar.date(from: dateComponents) ?? Date()
     }

--- a/Offroad-iOS/Offroad-iOS/Presentation/Diary/ViewModel/DiaryViewModel.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Diary/ViewModel/DiaryViewModel.swift
@@ -16,7 +16,7 @@ final class DiaryViewModel {
     
     // MARK: - Properties
     
-    private let calendar = Calendar.current
+    private let calendar = Calendar(identifier: .gregorian)
     private let dummyDatesAndColor = ["2024-12-11": ["70DAFFB2", "FFDC14B2"], "2024-12-22": ["FF69E1B2", "FFB73BB2"], "2024-12-29": ["FF69E1B2", "5580FFB2"], "2025-03-07": ["70DAFFB2", "FFDC14B2"], "2025-03-08": ["FF69E1B2", "FFB73BB2"], "2025-03-10": ["FF69E1B2", "5580FFB2"]]
 }
 

--- a/Offroad-iOS/Offroad-iOS/Presentation/Diary/ViewModel/DiaryViewModel.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Diary/ViewModel/DiaryViewModel.swift
@@ -19,9 +19,6 @@ final class DiaryViewModel {
     private let calendar = Calendar.current
     private let dummyDatesAndColor = ["2024-12-11": ["70DAFFB2", "FFDC14B2"], "2024-12-22": ["FF69E1B2", "FFB73BB2"], "2024-12-29": ["FF69E1B2", "5580FFB2"], "2025-03-07": ["70DAFFB2", "FFDC14B2"], "2025-03-08": ["FF69E1B2", "FFB73BB2"], "2025-03-10": ["FF69E1B2", "5580FFB2"]]
     
-    private var minimumDate: Date?
-    private let maximumDate = Date()
-    
     var currentPage = Date()
 }
 
@@ -41,25 +38,19 @@ extension DiaryViewModel {
         return dummyDatesAndColor[key]
     }
     
-    func fetchMinumumDate() -> Date {
+    func fetchMinimumDate() {
         //임시(서버에서 불러와서 설정할 예정)
         var dateComponents = DateComponents()
         dateComponents.year = 2024
         dateComponents.month = 11
         
-        minimumDate = calendar.date(from: dateComponents)
-        
-        return minimumDate ?? Date()
-    }
-    
-    func fetchMaximumDate() -> Date {
-        return maximumDate
+        MyDiaryManager.shared.minimumDate = calendar.date(from: dateComponents) ?? Date()
     }
     
     func canMoveMonth(_ target: Month) -> Bool {
         let currentComponents = calendar.dateComponents([.year, .month], from: currentPage)
-        let minimumComponents = calendar.dateComponents([.year, .month], from: minimumDate ?? Date())
-        let maximumComponents = calendar.dateComponents([.year, .month], from: maximumDate)
+        let minimumComponents = calendar.dateComponents([.year, .month], from: MyDiaryManager.shared.minimumDate)
+        let maximumComponents = calendar.dateComponents([.year, .month], from: MyDiaryManager.shared.maximumDate)
         
         if let currentYear = currentComponents.year,
            let currentMonth = currentComponents.month,

--- a/Offroad-iOS/Offroad-iOS/Presentation/Diary/ViewModel/DiaryViewModel.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Diary/ViewModel/DiaryViewModel.swift
@@ -18,8 +18,6 @@ final class DiaryViewModel {
     
     private let calendar = Calendar.current
     private let dummyDatesAndColor = ["2024-12-11": ["70DAFFB2", "FFDC14B2"], "2024-12-22": ["FF69E1B2", "FFB73BB2"], "2024-12-29": ["FF69E1B2", "5580FFB2"], "2025-03-07": ["70DAFFB2", "FFDC14B2"], "2025-03-08": ["FF69E1B2", "FFB73BB2"], "2025-03-10": ["FF69E1B2", "5580FFB2"]]
-    
-    var currentPage = Date()
 }
 
 extension DiaryViewModel {
@@ -48,7 +46,7 @@ extension DiaryViewModel {
     }
     
     func canMoveMonth(_ target: Month) -> Bool {
-        let (currentYear, currentMonth) = MyDiaryManager.shared.fetchYearMonthValue(dateType: .custom, targetDate: currentPage)
+        let (currentYear, currentMonth) = MyDiaryManager.shared.fetchYearMonthValue(dateType: .current)
         let (minYear, minMonth) = MyDiaryManager.shared.fetchYearMonthValue(dateType: .minimum)
         let (maxYear, maxMonth) = MyDiaryManager.shared.fetchYearMonthValue(dateType: .maximum)
         

--- a/Offroad-iOS/Offroad-iOS/Presentation/Diary/ViewModel/DiaryViewModel.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Diary/ViewModel/DiaryViewModel.swift
@@ -46,15 +46,15 @@ extension DiaryViewModel {
     }
     
     func canMoveMonth(_ target: Month) -> Bool {
-        let (currentYear, currentMonth) = MyDiaryManager.shared.fetchYearMonthValue(dateType: .current)
+        let (currentPageYear, currentPageMonth) = MyDiaryManager.shared.fetchYearMonthValue(dateType: .currentPage)
         let (minYear, minMonth) = MyDiaryManager.shared.fetchYearMonthValue(dateType: .minimum)
         let (maxYear, maxMonth) = MyDiaryManager.shared.fetchYearMonthValue(dateType: .maximum)
         
         switch target {
         case .previous:
-            return (currentYear > minYear) || (currentYear == minYear && currentMonth > minMonth)
+            return (currentPageYear > minYear) || (currentPageYear == minYear && currentPageMonth > minMonth)
         case .next:
-            return (currentYear < maxYear) || (currentYear == maxYear && currentMonth < maxMonth)
+            return (currentPageYear < maxYear) || (currentPageYear == maxYear && currentPageMonth < maxMonth)
         }
     }
 }

--- a/Offroad-iOS/Offroad-iOS/Presentation/Diary/ViewModel/DiaryViewModel.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Diary/ViewModel/DiaryViewModel.swift
@@ -48,25 +48,15 @@ extension DiaryViewModel {
     }
     
     func canMoveMonth(_ target: Month) -> Bool {
-        let currentComponents = calendar.dateComponents([.year, .month], from: currentPage)
-        let minimumComponents = calendar.dateComponents([.year, .month], from: MyDiaryManager.shared.minimumDate)
-        let maximumComponents = calendar.dateComponents([.year, .month], from: MyDiaryManager.shared.maximumDate)
+        let (currentYear, currentMonth) = MyDiaryManager.shared.fetchYearMonthValue(dateType: .custom, targetDate: currentPage)
+        let (minYear, minMonth) = MyDiaryManager.shared.fetchYearMonthValue(dateType: .minimum)
+        let (maxYear, maxMonth) = MyDiaryManager.shared.fetchYearMonthValue(dateType: .maximum)
         
-        if let currentYear = currentComponents.year,
-           let currentMonth = currentComponents.month,
-           let minYear = minimumComponents.year,
-           let minMonth = minimumComponents.month,
-           let maxYear = maximumComponents.year,
-           let maxMonth = maximumComponents.month {
-            
-            switch target {
-            case .previous:
-                return (currentYear > minYear) || (currentYear == minYear && currentMonth > minMonth)
-            case .next:
-                return (currentYear < maxYear) || (currentYear == maxYear && currentMonth < maxMonth)
-            }
-        } else {
-            return false
+        switch target {
+        case .previous:
+            return (currentYear > minYear) || (currentYear == minYear && currentMonth > minMonth)
+        case .next:
+            return (currentYear < maxYear) || (currentYear == maxYear && currentMonth < maxMonth)
         }
     }
 }


### PR DESCRIPTION
### 🌴 작업한 브랜치
- #477


### ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->
일기 캘린더 pickerView를 구현했습니다.
- `MyDiaryManager`라는 싱글톤 객체를 생성하였으며 일기 기능에서 저장해야할 데이터나 전역적으로 관리할 로직을 담을 예정입니다.
- 현재 보여지는 캘린더 페이지와 PickerView의 선택된 연도/월 데이터를 일치시킬 수 있도록 RxSwift를 활용하여 바인딩했습니다.  
<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### ❗️PR Point
<!-- 부족했던 점 혹은 개선하고 싶은 방향이 있다면 얘기해주세요 -->

<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->

|iPhone SE|iPhone 16|
|:------:|:---:|
|<img src = "https://github.com/user-attachments/assets/27e67ada-bf75-46ce-ab8d-e1e3254ad367" width ="280">|<img src = "https://github.com/user-attachments/assets/65b31071-096c-4145-bd2d-5678a038215e" width ="280">|

- Resolved: #477