### PR TITLE
[Fix] #525 - 오브 그라데이션 애니메이션 성능 개선

### DIFF
--- a/Offroad-iOS/Offroad-iOS/Global/Components/ORBRecommendationGradient/ORBRecommendationBaseBackground.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Components/ORBRecommendationGradient/ORBRecommendationBaseBackground.swift
@@ -49,8 +49,8 @@ final class ORBRecommendationBaseBackground: UIView {
     override func layoutSubviews() {
         super.layoutSubviews()
         
-        // 뷰의 크기가 작아지는 애니메이션에서 gradient가 잘리는 현상이 없도록 30만큼 여유분 설정
-        gradient.frame = bounds.insetBy(dx: -30, dy: -30)
+        // 뷰의 크기가 작아지는 애니메이션에서 gradient가 잘리는 현상이 없도록 300만큼 여유분 설정
+        gradient.frame = bounds.insetBy(dx: -300, dy: -300)
         
         let borderWidth = gradientBorderWidth
         blur.frame = bounds.insetBy(dx: borderWidth, dy: borderWidth)

--- a/Offroad-iOS/Offroad-iOS/Global/Components/ORBRecommendationGradient/ORBRecommendationGradientLayer.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Components/ORBRecommendationGradient/ORBRecommendationGradientLayer.swift
@@ -58,18 +58,13 @@ final class ORBRecommendationGradientLayer: CAGradientLayer {
     }
     
     private func startAnimation() {
-        CATransaction.begin()
-        CATransaction.setCompletionBlock { [weak self] in
-            self?.startAnimation()
-        }
-        
         let glowAnimation = CAKeyframeAnimation(keyPath: "colors")
         glowAnimation.values = [colorCombinations1, colorCombinations2, colorCombinations3, colorCombinations4].randomElement()
         glowAnimation.keyTimes = [0, 0.25, 0.5, 0.75, 1]
         glowAnimation.duration = Double([4, 5, 6].randomElement()!)
+        glowAnimation.repeatCount = .infinity
+        glowAnimation.isRemovedOnCompletion = false
         add(glowAnimation, forKey: "glowAnimation")
-        
-        CATransaction.commit()
     }
     
 }


### PR DESCRIPTION
### 🌴 작업한 브랜치
- #525


### ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->
### 오브 그라데이션 애니메이션을 무한 반복하는 방법을 개선하였습니다.
기존 방법은 completionHandler 를 통해서 재귀적으로 호출하는 방법이었는데, 
이러한 방법으로 인해 무한하게 콜스택이 생성되고 성능에 문제가 되는 것을 발견했습니다.

Core Animation에서 무한하게 애니메이션을 구현하기 위해 `repeatCount = .infinity` 로 설정해 주었습니다.

### 기타
그라데이션 애니메이션의 배경이 되는 그라데이션 레이어의 여유분을 30 -> 300 으로 증가시켰습니다.
(애니메이션을 구현하다보니 30으로는 부족한 것 같더라구요)
<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### ❗️PR Point
<!-- 부족했던 점 혹은 개선하고 싶은 방향이 있다면 얘기해주세요 -->

<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->

|뷰|설명|
|:------:|:---:|
|        |     |


- Resolved: #525
