### PR TITLE
[Fix] #484 - AmplitudeManager 동작 범위 수정

### DIFF
--- a/Offroad-iOS/Offroad-iOS.xcodeproj/project.pbxproj
+++ b/Offroad-iOS/Offroad-iOS.xcodeproj/project.pbxproj
@@ -417,6 +417,7 @@
 		4EE0498B2CA10DFC00754488 /* CouponAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EE0498A2CA10DFC00754488 /* CouponAPI.swift */; };
 		4EE0498D2CA10E2A00754488 /* CouponService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EE0498C2CA10E2A00754488 /* CouponService.swift */; };
 		4EE049912CA14E6500754488 /* CouponCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EE049902CA14E6500754488 /* CouponCell.swift */; };
+		4EE6B5242D85703700AEFCD4 /* AmplitudeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ED6BE3B2D7B3C000020C871 /* AmplitudeManager.swift */; };
 		4EEA82FC2CE3907C0062F0DE /* CharacterChatLogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EEA82FB2CE3907C0062F0DE /* CharacterChatLogView.swift */; };
 		4EEA82FE2CE3908C0062F0DE /* CharacterChatLogViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EEA82FD2CE3908C0062F0DE /* CharacterChatLogViewController.swift */; };
 		4EEC2FA82C41216700007353 /* OffroadTabBarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EEC2FA72C41216700007353 /* OffroadTabBarViewController.swift */; };
@@ -3435,6 +3436,7 @@
 				87738CD02C8DC15200E107C7 /* UIColor+.swift in Sources */,
 				D0E795FC2C447511005B47A5 /* AppleAuthManager.swift in Sources */,
 				D06D26C12C3D6A2A00E79F25 /* UILabel+.swift in Sources */,
+				4EE6B5242D85703700AEFCD4 /* AmplitudeManager.swift in Sources */,
 				D00A48892C763D24008B286A /* NavigationPopButton.swift in Sources */,
 				D0E7965F2C45518B005B47A5 /* EmblemInfoResponseDTO.swift in Sources */,
 				4E99007C2CDB952C007EEFF7 /* ORBCharacterChatWindow.swift in Sources */,

--- a/Offroad-iOS/Offroad-iOS/Global/Amplitude/AmplitudeManager.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Amplitude/AmplitudeManager.swift
@@ -21,11 +21,14 @@ public class AmplitudeManager {
     
     /// background에서 다음 시간 동안 아무런 앰플리튜드 이벤트가 발생하지 않을 경우 세션 종료. millisecond 단위이며, 10분으로 설정
     private let minTimeBetweenSessionsMillis: Int = 1000 * 60 * 10
-    private var amplitude: Amplitude
+    
+    /// 배포용 타겟에서는 nil 할당
+    private var amplitude: Amplitude? = nil
     
     // MARK: - Life Cycle
     
     private init() {
+        #if DevTarget
         let amplitudeAPIKey = Bundle.main.infoDictionary?["AMPLITUDE_API_KEY"] as? String
         self.amplitude = Amplitude(
             configuration: .init(
@@ -34,6 +37,7 @@ public class AmplitudeManager {
                 autocapture: [.sessions]
             )
         )
+        #endif
     }
     
 }
@@ -43,8 +47,10 @@ public extension AmplitudeManager {
     /// 간단한 텍스트만을 이용한 이벤트 기록
     /// - Parameters:
     ///   - eventName: 이벤트 이름.
+    ///
+    /// 현재 개발용 타겟에서만 동작. 배포용 타겟에서는 아무런 효과도 없음.
     func trackEvent(withName eventName: String) {
-        amplitude.track(eventType: eventName)
+        amplitude?.track(eventType: eventName)
     }
     
 }


### PR DESCRIPTION
### 🌴 작업한 브랜치
- #484 


### ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->
- [AmplitudeManager.swift 파일을 배포용 타겟에서 제거하면서 발생하는 문제](https://desk.channel.io/z3vne/threads/groups/1_%EC%95%84%EC%9A%94-409118/67d282e7e552c44772e5/67d534279d06a651dd3e) 해결
AmplitudeManager.swift 파일을 개발용 타겟에만 한정하였더니, 이 객체를 활용하는 코드에서 에러가 발생하였습니다.
(trackEvent 메서드를 호출하는 곳)
배포용 타겟에 포함하되, Amplitude 기능 적용 범위를 개발용 타겟으로 한정하는 방법을 이용하여 문제를 해결하였습니다.
amplitude 변수를 옵셔널 타입으로 구현하여 개발용 타겟에서 컴파일될 경우 nil을 할당하였습니다.

<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->

AmplitudeManager 의 전체 코드는 다음과 같습니다.
``` swift
import Foundation

import AmplitudeSwift

/// Amplitude 객체를 보관하는 싱글톤 객체.
/// 이벤트를 트래킹하는 간단한 동작들 구현
public class AmplitudeManager {
    
    //MARK: - Type Properties
    
    static var shared = AmplitudeManager()
    
    //MARK: - Properties
    
    /// background에서 다음 시간 동안 아무런 앰플리튜드 이벤트가 발생하지 않을 경우 세션 종료. millisecond 단위이며, 10분으로 설정
    private let minTimeBetweenSessionsMillis: Int = 1000 * 60 * 10
    
    /// 배포용 타겟에서는 nil 할당
    private var amplitude: Amplitude? = nil
    
    // MARK: - Life Cycle
    
    private init() {
        #if DevTarget
        let amplitudeAPIKey = Bundle.main.infoDictionary?["AMPLITUDE_API_KEY"] as? String
        self.amplitude = Amplitude(
            configuration: .init(
                apiKey: amplitudeAPIKey ?? "",
                minTimeBetweenSessionsMillis: minTimeBetweenSessionsMillis,
                autocapture: [.sessions]
            )
        )
        #endif
    }
    
}

public extension AmplitudeManager {
    
    /// 간단한 텍스트만을 이용한 이벤트 기록
    /// - Parameters:
    ///   - eventName: 이벤트 이름.
    ///
    /// 현재 개발용 타겟에서만 동작. 배포용 타겟에서는 아무런 효과도 없음.
    func trackEvent(withName eventName: String) {
        amplitude?.track(eventType: eventName)
    }
    
}
```

### ❗️PR Point
<!-- 부족했던 점 혹은 개선하고 싶은 방향이 있다면 얘기해주세요 -->

<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->

### 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->

|뷰|설명|
|:------:|:---:|
|        |     |


- Resolved: #484
