### PR TITLE
[Del] #547 - 홈 화면 캐릭터 채팅 박스에서 그라데이션 효과 삭제

### DIFF
--- a/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/Views/ORBCharacterChatBox.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Chat/CharacterChat/Views/ORBCharacterChatBox.swift
@@ -65,10 +65,6 @@ class ORBCharacterChatBox: UIControl, Shrinkable {
     
 }
 
-#if DevTarget
-extension ORBCharacterChatBox: ORBRecommendationGradientStyle { }
-#endif
-
 extension ORBCharacterChatBox {
     
     //MARK: - Layout Func
@@ -259,14 +255,6 @@ extension ORBCharacterChatBox {
         modeChangingAnimator.stopAnimation(true)
         self.mode = mode
         chevronImageButton.isHidden = (mode == .loading)
-#if DevTarget
-        if mode == .withReplyButtonExpanded || mode == .withoutReplyButtonExpanded  {
-            applyGradientStyle()
-        } else {
-            removeGradientStyle()
-        }
-#endif
-        
         if animated {
             modeChangingAnimator.addAnimations { [weak self] in
                 guard let self else { return }


### PR DESCRIPTION
### 🌴 작업한 브랜치
- #547 


### ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->
### 홈 화면에서 채팅할 때 캐릭터의 채팅 응답 상자를 확장하면 그라데이션이 적용되는 기능을 제거하였습니다.
### ❗️수정 내용은 개발용 앱에 한정됩니다.
채팅 박스를 확장하면 오브의 그라데이션이 적용되는 것은 과거 오브의 그라데이션을 구현할 때 테스트용으로 넣어둔 기능인데,
이를 삭제하는 것을 깜박하고 있다가 최근에 이를 발견하여 관련 코드들을 삭제하였습니다.

<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### ❗️PR Point
<!-- 부족했던 점 혹은 개선하고 싶은 방향이 있다면 얘기해주세요 -->

<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->

|before|after|
|:------:|:---:|
|  <img src="https://github.com/user-attachments/assets/b7a0d2a4-f4cf-4d54-b5f1-7b24942a6033" width=300> | <img src="https://github.com/user-attachments/assets/41ba57e9-b4fc-44d1-bcc2-95c25e1b781d" width=300>  |


- Resolved: #547 
