### PR TITLE
[Feat] #437 - 앱 업데이트 유도 기능 구현

### DIFF
--- a/Offroad-iOS/Offroad-iOS.xcodeproj/project.pbxproj
+++ b/Offroad-iOS/Offroad-iOS.xcodeproj/project.pbxproj
@@ -77,6 +77,9 @@
 		4E46E5FB2CBA3F55000A1EEE /* UIWindowScene+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E46E5FA2CBA3F55000A1EEE /* UIWindowScene+.swift */; };
 		4E46E5FD2CBA483D000A1EEE /* UIViewController+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E46E5FC2CBA483D000A1EEE /* UIViewController+.swift */; };
 		4E4A8FD72C4A5752001FB498 /* UIImage+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E4A8FD62C4A5752001FB498 /* UIImage+.swift */; };
+		4E4D01482DCE0DB9002D9C6A /* MinimumSupportedVersionAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E4D01472DCE0DB9002D9C6A /* MinimumSupportedVersionAPI.swift */; };
+		4E4D014B2DCE0DD6002D9C6A /* MinimumSupportedVersionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E4D014A2DCE0DD6002D9C6A /* MinimumSupportedVersionService.swift */; };
+		4E4D01502DCE371A002D9C6A /* MinimumSupportedVersionResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E4D014E2DCE3719002D9C6A /* MinimumSupportedVersionResponseDTO.swift */; };
 		4E4E2C022CCE2841000A634D /* PlaceInfoTooltip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E4E2C012CCE2841000A634D /* PlaceInfoTooltip.swift */; };
 		4E4E2C0C2CCF6518000A634D /* AdventureMapViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E4E2C0B2CCF6518000A634D /* AdventureMapViewModel.swift */; };
 		4E4F31452D4716F500C3B2FF /* SecretConfig_Dev.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 4E4F31442D4716F500C3B2FF /* SecretConfig_Dev.xcconfig */; };
@@ -736,6 +739,9 @@
 		4E46E5FA2CBA3F55000A1EEE /* UIWindowScene+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIWindowScene+.swift"; sourceTree = "<group>"; };
 		4E46E5FC2CBA483D000A1EEE /* UIViewController+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+.swift"; sourceTree = "<group>"; };
 		4E4A8FD62C4A5752001FB498 /* UIImage+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+.swift"; sourceTree = "<group>"; };
+		4E4D01472DCE0DB9002D9C6A /* MinimumSupportedVersionAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MinimumSupportedVersionAPI.swift; sourceTree = "<group>"; };
+		4E4D014A2DCE0DD6002D9C6A /* MinimumSupportedVersionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MinimumSupportedVersionService.swift; sourceTree = "<group>"; };
+		4E4D014E2DCE3719002D9C6A /* MinimumSupportedVersionResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MinimumSupportedVersionResponseDTO.swift; sourceTree = "<group>"; };
 		4E4E2C012CCE2841000A634D /* PlaceInfoTooltip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaceInfoTooltip.swift; sourceTree = "<group>"; };
 		4E4E2C0B2CCF6518000A634D /* AdventureMapViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdventureMapViewModel.swift; sourceTree = "<group>"; };
 		4E4F31442D4716F500C3B2FF /* SecretConfig_Dev.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = SecretConfig_Dev.xcconfig; sourceTree = "<group>"; };
@@ -1258,6 +1264,7 @@
 			isa = PBXGroup;
 			children = (
 				4E0394672C2AA132007F0517 /* Base */,
+				4E4D01462DCE0D8F002D9C6A /* MinimumSupportedVersion */,
 				D0600BE32CE61DCD00D8F1D6 /* PushNotification */,
 				D004F84E2CA129FC00D5A2CD /* Notice */,
 				4EE0497A2CA0FD1300754488 /* Coupon */,
@@ -1789,6 +1796,24 @@
 				4E416CE72C45DBE200CF6AB4 /* ORBPlaceCategory.swift */,
 			);
 			path = Models;
+			sourceTree = "<group>";
+		};
+		4E4D01462DCE0D8F002D9C6A /* MinimumSupportedVersion */ = {
+			isa = PBXGroup;
+			children = (
+				4E4D014D2DCE36FB002D9C6A /* DTO */,
+				4E4D01472DCE0DB9002D9C6A /* MinimumSupportedVersionAPI.swift */,
+				4E4D014A2DCE0DD6002D9C6A /* MinimumSupportedVersionService.swift */,
+			);
+			path = MinimumSupportedVersion;
+			sourceTree = "<group>";
+		};
+		4E4D014D2DCE36FB002D9C6A /* DTO */ = {
+			isa = PBXGroup;
+			children = (
+				4E4D014E2DCE3719002D9C6A /* MinimumSupportedVersionResponseDTO.swift */,
+			);
+			path = DTO;
 			sourceTree = "<group>";
 		};
 		4E4E2C082CCE7B52000A634D /* PlaceInfoTooltip */ = {
@@ -4091,6 +4116,7 @@
 				4E4F31B12D4718F400C3B2FF /* ShrinkableCollectionViewCell.swift in Sources */,
 				4E4F31B22D4718F400C3B2FF /* ORBAlertBackgroundView.swift in Sources */,
 				4E4F31B32D4718F400C3B2FF /* CouponRedemptionResponseDTO.swift in Sources */,
+				4E4D01502DCE371A002D9C6A /* MinimumSupportedVersionResponseDTO.swift in Sources */,
 				4E4F31B42D4718F400C3B2FF /* AuthAPI.swift in Sources */,
 				4EC611642D5F167300B09E23 /* PlaceListCollectionView.swift in Sources */,
 				D006EA312D6DB3C4004D3D95 /* MyPageScrollView.swift in Sources */,
@@ -4104,6 +4130,7 @@
 				4E4F31BB2D4718F400C3B2FF /* AppleAuthManager.swift in Sources */,
 				4E4F31BC2D4718F400C3B2FF /* UILabel+.swift in Sources */,
 				4E246B352DB4F72300198433 /* ORBRecommendationMainViewController.swift in Sources */,
+				4E4D01482DCE0DB9002D9C6A /* MinimumSupportedVersionAPI.swift in Sources */,
 				D0CA20822D7FE06B00FDF7F4 /* MonthPickerModalView.swift in Sources */,
 				4E4F31BD2D4718F400C3B2FF /* NavigationPopButton.swift in Sources */,
 				4E4F31BE2D4718F400C3B2FF /* EmblemInfoResponseDTO.swift in Sources */,
@@ -4166,6 +4193,7 @@
 				4E4F31EC2D4718F400C3B2FF /* NicknameAPI.swift in Sources */,
 				4E4F31ED2D4718F400C3B2FF /* UIWindow+.swift in Sources */,
 				4E4F31EE2D4718F400C3B2FF /* CharacterListView.swift in Sources */,
+				4E4D014B2DCE0DD6002D9C6A /* MinimumSupportedVersionService.swift in Sources */,
 				4E4F31EF2D4718F400C3B2FF /* ScrollLoadingView.swift in Sources */,
 				4E4F31F02D4718F400C3B2FF /* UITextField+.swift in Sources */,
 				4E4F31F12D4718F400C3B2FF /* DeleteAccountResponseDTO.swift in Sources */,

--- a/Offroad-iOS/Offroad-iOS/Network/Base/NetworkService.swift
+++ b/Offroad-iOS/Offroad-iOS/Network/Base/NetworkService.swift
@@ -28,5 +28,6 @@ final class NetworkService {
     #if DevTarget
     let diarySettingService: DiarySettingServiceProtocol = DiarySettingService()
     let diaryService: DiaryServiceProtocol = DiaryService()
+    let minimumSupportedVersionService = MinimumSupportedVersionService()
     #endif
 }

--- a/Offroad-iOS/Offroad-iOS/Network/MinimumSupportedVersion/DTO/MinimumSupportedVersionResponseDTO.swift
+++ b/Offroad-iOS/Offroad-iOS/Network/MinimumSupportedVersion/DTO/MinimumSupportedVersionResponseDTO.swift
@@ -1,0 +1,13 @@
+//
+//  MinimumSupportedVersionResponseDTO.swift
+//  Offroad-iOS
+//
+//  Created by 김민성 on 5/9/25.
+//
+
+import Foundation
+
+struct MinimumSupportedVersionResponseDTO: Decodable {
+    let ios: String
+    let android: String
+}

--- a/Offroad-iOS/Offroad-iOS/Network/MinimumSupportedVersion/DTO/MinimumSupportedVersionResponseDTO.swift
+++ b/Offroad-iOS/Offroad-iOS/Network/MinimumSupportedVersion/DTO/MinimumSupportedVersionResponseDTO.swift
@@ -9,5 +9,6 @@ import Foundation
 
 struct MinimumSupportedVersionResponseDTO: Decodable {
     let ios: String
+    // JSON에는 포함되나, android 최소 지원 버전 값은 사용하지 않음.
     let android: String
 }

--- a/Offroad-iOS/Offroad-iOS/Network/MinimumSupportedVersion/MinimumSupportedVersionAPI.swift
+++ b/Offroad-iOS/Offroad-iOS/Network/MinimumSupportedVersion/MinimumSupportedVersionAPI.swift
@@ -1,0 +1,22 @@
+//
+//  MinimumSupportedVersionAPI.swift
+//  Offroad-iOS
+//
+//  Created by 김민성 on 5/9/25.
+//
+
+import Foundation
+
+import Moya
+
+
+enum MinimumSupportedVersionAPI {
+    case getMinimumSupportedVersion
+}
+
+extension MinimumSupportedVersionAPI: BaseTargetType {
+    var headerType: HeaderType { .noneHeader }
+    var path: String { "/app/min-supported-version" }
+    var method: Moya.Method { .get }
+    var task: Moya.Task { .requestPlain }
+}

--- a/Offroad-iOS/Offroad-iOS/Network/MinimumSupportedVersion/MinimumSupportedVersionService.swift
+++ b/Offroad-iOS/Offroad-iOS/Network/MinimumSupportedVersion/MinimumSupportedVersionService.swift
@@ -1,0 +1,38 @@
+//
+//  MinimumSupportedVersionService.swift
+//  Offroad-iOS
+//
+//  Created by 김민성 on 5/9/25.
+//
+
+import Foundation
+
+import Moya
+
+final class MinimumSupportedVersionService: BaseService {
+    private let provider = MoyaProvider<MinimumSupportedVersionAPI>.init(
+        session: Session(interceptor: TokenInterceptor.shared),
+        plugins: [MoyaPlugin()]
+    )
+    
+    func getMinimumSupportedVersion() async -> NetworkResult<MinimumSupportedVersionResponseDTO> {
+        await withCheckedContinuation { continuation in
+            provider.request(.getMinimumSupportedVersion, completion: { [weak self] result in
+                guard let self else { return }
+                switch result {
+                case .success(let response):
+                    let networkResult: NetworkResult<MinimumSupportedVersionResponseDTO> = self.fetchNetworkResult(
+                        statusCode: response.statusCode,
+                        data: response.data
+                    )
+                    continuation.resume(returning: networkResult)
+                case .failure(let error):
+                    print(error.localizedDescription)
+                    if case .underlying(_, let response) = error, response == nil {
+                        continuation.resume(returning: .networkFail())
+                    }
+                }
+            })
+        }
+    }
+}

--- a/Offroad-iOS/Offroad-iOS/Presentation/Splash/ViewController/SplashViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Splash/ViewController/SplashViewController.swift
@@ -45,7 +45,7 @@ final class SplashViewController: UIViewController {
                     self?.processToLogIn()
                 }
             } catch {
-                print(error.localizedDescription)
+                assertionFailure(error.localizedDescription)
             }
         }
 #else

--- a/Offroad-iOS/Offroad-iOS/Presentation/Splash/ViewController/SplashViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Splash/ViewController/SplashViewController.swift
@@ -34,11 +34,23 @@ final class SplashViewController: UIViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         
-        if ((UserDefaults.standard.string(forKey: "isLoggedIn")?.isEmpty) != nil) && KeychainManager.shared.loadAccessToken() != nil {
-            checkUserChoosingInfo()
-        } else {
-            presentViewController(viewController: LoginViewController())
+#if DevTarget
+        Task { [weak self] in
+            do {
+                guard let currentAppVersion = try self?.checkCurrentAppVersion() else { return }
+                guard let minimumVersion = try await self?.checkMinimumSupportedVersion() else { return }
+                if currentAppVersion < minimumVersion {
+                    self?.requestUserToUpdateApp()
+                } else {
+                    self?.processToLogIn()
+                }
+            } catch {
+                print(error.localizedDescription)
+            }
         }
+#else
+        processToLogIn()
+#endif
     }
 }
 
@@ -84,4 +96,102 @@ extension SplashViewController {
         }
     }
     
+    @MainActor
+    private func processToLogIn() {
+        if ((UserDefaults.standard.string(forKey: "isLoggedIn")?.isEmpty) != nil
+            && KeychainManager.shared.loadAccessToken() != nil) {
+            checkUserChoosingInfo()
+        } else {
+            presentViewController(viewController: LoginViewController())
+        }
+    }
+    
 }
+
+#if DevTarget
+// 앱 버전 체크(강제 업데이트 유도) 관련
+private extension SplashViewController {
+    
+    enum AppVersionCheckError: LocalizedError {
+        case infoPlistNotFound
+        case versionNotFound
+        case dtoNotFound
+        case dtoDecodingFailed
+        case minimumSupportedVersionNotFound
+        case networkFail
+        
+        var errorDescription: String? {
+            switch self {
+            case .infoPlistNotFound: "Info.plist 확인 불가"
+            case .versionNotFound: "버전 번호 확인 불가"
+            case .dtoNotFound: "DTO 확인 불가. 응답값에서 데이터를 포함하지 않았을 가능성이 높습니다."
+            case .dtoDecodingFailed: "DTO 디코딩 실패. MinimumSupportedVersionResponseDTO의 데이터 형식을 확인하세요."
+            case .minimumSupportedVersionNotFound: "최소 지원 버전 확인 불가"
+            case .networkFail: "네트워크 통신 문제로 인해 최소 지원 버전 확인 불가"
+            }
+        }
+    }
+    
+    // 현재 설치된 앱의 버전 확인
+    func checkCurrentAppVersion() throws -> String {
+        guard let infoPlist = Bundle.main.infoDictionary else {
+            throw AppVersionCheckError.infoPlistNotFound
+        }
+        guard let version = infoPlist["CFBundleShortVersionString"] as? String else {
+            throw AppVersionCheckError.versionNotFound
+        }
+        return version
+    }
+    
+    // 서버에서 최소 지원 버전 확인
+    func checkMinimumSupportedVersion() async throws -> String {
+        let networkService = NetworkService.shared.minimumSupportedVersionService
+        let networkResult = await networkService.getMinimumSupportedVersion()
+        switch networkResult {
+        case .success(let dto):
+            guard let dto else { throw AppVersionCheckError.dtoNotFound }
+            return dto.ios
+        case .networkFail:
+            ORBToastManager.shared.showToast(message: ErrorMessages.networkError, inset: 0)
+            throw AppVersionCheckError.networkFail
+        case .decodeErr:
+            ORBToastManager.shared.showToast(message: "알 수 없는 문제가 발생했어요. 잠시 후 다시 시도해 주세요.", inset: 0)
+            throw AppVersionCheckError.dtoDecodingFailed
+        default:
+            ORBToastManager.shared.showToast(message: "알 수 없는 문제가 발생했어요. 잠시 후 다시 시도해 주세요.", inset: 0)
+            throw AppVersionCheckError.minimumSupportedVersionNotFound
+        }
+    }
+    
+    @MainActor
+    func requestUserToUpdateApp() {
+        let alertController = ORBAlertController(message: "원활한 기능 사용을 위해 최신 버전으로 앱을 업데이트해 주세요.", type: .messageOnly)
+        alertController.xButton.isHidden = true
+        let action = ORBAlertAction(title: "앱스토어로 이동", style: .default) { [weak self] _ in
+            self?.redirectToAppStore()
+        }
+        alertController.addAction(action)
+        present(alertController, animated: true)
+    }
+    
+    func redirectToAppStore() {
+        let urlString = "itms-apps://itunes.apple.com/app/id6541756824"
+        if let url = URL(string: urlString), UIApplication.shared.canOpenURL(url) {
+            UIApplication.shared.open(url)
+        } else {
+            // 앱 설치가 불가능한 경우 사용자에게 안내.
+            // 설정 앱>스크린 타임>콘텐츠 및 개인 정보 보호 제한>iTunes 및 App Store 구입 -> '허용 안 함' 인 경우
+            alertIfAppStoreRedirectionFailed()
+        }
+    }
+    
+    func alertIfAppStoreRedirectionFailed() {
+        let alertController = ORBAlertController(message: "앱스토어를 열 수 없습니다. 다시 시도해 주세요.", type: .normal)
+        alertController.xButton.isHidden = true
+        let action = ORBAlertAction(title: "확인", style: .default) { _ in return }
+        alertController.addAction(action)
+        present(alertController, animated: true)
+    }
+    
+}
+#endif


### PR DESCRIPTION
### 🌴 작업한 브랜치
- #437 


### ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->
### 앱 강제 업데이트 기능을 구현했습니다.
오브에서 정한 최소 지원 버전보다 앱의 버전이 낮을 경우 앱스토어로 이동하여 앱을 업데이트하도록 유도하는 기능을 구현했습니다.
`SplashViewController`에서 구현했으며,
현재 버전이 최소 지원 버전보다 낮을 경우 앱스토어로 리다이렉션하는 팝업을 띄우고 로그인을 진행하지 않습니다.
현재 버전이 최소 지원 버전 이상인 경우 사용자에게 별다른 안내 없이 로그인을 진행합니다.
- 코드를 깔끔하게 적기 위해 기존 `SplashViewController`의 `viewDidAppear` 메서드 안에서 구현되어있는 로그인 로직을 `processToLogIn()` 이라는 메서드로 감쌌습니다.
- `SplashViewController`에서 앱 버전을 체크하고 업데이트를 유도하는 메서드들만을 별도 `extension` 으로 감싸서 관리하였습니다.

* 현재 최소 지원 버전 정보을 요청하는 서버 API는 은 개발 서버에서만 동작하므로, 개발용 앱에서만 동작하도록 구현되어있습니다. 참고 바랍니다.

### `Swift Concurrency` 를 도입하였습니다.
최소 지원 버전을 서버에 요청하는 코드를 구현하면서 `async/await` 를 적용해 보았습니다.
우리 팀에 `Swift Concurrency`를 도입한 적이 없어서 많이 낯설 수도 있을 것 같아, 최소한의 기능으로만 구현해 보았습니다. 아마 조금만 검색하시거나 `chatGPT` 등에 물어보시기만 해도 코드를 읽는데 큰 어려움은 없을 것이라 생각합니다. 그럼에도 불구하고 모르거나 헷갈리는 점이 있으면 물어봐 주세요! 저도 아직 공부중이라 같이 알아나가면 좋을 것 같습니다.
추후 여유로울 때 간단한 비동기 로직 등에 `async/await` 를 도입할 예정입니다. (위치 권한 여부를 체크할 때 등..)
<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### ❗️PR Point
<!-- 부족했던 점 혹은 개선하고 싶은 방향이 있다면 얘기해주세요 -->

<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->

|뷰|설명|
|:------:|:---:|
|        |     |


- Resolved: #437 
