### PR TITLE
[Fix] #529 - 채팅 말풍선 로딩이 끝나지 않는 문제 해결, 에러 추가

### DIFF
--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/ChatLog/ViewControllers/CharacterChatLogViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/ChatLog/ViewControllers/CharacterChatLogViewController.swift
@@ -10,6 +10,29 @@ import UIKit
 import RxSwift
 import RxCocoa
 
+enum CharacterChatLogError: LocalizedError {
+    case serverError
+    case invalidResponse
+    case invalidChatLogUpdating
+    case networkResultError
+    case decodingError
+    
+    var errorDescription: String? {
+        switch self {
+        case .serverError:
+            return "500대 서버 에러"
+        case .invalidResponse:
+            return "서버의 응답값이 올바른 형식이 아닙니다."
+        case .invalidChatLogUpdating:
+            return "updateChatLog 메서드가 호출된 시점에 chatLogDataList의 요소가 2개 이하면 안됩니다."
+        case .networkResultError:
+            return "네트워크 통신에 문제가 있습니다. `NetworkResult` 의 케이스 중 하나입니다."
+        case .decodingError:
+            return "응답값을 DTO로 변환하는 것을 실패했습니다."
+        }
+    }
+}
+
 class CharacterChatLogViewController: OffroadTabBarViewController {
     
     //MARK: - Properties
@@ -424,92 +447,77 @@ private extension CharacterChatLogViewController {
         let dto = CharacterChatPostRequestDTO(content: message)
         NetworkService.shared.characterChatService.postChat(characterId: characterId, body: dto) { [weak self] result in
             guard let self else { return }
-            switch result {
-            case .success(let dto):
-                guard let data = dto?.data else {
-                    self.showToast(message: "response data is Empty", inset: 66)
-                    return
-                }
-                do {
+            do {
+                switch result {
+                case .success(let dto):
+                    guard let data = dto?.data else {
+                        self.showToast(message: "response data is Empty", inset: 66)
+                        return
+                    }
                     let item = try CharacterChatItem.message(.from(dto: data))
-                    self.updateChatLog(chatSuccess: true, characterResponse: item)
-                } catch {
-                    assertionFailure("ChatDataModel init failed: \(error.localizedDescription)")
+                    switch item {
+                    case .message(let messageItem):
+                        try self.updateChatLog(result: .success(messageItem))
+                    case .loading:
+                        try self.updateChatLog(result: .failure(.invalidResponse))
+                    }
+                case .decodeErr:
+                    self.showToast(message: "decode Error occurred", inset: 66)
+                    try self.updateChatLog(result: .failure(.decodingError))
+                case .serverErr:
+                    self.showToast(message: "오브가 답변하기 힘든 질문이예요.\n다른 이야기를 해볼까요?", inset: 66)
+                    try self.updateChatLog(result: .failure(.networkResultError))
+                case .requestErr:
+                    self.showToast(message: "requestError occurred", inset: 66)
+                    try self.updateChatLog(result: .failure(.networkResultError))
+                case .unAuthentication:
+                    self.showToast(message: "unAuthentication Error occurred", inset: 66)
+                    try self.updateChatLog(result: .failure(.networkResultError))
+                case .unAuthorization:
+                    self.showToast(message: "unAuthorized Error occurred", inset: 66)
+                    try self.updateChatLog(result: .failure(.networkResultError))
+                case .apiArr:
+                    self.showToast(message: "api Error occurred", inset: 66)
+                    try self.updateChatLog(result: .failure(.networkResultError))
+                case .pathErr:
+                    self.showToast(message: "path Error occurred", inset: 66)
+                    try self.updateChatLog(result: .failure(.networkResultError))
+                case .registerErr:
+                    self.showToast(message: "register Error occurred", inset: 66)
+                    try self.updateChatLog(result: .failure(.networkResultError))
+                case .networkFail:
+                    self.showToast(message: ErrorMessages.networkError, inset: 66)
+                    try self.updateChatLog(result: .failure(.networkResultError))
                 }
-                
-            case .requestErr:
-                self.showToast(message: "requestError occurred", inset: 66)
-            case .unAuthentication:
-                self.showToast(message: "unAuthentication Error occurred", inset: 66)
-            case .unAuthorization:
-                self.showToast(message: "unAuthorized Error occurred", inset: 66)
-            case .apiArr:
-                self.showToast(message: "api Error occurred", inset: 66)
-            case .pathErr:
-                self.showToast(message: "path Error occurred", inset: 66)
-            case .registerErr:
-                self.showToast(message: "register Error occurred", inset: 66)
-            case .networkFail:
-                self.showToast(message: ErrorMessages.networkError, inset: 66)
-            case .serverErr:
-                self.showToast(message: "오브가 답변하기 힘든 질문이예요.\n다른 이야기를 해볼까요?", inset: 66)
-                self.updateChatLog(chatSuccess: false)
-            case .decodeErr:
-                self.showToast(message: "decode Error occurred", inset: 66)
+                self.isCharacterResponding.accept(false)
+            } catch {
+                assertionFailure(error.localizedDescription)
             }
-            self.isCharacterResponding.accept(false)
         }
     }
     
-    
-    /// 채팅의 결과가 나왔을 때, 채팅 로그를 업데이트하는 메서드
-    /// - Parameter chatSuccess: 채팅이 성공했는지, 실패했는지 여부
-    /// - Parameter characterResponse: 채팅이 성공했을 경우, 받은 캐릭터의 답장. chatSuccess 가 false인 경우, 이 값은 무시됨.
-    ///
-    /// 채팅이 성공했을 경우, 로딩 중이던 캐릭터의 말풍선이 캐릭터가 답변한 내용으로 변경됨.
-    ///
-    /// 채팅이 실패했을 경우, 로딩 중이던 캐릭터의 말풍선과 직전에 내가 했던 말풍선을 지움.
-    ///
-    /// 지우려는 말풍선의 indexPath를 구할 수 없는 경우, 채팅 로그 뷰컨트롤러를 nagivation stack에서 pop 하며 에러 메시지 토스트 표시
-    private func updateChatLog(chatSuccess: Bool, characterResponse: CharacterChatItem? = nil) {
-        let dataSourceSectionCount = dataSource.snapshot().sectionIdentifiers.count
-        let dataSourceLastSectionItemCount: Int
-        if let lastSection = dataSource.snapshot().sectionIdentifiers.last {
-            dataSourceLastSectionItemCount = dataSource.snapshot().itemIdentifiers(inSection: lastSection).count
-        } else {
-            dataSourceLastSectionItemCount = 0
+    private func updateChatLog(result: Result<CharacterChatMessageItem, CharacterChatLogError>) throws {
+        // 이 메서드는 채팅 시도 후 결과를 업데이트하기 위한 것이므로,
+        // `chatLogDataList`에 최소 2개(사용자가 보낸 채팅 아이템, 캐릭터 로딩 아이템) 이상의 요소가 존재해야 함.
+        guard chatLogDataList.count >= 2 else {
+            throw CharacterChatLogError.invalidChatLogUpdating
         }
-        
-        guard dataSourceSectionCount > 0, dataSourceLastSectionItemCount > 1 else { return }
-        
-        guard
-            rootView.chatLogCollectionView.getIndexPathFromLast(index: 1) != nil,
-            rootView.chatLogCollectionView.getIndexPathFromLast(index: 2) != nil
-        else {
-            showToast(message: "알 수 없는 오류가 발생했어요. 채팅을 다시 시도해 주세요.", inset: 66)
-            rootView.chatLogCollectionView.reloadData()
-            scrollToFirstCell(animated: true)
-            return
-        }
-        
-        if chatSuccess {
-            if let characterResponse, chatLogDataList.count > 0 {
-                chatLogDataList[0] = characterResponse
+        switch result {
+        case .success(let chatItem):
+            guard case .orbCharacter = chatItem else {
+                throw CharacterChatLogError.invalidResponse
             }
-            updateCollectionView(animatingDifferences: true) { [weak self] in
-                guard let self else { return }
-                self.scrollToFirstCell(animated: true)
-                self.patchChatReadRelay.accept(characterId)
-                self.rootView.showChatButton()
-            }
-        } else {
+            chatLogDataList[0] = .message(chatItem)
+        case .failure(let error):
+            assertionFailure(error.localizedDescription)
             chatLogDataList.removeFirst(2)
-            updateCollectionView(animatingDifferences: true) { [weak self] in
-                guard let self else { return }
-                self.scrollToFirstCell(animated: true)
-                self.patchChatReadRelay.accept(characterId)
-                self.rootView.showChatButton()
-            }
+        }
+        
+        updateCollectionView(animatingDifferences: true) { [weak self] in
+            guard let self else { return }
+            self.scrollToFirstCell(animated: true)
+            self.patchChatReadRelay.accept(characterId)
+            self.rootView.showChatButton()
         }
     }
     


### PR DESCRIPTION
### 🌴 작업한 브랜치
- #529 


### ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->
### 채팅 말풍선 로딩이 끝나지 않는 문제를 파악하고 해결하였습니다.
채팅에 성공하면 로그를 업데이트하는 과정에서 의도한 것과 다른 방법으로 guard문이 사용되면서 guard문에서 코드가 조기 종료되는 문제가 발생했습니다.
#### 문제 코드
기존 코드의 475-483번 줄 (`updateChatLog` 메서드 내에서)
``` swift
let dataSourceSectionCount = dataSource.snapshot().sectionIdentifiers.count
let dataSourceLastSectionItemCount: Int
// 여기서 `last`는 가장 오래된 section을 의미.(내림차순 정렬되어있기 때문) 의도한 대로의 코드대로라면 `first`로 적어야 함.
if let lastSection = dataSource.snapshot().sectionIdentifiers.last {
    dataSourceLastSectionItemCount = dataSource.snapshot().itemIdentifiers(inSection: lastSection).count
} else {
    dataSourceLastSectionItemCount = 0
}
// 만약 가장 처음 section(날짜)에서의 채팅이 하나뿐이면 (오브에게 선톡이 오고 답장을 하지 않은 경우) guard문에서 조건을 만족하지 못해 조기 종료됨.
guard dataSourceSectionCount > 0, dataSourceLastSectionItemCount > 1 else { return }
```

이를 해결하기 위해 불필요한 코드를 제거하고, `updateChatLog` 메서드를 전면적으로 개선했습니다.
우선 `updateChatLog` 메서드의 매개변수를 기존의 두 개에서 하나로 수정했고, 대신 매개변수 타입을 Result 타입으로 변경하면서 훨씬 깔끔하고 안전하게 처리할 수 있도록 했습니다.

추가로, 채팅 로그에서 발생할 수 있는 에러들을 정의하여, 디버깅에 용이하도록 개선했습니다.
<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### ❗️PR Point
<!-- 부족했던 점 혹은 개선하고 싶은 방향이 있다면 얘기해주세요 -->

<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->

|뷰|설명|
|:------:|:---:|
|        |     |


- Resolved: #529 
