### PR TITLE
[Hotfix] #521 - 지도 권한 요청 시 앱이 꺼지는 문제 해결

### DIFF
--- a/Offroad-iOS/Offroad-iOS/Presentation/QuestMap/ViewControllers/AdventureMapViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/QuestMap/ViewControllers/AdventureMapViewController.swift
@@ -46,13 +46,14 @@ class AdventureMapViewController: OffroadTabBarViewController {
         rootView.orbMapView.mapView.positionMode = .direction
         locationManager.startUpdatingHeading()
         rootView.orbMapView.mapView.moveCamera(.init(heading: 0))
-        viewModel.checkLocationAuthorizationStatus { [weak self] authorizationCase in
-            guard let self else { return }
-            if authorizationCase != .fullAccuracy && authorizationCase != .reducedAccuracy {
-                // 사용자 위치 불러올 수 없을 시 초기 위치 설정
-                // 초기 위치: 광화문광장 (37.5716229, 126.9767879)
-                rootView.orbMapView.moveCamera(scrollTo: .init(lat: 37.5716229, lng: 126.9767879), animationDuration: 0)
-                self.viewModel.updateRegisteredPlaces(at: .init(lat: 37.5716229, lng: 126.9767879))
+        viewModel.checkLocationAuthorizationStatus { authorizationCase in
+            DispatchQueue.main.async { [weak self] in
+                if authorizationCase != .fullAccuracy && authorizationCase != .reducedAccuracy {
+                    // 사용자 위치 불러올 수 없을 시 초기 위치 설정
+                    // 초기 위치: 광화문광장 (37.5716229, 126.9767879)
+                    self?.rootView.orbMapView.moveCamera(scrollTo: .init(lat: 37.5716229, lng: 126.9767879), animationDuration: 0)
+                    self?.viewModel.updateRegisteredPlaces(at: .init(lat: 37.5716229, lng: 126.9767879))
+                }
             }
         }
         viewModel.updateRegisteredPlaces(at: currentPositionTarget)


### PR DESCRIPTION
### 🌴 작업한 브랜치
- #521 


### ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->
지도 뷰에 접근하면서 위치 권한 요청 시 앱이 꺼지는 문제를 해결하였습니다.
위치 권한을 비동기적으로 불러오는데, UI 관련 코드를 메인스레드에서 호출하지 않아 생기는 문제였고, 이를 해결하였습니다.
(`DispatchQueue.main.async` 사용)
<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### ❗️PR Point
<!-- 부족했던 점 혹은 개선하고 싶은 방향이 있다면 얘기해주세요 -->

<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->

|뷰|설명|
|:------:|:---:|
|        |     |


- Resolved: #521 
