### PR TITLE
[Network] #495 - 일기 fcm api 연결

### DIFF
--- a/Offroad-iOS/Offroad-iOS/Application/AppDelegate.swift
+++ b/Offroad-iOS/Offroad-iOS/Application/AppDelegate.swift
@@ -93,6 +93,13 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
             } else if category == "ANNOUNCEMENT_REDIRECT" {
                 completionHandler([.list, .banner])
             }
+            #if DevTarget
+            if category == "MEMBER_DIARY_CREATE" {
+                completionHandler([])
+                MyDiaryManager.shared.didCompleteCreateDiary.accept(())
+                MyDiaryManager.shared.didUpdateLatestDiaryInfo.accept(())
+            }
+            #endif
         }
     }
     

--- a/Offroad-iOS/Offroad-iOS/Global/Literals/StringLiterals.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Literals/StringLiterals.swift
@@ -69,6 +69,8 @@ struct DiaryGuideMessage {
 
 struct DiaryMessage {
     static let diaryEmptyDesription = "만들어진 일기가 없어요.\n\n오브가 아직 어색한가 봐요.\n조금 더 대화를 나눠보세요."
+    static let completeCreateDiaryTitle = "일기 완성!"
+    static let completeCreateDiaryMessage = "오늘의 일기가 완성되었어요.\n기억빛과 함께 하루를 돌아보세요."
 }
 
 struct AmplitudeEventTitles {

--- a/Offroad-iOS/Offroad-iOS/Presentation/Diary/MyDiaryManager/MyDiaryManager.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Diary/MyDiaryManager/MyDiaryManager.swift
@@ -30,6 +30,7 @@ final class MyDiaryManager {
     let updateCalenderCurrentPage = PublishRelay<Date>()
     let didSuccessUpdateTutorialCheckStatus = PublishRelay<Void>()
     let didUpdateLatestDiaryInfo = PublishRelay<Void>()
+    let didCompleteCreateDiary = PublishRelay<Void>()
     
     //MARK: - Life Cycle
     

--- a/Offroad-iOS/Offroad-iOS/Presentation/Diary/MyDiaryManager/MyDiaryManager.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Diary/MyDiaryManager/MyDiaryManager.swift
@@ -29,7 +29,7 @@ final class MyDiaryManager {
 
     let updateCalenderCurrentPage = PublishRelay<Date>()
     let didSuccessUpdateTutorialCheckStatus = PublishRelay<Void>()
-    let didReadLatestDiary = PublishRelay<Void>()
+    let didUpdateLatestDiaryInfo = PublishRelay<Void>()
     
     //MARK: - Life Cycle
     

--- a/Offroad-iOS/Offroad-iOS/Presentation/Diary/MyDiaryManager/MyDiaryManager.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Diary/MyDiaryManager/MyDiaryManager.swift
@@ -5,7 +5,7 @@
 //  Created by 조혜린 on 3/11/25.
 //
 
-import Foundation
+import UIKit
 
 import RxSwift
 import RxRelay
@@ -52,5 +52,23 @@ extension MyDiaryManager {
         case .currentPage:
             return (calendar.component(.year, from: currentPageDate), calendar.component(.month, from: currentPageDate))
         }
+    }
+    
+    func showCompleteCreateDiaryAlert(viewController: UIViewController) {
+        let alertController = ORBAlertController(title: DiaryMessage.completeCreateDiaryTitle, message: DiaryMessage.completeCreateDiaryMessage, type: .normal)
+        alertController.configureMessageLabel{ label in
+            label.setLineHeight(percentage: 150)
+        }
+        alertController.xButton.isHidden = true
+        let cancelAction = ORBAlertAction(title: "나중에", style: .cancel) { _ in return }
+        let okAction = ORBAlertAction(title: "확인", style: .default) { _ in
+            let diaryViewController = DiaryViewController(shouldShowLatestDiary: true)
+            diaryViewController.setupCustomBackButton(buttonTitle: "")
+            viewController.navigationController?.pushViewController(diaryViewController, animated: true)
+        }
+        alertController.addAction(cancelAction)
+        alertController.addAction(okAction)
+        
+        viewController.present(alertController, animated: true)
     }
 }

--- a/Offroad-iOS/Offroad-iOS/Presentation/Home/View/HomeView.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Home/View/HomeView.swift
@@ -26,8 +26,10 @@ final class HomeView: UIView {
     let shareButton = UIButton()
     let changeCharacterButton = UIButton()
     let recommendButton = UIButton()
+    #if DevTarget
     let diaryButton = UIButton()
     let diaryUnreadDotView = UIView()
+    #endif
     private let buttonStackView = UIStackView()
     private let characterMotionView = LottieAnimationView()
     private let titleView = UIView()
@@ -104,6 +106,7 @@ extension HomeView {
             $0.setImage(.btnRecommend, for: .normal)
         }
         
+        #if DevTarget
         diaryButton.do {
             $0.setImage(.btnDiaryHome, for: .normal)
         }
@@ -120,6 +123,14 @@ extension HomeView {
             button.layer.shadowOpacity = 0.1
             button.layer.shadowRadius = 4
         }
+        #else
+        [chatButton, recommendButton, changeCharacterButton].forEach { button in
+            button.layer.shadowColor = UIColor.black.cgColor
+            button.layer.shadowOffset = CGSize(width: 0, height: 1)
+            button.layer.shadowOpacity = 0.1
+            button.layer.shadowRadius = 4
+        }
+        #endif
         
         buttonStackView.do {
             $0.axis = .vertical
@@ -239,12 +250,6 @@ extension HomeView {
             $0.top.equalTo(characterNameView.snp.top)
             $0.trailing.equalToSuperview().inset(24)
         }
-
-        [chatButton, shareButton, changeCharacterButton, diaryButton].forEach { button in
-            button.snp.makeConstraints {
-                $0.size.equalTo(44)
-            }
-        }
         
         chatUnreadDotView.snp.makeConstraints {
             $0.top.equalToSuperview().inset(2)
@@ -253,10 +258,22 @@ extension HomeView {
         }
         
         #if DevTarget
+        [chatButton, shareButton, changeCharacterButton, diaryButton].forEach { button in
+            button.snp.makeConstraints {
+                $0.size.equalTo(44)
+            }
+        }
+        
         diaryUnreadDotView.snp.makeConstraints {
             $0.top.equalToSuperview().inset(2)
             $0.trailing.equalToSuperview().inset(4)
             $0.size.equalTo(8)
+        }
+        #else
+        [chatButton, shareButton, changeCharacterButton].forEach { button in
+            button.snp.makeConstraints {
+                $0.size.equalTo(44)
+            }
         }
         #endif
         

--- a/Offroad-iOS/Offroad-iOS/Presentation/Home/View/HomeView.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Home/View/HomeView.swift
@@ -252,11 +252,13 @@ extension HomeView {
             $0.size.equalTo(8)
         }
         
+        #if DevTarget
         diaryUnreadDotView.snp.makeConstraints {
             $0.top.equalToSuperview().inset(2)
             $0.trailing.equalToSuperview().inset(4)
             $0.size.equalTo(8)
         }
+        #endif
         
         characterMotionView.snp.makeConstraints {
             $0.top.equalTo(characterNameView.snp.bottom)

--- a/Offroad-iOS/Offroad-iOS/Presentation/Home/ViewController/HomeViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Home/ViewController/HomeViewController.swift
@@ -195,6 +195,12 @@ extension HomeViewController {
         }).disposed(by: disposeBag)
         
         #if DevTarget
+        MyDiaryManager.shared.didCompleteCreateDiary
+            .bind { _ in
+                self.showCompleteCreateDiaryAlert()
+            }
+            .disposed(by: disposeBag)
+
         MyDiaryManager.shared.didUpdateLatestDiaryInfo
             .bind { _ in
                 self.getLatestDiaryInfo()
@@ -223,6 +229,26 @@ extension HomeViewController {
             }
         }
     }
+    
+    #if DevTarget
+    private func showCompleteCreateDiaryAlert() {
+        let alertController = ORBAlertController(title: DiaryMessage.completeCreateDiaryTitle, message: DiaryMessage.completeCreateDiaryMessage, type: .normal)
+        alertController.configureMessageLabel{ label in
+            label.setLineHeight(percentage: 150)
+        }
+        alertController.xButton.isHidden = true
+        let cancelAction = ORBAlertAction(title: "나중에", style: .cancel) { _ in return }
+        let okAction = ORBAlertAction(title: "확인", style: .default) { _ in
+            let diaryViewController = DiaryViewController(shouldShowLatestDiary: !self.isReadLatestDiary)
+            diaryViewController.setupCustomBackButton(buttonTitle: "홈")
+            self.navigationController?.pushViewController(diaryViewController, animated: true)
+        }
+        alertController.addAction(cancelAction)
+        alertController.addAction(okAction)
+        
+        present(alertController, animated: true)
+    }
+    #endif
     
     private func requestPushNotificationPermission() {
         let center = UNUserNotificationCenter.current()
@@ -284,6 +310,10 @@ extension HomeViewController {
             case "CHARACTER_CHAT":
                 ORBCharacterChatManager.shared.chatViewController.patchChatReadRelay.accept(())
                 ORBCharacterChatManager.shared.showCharacterChatBox(character: self.pushType?.data?["characterName"] as! String, message: self.pushType?.data?["message"] as! String, mode: .withReplyButtonShrinked)
+            #if DevTarget
+            case "MEMBER_DIARY_CREATE":
+                MyDiaryManager.shared.didCompleteCreateDiary.accept(())
+            #endif
             default:
                 break
             }

--- a/Offroad-iOS/Offroad-iOS/Presentation/Home/ViewController/HomeViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Home/ViewController/HomeViewController.swift
@@ -195,7 +195,7 @@ extension HomeViewController {
         }).disposed(by: disposeBag)
         
         #if DevTarget
-        MyDiaryManager.shared.didReadLatestDiary
+        MyDiaryManager.shared.didUpdateLatestDiaryInfo
             .bind { _ in
                 self.getLatestDiaryInfo()
             }

--- a/Offroad-iOS/Offroad-iOS/Presentation/Home/ViewController/HomeViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Home/ViewController/HomeViewController.swift
@@ -197,7 +197,11 @@ extension HomeViewController {
         #if DevTarget
         MyDiaryManager.shared.didCompleteCreateDiary
             .bind { _ in
-                self.showCompleteCreateDiaryAlert()
+                guard let offroadTabBarController = self.tabBarController as? OffroadTabBarController else { return }
+                
+                if offroadTabBarController.selectedIndex == 0 {
+                    MyDiaryManager.shared.showCompleteCreateDiaryAlert(viewController: self)
+                }
             }
             .disposed(by: disposeBag)
 
@@ -229,26 +233,6 @@ extension HomeViewController {
             }
         }
     }
-    
-    #if DevTarget
-    private func showCompleteCreateDiaryAlert() {
-        let alertController = ORBAlertController(title: DiaryMessage.completeCreateDiaryTitle, message: DiaryMessage.completeCreateDiaryMessage, type: .normal)
-        alertController.configureMessageLabel{ label in
-            label.setLineHeight(percentage: 150)
-        }
-        alertController.xButton.isHidden = true
-        let cancelAction = ORBAlertAction(title: "나중에", style: .cancel) { _ in return }
-        let okAction = ORBAlertAction(title: "확인", style: .default) { _ in
-            let diaryViewController = DiaryViewController(shouldShowLatestDiary: !self.isReadLatestDiary)
-            diaryViewController.setupCustomBackButton(buttonTitle: "홈")
-            self.navigationController?.pushViewController(diaryViewController, animated: true)
-        }
-        alertController.addAction(cancelAction)
-        alertController.addAction(okAction)
-        
-        present(alertController, animated: true)
-    }
-    #endif
     
     private func requestPushNotificationPermission() {
         let center = UNUserNotificationCenter.current()

--- a/Offroad-iOS/Offroad-iOS/Presentation/MemoryLight/ViewModel/MemoryLightViewModel.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/MemoryLight/ViewModel/MemoryLightViewModel.swift
@@ -39,7 +39,7 @@ extension MemoryLightViewModel {
             switch response {
             case .success:
                 print("일기 확인 여부 업데이트 완료")
-                MyDiaryManager.shared.didReadLatestDiary.accept(())
+                MyDiaryManager.shared.didUpdateLatestDiaryInfo.accept(())
             default:
                 break
             }

--- a/Offroad-iOS/Offroad-iOS/Presentation/MyPage/Settings/Notice/NoticePost/ViewController/NoticePostViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/MyPage/Settings/Notice/NoticePost/ViewController/NoticePostViewController.swift
@@ -71,8 +71,12 @@ extension NoticePostViewController {
     }
     
     @objc private func contentButtonTapped() {
-        let redirectionURL = NSURL(string: noticeDetailInfo.externalLinks[0])
-        let safariViewController = SFSafariViewController(url: (redirectionURL ?? NSURL()) as URL)
-        self.present(safariViewController, animated: true, completion: nil)
+        let redirectionURL = noticeDetailInfo.externalLinks[0]
+        guard let url = URL(string: redirectionURL), ["http", "https"].contains(url.scheme?.lowercased()) else {
+            ORBToastManager.shared.showToast(message: "콘텐츠 링크를 찾을 수 없습니다.", inset: 30)
+            return
+        }
+        let safariViewController = SFSafariViewController(url: url)
+        present(safariViewController, animated: true)
     }
 }

--- a/Offroad-iOS/Offroad-iOS/Presentation/MyPage/ViewControllers/MyPageViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/MyPage/ViewControllers/MyPageViewController.swift
@@ -74,6 +74,18 @@ extension MyPageViewController {
             guard let self else { return }
             self.getUserInfo()
         }).disposed(by: disposeBag)
+        
+        #if DevTarget
+        MyDiaryManager.shared.didCompleteCreateDiary
+            .bind { _ in
+                guard let offroadTabBarController = self.tabBarController as? OffroadTabBarController else { return }
+                
+                if offroadTabBarController.selectedIndex == 2 {
+                    MyDiaryManager.shared.showCompleteCreateDiaryAlert(viewController: self)
+                }
+            }
+            .disposed(by: disposeBag)
+        #endif
     }
     
     // MARK: - @objc Func

--- a/Offroad-iOS/Offroad-iOS/Presentation/QuestMap/ViewControllers/ORBMapViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/QuestMap/ViewControllers/ORBMapViewController.swift
@@ -239,6 +239,18 @@ extension ORBMapViewController {
             guard let self else { return }
             self.navigationController?.pushViewController(PlaceListViewController(), animated: true)
         }.disposed(by: disposeBag)
+        
+        #if DevTarget
+        MyDiaryManager.shared.didCompleteCreateDiary
+            .bind { _ in
+                guard let offroadTabBarController = self.tabBarController as? OffroadTabBarController else { return }
+                
+                if offroadTabBarController.selectedIndex == 1 {
+                    MyDiaryManager.shared.showCompleteCreateDiaryAlert(viewController: self)
+                }
+            }
+            .disposed(by: disposeBag)
+        #endif
     }
     
     private func setupTooltipAction() {


### PR DESCRIPTION
### 🌴 작업한 브랜치
- #495

### ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->
일기 fcm을 연결했습니다.

- fcm을 수신했을 때, 팝업 띄우고 최신 일기 확인 여부 UI 업데이트(일기 버튼 위 빨간 점)하도록 구현 
- 공지사항 외부링크 연결되지 않던 버그 해결

<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### ❗️PR Point
<!-- 부족했던 점 혹은 개선하고 싶은 방향이 있다면 얘기해주세요 -->

<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->

|앱 실행 중 fcm 수신(일기 바로 확인)|앱 실행 중 fcm 수신(일기 나중에 확인)|
|:------:|:------:|
|<img src = "https://github.com/user-attachments/assets/18b3a786-9988-4f9e-9f97-91fe8896d987" width ="280">|<img src = "https://github.com/user-attachments/assets/770beb99-7020-4bc6-86a0-66adb2681ba2" width ="280">|

|앱이 실행 중이지 않을 때 fcm 수신|공지사항 리다이렉션 에러 처리|
|:---:|:---:|
|<img src = "https://github.com/user-attachments/assets/9e965b85-f446-4fe4-a6de-72d6b7efe924" width ="280">|<img src = "https://github.com/user-attachments/assets/b091a384-3fee-435e-8a55-728c606be55e" width ="280">|

- Resolved: #495