### PR TITLE
[Fix] #538 - 다른 기기에서 회원 탈퇴한 경우, 스플래시 화면에서 다음으로 진행되지 않는 문제 해결

### DIFF
--- a/Offroad-iOS/Offroad-iOS/Presentation/Login/AuthManager/TokenIntercepter.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Login/AuthManager/TokenIntercepter.swift
@@ -56,7 +56,7 @@ final class TokenInterceptor: RequestInterceptor {
                 AppUtility.changeRootViewController(to: loginViewController)
                 
             /// 다른 기기에서 로그인 후 회원을 탈퇴하면 현재 갖고 있는 `refreshToken`에 해당하는 계정이 사라지면서
-            /// `HTTP` 상태 코드로 `401`이 아니라 `404`이 반환됨. 이에 대한 분기처리
+            /// `HTTP` 상태 코드로 `401`이 아니라 `404`가 반환됨. 이에 대한 분기처리
             /// 응답값: `{"message":"해당 ID의 유저가 존재하지 않습니다.","customErrorCode":"NOT_EXISTS_MEMBER"}`
             case .apiArr(let dto):
                 AppUtility.changeRootViewController(to: LoginViewController())

--- a/Offroad-iOS/Offroad-iOS/Presentation/Login/AuthManager/TokenIntercepter.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Login/AuthManager/TokenIntercepter.swift
@@ -54,6 +54,12 @@ final class TokenInterceptor: RequestInterceptor {
             case .unAuthentication:
                 let loginViewController = LoginViewController()
                 AppUtility.changeRootViewController(to: loginViewController)
+                
+            /// 다른 기기에서 로그인 후 회원을 탈퇴하면 현재 갖고 있는 `refreshToken`에 해당하는 계정이 사라지면서
+            /// `HTTP` 상태 코드로 `401`이 아니라 `404`이 반환됨. 이에 대한 분기처리
+            /// 응답값: `{"message":"해당 ID의 유저가 존재하지 않습니다.","customErrorCode":"NOT_EXISTS_MEMBER"}`
+            case .apiArr(let dto):
+                AppUtility.changeRootViewController(to: LoginViewController())
             default:
                 completion(.doNotRetry)
             }


### PR DESCRIPTION
### 🌴 작업한 브랜치
- #538 


### ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->

여러 대의 기기에서 로그인했을 때, 그 중 한 기기에서 회원 탈퇴를 진행하면 다른 앱에서 로그인이 진행되지 않는 문제가 발견되었습니다.
다른 기기에서 로그인 후 회원을 탈퇴하면 탈퇴한 기기가 아닌 다른 기기에는 여전히 `refreshToken` 값이 남아있는데요,
서버의 DB에는 이 `refreshToken`에 해당하는 계정이 사라지면서
`HTTP` 상태 코드로 `401`이 아니라 `404`가 반환됩니다. 

> 응답값: `{"message":"해당 ID의 유저가 존재하지 않습니다.","customErrorCode":"NOT_EXISTS_MEMBER"}`

현재 `TokenInterceptor`에는 401(`Unauthorized`)에 대한 대응은 되어있으나, 404일때의 분기처리가 되어있지 않아서 스플래시 화면에서 앱이 더 이상 진행하지 않고 멈춰있는 것처럼 보입니다.
HTTP 상태 코드로 404가 반환될 경우 401에서와 마찬가지로 로그인 화면으로 이동하도록 유도하였습니다.


<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### ❗️PR Point
<!-- 부족했던 점 혹은 개선하고 싶은 방향이 있다면 얘기해주세요 -->

<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->

|뷰|설명|
|:------:|:---:|
|        |     |


- Resolved: #538 
