### PR TITLE
[Fix] #527 - 채팅 입력창 레이아웃 수정

### DIFF
--- a/Offroad-iOS/Offroad-iOS/Global/Components/Chat/ChatTextInput/ChatTextInputView.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Components/Chat/ChatTextInput/ChatTextInputView.swift
@@ -74,9 +74,8 @@ private extension ChatTextInputView {
     
     private func setupLayout() {
         textViewBackground.snp.makeConstraints { make in
-            make.top.equalToSuperview().inset(16)
+            make.verticalEdges.equalToSuperview().inset(16)
             make.leading.equalToSuperview().inset(24)
-            make.bottom.equalTo(keyboardLayoutGuide.snp.top).offset(-16)
         }
         
         userChatInputViewHeightConstraint.isActive = true

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/ViewControllers/ORBCharacterChatViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/ViewControllers/ORBCharacterChatViewController.swift
@@ -172,6 +172,7 @@ extension ORBCharacterChatViewController {
         rootView.endChatButton.isHidden = false
         rootView.chatTextInputView.startChat()
         rootView.chatTextDisplayView.show()
+        rootView.keyboardBackgroundView.alpha = 1
         isChatTextInputViewShown = true
         panGesture.isEnabled = true
     }
@@ -180,6 +181,7 @@ extension ORBCharacterChatViewController {
         rootView.endChatButton.isHidden = true
         rootView.chatTextInputView.endChat(erase: true)
         rootView.chatTextDisplayView.hide(erase: true)
+        rootView.keyboardBackgroundView.alpha = 0
         isChatTextInputViewShown = false
         panGesture.isEnabled = false
     }

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/Views/ORBCharacterChatView.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/Views/ORBCharacterChatView.swift
@@ -22,6 +22,7 @@ final class ORBCharacterChatView: UIView {
     let characterChatBox = ORBCharacterChatBox(mode: .withoutReplyButtonShrinked)
     let chatTextInputView = ChatTextInputView()
     let chatTextDisplayView = ChatTextDisplayView()
+    let keyboardBackgroundView = UIView()
     let endChatButton = ShrinkableButton(shrinkScale: 0.93)
     
     override init(frame: CGRect) {
@@ -57,13 +58,19 @@ extension ORBCharacterChatView {
         
         chatTextInputView.snp.makeConstraints { make in
             make.horizontalEdges.equalToSuperview()
-            make.bottom.equalToSuperview()
+            make.bottom.equalTo(keyboardLayoutGuide.snp.top)
         }
         
         chatTextDisplayView.snp.makeConstraints { make in
             make.horizontalEdges.equalTo(chatTextInputView)
             // 두 뷰를 딱 붙여놓으니, 애니메이션 과정에서 경계선이 약간 보이는 문제가 있어 1포인트만큼 겹쳐놓았음.
             make.bottom.equalTo(chatTextInputView.snp.top).offset(1)
+        }
+        
+        keyboardBackgroundView.snp.makeConstraints { make in
+            make.top.equalTo(chatTextInputView.snp.bottom)
+            make.horizontalEdges.equalToSuperview()
+            make.bottom.equalToSuperview()
         }
         
         endChatButton.snp.makeConstraints { make in
@@ -91,6 +98,12 @@ extension ORBCharacterChatView {
             view.layer.masksToBounds = false
         }
         
+        keyboardBackgroundView.do { view in
+            view.backgroundColor = .primary(.white)
+            view.alpha = 0
+            view.isUserInteractionEnabled = false
+        }
+        
         endChatButton.do { button in
             button.backgroundColor = .sub(.sub55)
             button.layer.borderColor = UIColor.sub(.sub).cgColor
@@ -104,7 +117,13 @@ extension ORBCharacterChatView {
     }
     
     private func setupHierarchy() {
-        addSubviews(characterChatBox, chatTextDisplayView, chatTextInputView, endChatButton)
+        addSubviews(
+            characterChatBox,
+            chatTextDisplayView,
+            chatTextInputView,
+            keyboardBackgroundView,
+            endChatButton
+        )
     }
     
 }

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/ChatLog/ViewControllers/CharacterChatLogViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/ChatLog/ViewControllers/CharacterChatLogViewController.swift
@@ -216,6 +216,7 @@ private extension CharacterChatLogViewController {
             guard let self else { return }
             self.hideTabBar()
             self.rootView.chatTextInputView.startChat()
+            self.rootView.keyboardBackgroundView.alpha = 1
         }).disposed(by: disposeBag)
         
         rootView.chatTextInputView.onSendingText.subscribe(onNext: { [weak self] sendingText in
@@ -282,6 +283,7 @@ private extension CharacterChatLogViewController {
         tapGesture.rx.event.subscribe(onNext: { [weak self] _ in
             self?.showTabBar()
             self?.rootView.chatTextInputView.endChat()
+            self?.rootView.keyboardBackgroundView.alpha = 0
         }).disposed(by: disposeBag)
         rootView.chatLogCollectionView.addGestureRecognizer(tapGesture)
     }

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/ChatLog/ViewControllers/CharacterChatLogViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/ChatLog/ViewControllers/CharacterChatLogViewController.swift
@@ -298,19 +298,21 @@ private extension CharacterChatLogViewController {
     
     @objc private func keyboardWillShow(notification: Notification) {
         rootView.layoutIfNeeded()
-        
-        // 키보드가 올라올 때는 두 가지 동작이 필요.
-        // 1. collectionView의 inset을 설정해주어야 함.
-        // 2. collectionView의 스크롤 위치를 끝으로 이동 (채팅하기 버튼은 끝까지 스크롤했을 때에만 보이기 때문)
-        
-        // collectionView의 inset 추가
-        rootView.chatLogCollectionView.contentInset.top = rootView.chatTextInputView.frame.height + 16
-        // collectionView의 contentOffset을 끝으로 이동
-        rootView.chatLogCollectionView.setContentOffset(
-            .init(x: 0, y: -(rootView.chatTextInputView.frame.height + 16)),
-            animated: false
-        )
-        isKeyboardShown = true
+        if let keyboardFrame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect {
+            let keyboardHeight = keyboardFrame.height
+            // 키보드가 올라올 때는 두 가지 동작이 필요.
+            // 1. collectionView의 inset을 설정해주어야 함.
+            // 2. collectionView의 스크롤 위치를 끝으로 이동 (채팅하기 버튼은 끝까지 스크롤했을 때에만 보이기 때문)
+            
+            // collectionView의 inset 추가
+            rootView.chatLogCollectionView.contentInset.top = rootView.chatTextInputView.frame.height + 16 + keyboardHeight
+            // collectionView의 contentOffset을 끝으로 이동
+            rootView.chatLogCollectionView.setContentOffset(
+                .init(x: 0, y: -(rootView.chatTextInputView.frame.height + 16 + keyboardHeight)),
+                animated: false
+            )
+            isKeyboardShown = true
+        }
     }
     
     @objc private func keyboardWillHide(notification: Notification) {

--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/ChatLog/Views/CharacterChatLogView.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/ChatLog/Views/CharacterChatLogView.swift
@@ -35,7 +35,7 @@ class CharacterChatLogView: UIView {
     //MARK: - UI Properties
     
     let backgroundView: UIView
-    let blurShadeView = UIView().then { $0.backgroundColor = .black.withAlphaComponent(0.2) }
+    private let blurShadeView = UIView().then { $0.backgroundColor = .black.withAlphaComponent(0.2) }
     private let blurEffectView = UIVisualEffectView(effect: UIBlurEffect(style: .light))
     private let customNavigationBar = UIView()
     let backButton = UIButton()
@@ -44,7 +44,7 @@ class CharacterChatLogView: UIView {
     lazy var chatLogCollectionView = ScrollLoadingCollectionView(frame: .zero, collectionViewLayout: layout)
     let chatButton = ShrinkableButton(shrinkScale: 0.9)
     let chatTextInputView = ChatTextInputView()
-    
+    let keyboardBackgroundView = UIView()
     
     //MARK: - Life Cycle
     
@@ -113,6 +113,12 @@ private extension CharacterChatLogView {
         
         chatTextInputView.snp.makeConstraints { make in
             make.horizontalEdges.equalToSuperview()
+            make.bottom.equalTo(keyboardLayoutGuide.snp.top)
+        }
+        
+        keyboardBackgroundView.snp.makeConstraints { make in
+            make.top.equalTo(chatTextInputView.snp.bottom)
+            make.horizontalEdges.equalToSuperview()
             make.bottom.equalToSuperview()
         }
     }
@@ -157,6 +163,12 @@ private extension CharacterChatLogView {
             view.layer.shadowRadius = 10
             view.layer.masksToBounds = false   
         }
+        
+        keyboardBackgroundView.do { view in
+            view.backgroundColor = .primary(.white)
+            view.alpha = 0
+            view.isUserInteractionEnabled = false
+        }
     }
     
     func setupHierarchy() {
@@ -167,7 +179,8 @@ private extension CharacterChatLogView {
             customNavigationBar,
             chatLogCollectionView,
             chatButton,
-            chatTextInputView
+            chatTextInputView,
+            keyboardBackgroundView
         )
         customNavigationBar.addSubviews(backButton, customNavigationTitleLabel)
     }


### PR DESCRIPTION
### 🌴 작업한 브랜치
- #527 


### ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->
채팅 입력창의 레이아웃을 조정하였습니다.
기존 채팅 입력창은 textView의 `bottomAnchor`를 직접 `keyboardLayout`의 `topAnchor`과 연결하는 방식으로 레이아웃을 구성했는데요,
이렇게 하니까 키보드가 올라올 때 애니메이션이 적용이 되지 않거나 예상치 못하게 동작하는 경우가 발생하는 것 같았습니다.
또, 키보드가 올라올 때 `keyboardLayout` 대신 notification을 감지해서 조정하고 싶어도 제한사항이 있어서 이를 해결하고자 하였습니다.
수정한 chatInputView를 키보드 등에 연결하는 것은 chatInputView를 사용하는 곳(외부)에서 결정하게 됩니다.
이에 따라 현재 키보드 입력창을 사용하는 두 뷰(뷰컨트롤러)에서 바뀐 레이아웃에 맞게 조정하였습니다.
<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### ❗️PR Point
<!-- 부족했던 점 혹은 개선하고 싶은 방향이 있다면 얘기해주세요 -->

<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->

|뷰|설명|
|:------:|:---:|
|        |     |


- Resolved: #527 
