### PR TITLE
[Chore] #542 - 앱 강제 업데이트 문구 변경, 동작 개선

### DIFF
--- a/Offroad-iOS/Offroad-iOS/Global/Literals/StringLiterals.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Literals/StringLiterals.swift
@@ -13,6 +13,7 @@ struct ErrorMessages {
     static let birthDateError = "다시 한 번 확인해주세요."
     static let getCharacterListFailure = "캐릭터 목록을 불러오는 데 실패하였습니다."
     static let accessingLocationDataFailure = "위치 정보를 가져오는 데 실패했습니다."
+    static let appStoreRedirectionFailure = "앱스토어를 열 수 없어요.\n앱 설치 가능 여부를 확인해 주세요"
 }
 
 struct AlertMessage {
@@ -46,6 +47,8 @@ struct AlertMessage {
         "\(selectedTimePeriod == .am ? "오전" : "오후") \(selectedTime)시"
     }
     static let orbRecommendationOrderUnsavedExitMessage = "주문 내용이 저장되지 않아요.\n작성을 멈추고 나가시겠어요?"
+    static let enforceAppUpdateTitle = "업데이트 안내"
+    static let enforceAppUpdateMessage = "오브의 공간에 변화가 생겼어요!\n앱을 최신 버전으로 업데이트 해주세요."
 }
 
 struct LoadingMessage {

--- a/Offroad-iOS/Offroad-iOS/Network/MinimumSupportedVersion/MinimumSupportedVersionService.swift
+++ b/Offroad-iOS/Offroad-iOS/Network/MinimumSupportedVersion/MinimumSupportedVersionService.swift
@@ -10,10 +10,7 @@ import Foundation
 import Moya
 
 final class MinimumSupportedVersionService: BaseService {
-    private let provider = MoyaProvider<MinimumSupportedVersionAPI>.init(
-        session: Session(interceptor: TokenInterceptor.shared),
-        plugins: [MoyaPlugin()]
-    )
+    private let provider = MoyaProvider<MinimumSupportedVersionAPI>.init(plugins: [MoyaPlugin()])
     
     func getMinimumSupportedVersion() async -> NetworkResult<MinimumSupportedVersionResponseDTO> {
         await withCheckedContinuation { continuation in

--- a/Offroad-iOS/Offroad-iOS/Network/MinimumSupportedVersion/MinimumSupportedVersionService.swift
+++ b/Offroad-iOS/Offroad-iOS/Network/MinimumSupportedVersion/MinimumSupportedVersionService.swift
@@ -12,8 +12,8 @@ import Moya
 final class MinimumSupportedVersionService: BaseService {
     private let provider = MoyaProvider<MinimumSupportedVersionAPI>.init(plugins: [MoyaPlugin()])
     
-    func getMinimumSupportedVersion() async -> NetworkResult<MinimumSupportedVersionResponseDTO> {
-        await withCheckedContinuation { continuation in
+    func getMinimumSupportedVersion() async throws -> NetworkResult<MinimumSupportedVersionResponseDTO> {
+        try await withCheckedThrowingContinuation { continuation in
             provider.request(.getMinimumSupportedVersion, completion: { [weak self] result in
                 guard let self else { return }
                 switch result {
@@ -27,6 +27,8 @@ final class MinimumSupportedVersionService: BaseService {
                     print(error.localizedDescription)
                     if case .underlying(_, let response) = error, response == nil {
                         continuation.resume(returning: .networkFail())
+                    } else {
+                        continuation.resume(throwing: error)
                     }
                 }
             })

--- a/Offroad-iOS/Offroad-iOS/Presentation/Splash/ViewController/SplashViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Splash/ViewController/SplashViewController.swift
@@ -39,7 +39,7 @@ final class SplashViewController: UIViewController {
             do {
                 guard let currentAppVersion = try self?.checkCurrentAppVersion() else { return }
                 guard let minimumVersion = try await self?.checkMinimumSupportedVersion() else { return }
-                if currentAppVersion < minimumVersion {
+                if currentAppVersion > minimumVersion {
                     self?.requestUserToUpdateApp()
                 } else {
                     self?.processToLogIn()
@@ -169,9 +169,13 @@ private extension SplashViewController {
     
     @MainActor
     func requestUserToUpdateApp() {
-        let alertController = ORBAlertController(message: "원활한 기능 사용을 위해 최신 버전으로 앱을 업데이트해 주세요.", type: .messageOnly)
+        let alertController = ORBAlertController(
+            title: AlertMessage.enforceAppUpdateTitle,
+            message: AlertMessage.enforceAppUpdateMessage,
+            type: .normal
+        )
         alertController.xButton.isHidden = true
-        let action = ORBAlertAction(title: "앱스토어로 이동", style: .default) { [weak self] _ in
+        let action = ORBAlertAction(title: "업데이트하기", style: .default) { [weak self] _ in
             self?.redirectToAppStore()
         }
         alertController.addAction(action)
@@ -190,7 +194,10 @@ private extension SplashViewController {
     }
     
     func alertIfAppStoreRedirectionFailed() {
-        let alertController = ORBAlertController(message: "앱스토어를 열 수 없습니다. 다시 시도해 주세요.", type: .normal)
+        let alertController = ORBAlertController(
+            message: ErrorMessages.appStoreRedirectionFailure,
+            type: .normal
+        )
         alertController.xButton.isHidden = true
         let action = ORBAlertAction(title: "확인", style: .default) { _ in return }
         alertController.addAction(action)

--- a/Offroad-iOS/Offroad-iOS/Presentation/Splash/ViewController/SplashViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/Splash/ViewController/SplashViewController.swift
@@ -145,21 +145,25 @@ private extension SplashViewController {
     
     // 서버에서 최소 지원 버전 확인
     func checkMinimumSupportedVersion() async throws -> String {
-        let networkService = NetworkService.shared.minimumSupportedVersionService
-        let networkResult = await networkService.getMinimumSupportedVersion()
-        switch networkResult {
-        case .success(let dto):
-            guard let dto else { throw AppVersionCheckError.dtoNotFound }
-            return dto.ios
-        case .networkFail:
-            ORBToastManager.shared.showToast(message: ErrorMessages.networkError, inset: 0)
-            throw AppVersionCheckError.networkFail
-        case .decodeErr:
-            ORBToastManager.shared.showToast(message: "알 수 없는 문제가 발생했어요. 잠시 후 다시 시도해 주세요.", inset: 0)
-            throw AppVersionCheckError.dtoDecodingFailed
-        default:
-            ORBToastManager.shared.showToast(message: "알 수 없는 문제가 발생했어요. 잠시 후 다시 시도해 주세요.", inset: 0)
-            throw AppVersionCheckError.minimumSupportedVersionNotFound
+        do {
+            let networkService = NetworkService.shared.minimumSupportedVersionService
+            let networkResult = try await networkService.getMinimumSupportedVersion()
+            switch networkResult {
+            case .success(let dto):
+                guard let dto else { throw AppVersionCheckError.dtoNotFound }
+                return dto.ios
+            case .networkFail:
+                ORBToastManager.shared.showToast(message: ErrorMessages.networkError, inset: 0)
+                throw AppVersionCheckError.networkFail
+            case .decodeErr:
+                ORBToastManager.shared.showToast(message: "알 수 없는 문제가 발생했어요. 잠시 후 다시 시도해 주세요.", inset: 0)
+                throw AppVersionCheckError.dtoDecodingFailed
+            default:
+                ORBToastManager.shared.showToast(message: "알 수 없는 문제가 발생했어요. 잠시 후 다시 시도해 주세요.", inset: 0)
+                throw AppVersionCheckError.minimumSupportedVersionNotFound
+            }
+        } catch {
+            throw error
         }
     }
     


### PR DESCRIPTION
### 🌴 작업한 브랜치
- #542 


### ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->
### 1. 앱의 현재 최소 지원 버전을 서버에 요청할 때 사용되는 Moya provider에서 session 코드를 삭제하였습니다.
이 provider는 token을 사용하지 않으므로 `TokenInterceptor`를 사용할 필요가 없습니다.
(오히려 `TokenInterceptor`를 사용할 경우, `TokenInterceptor`에서 예외 처리로 인해 바로 로그인 화면을 띄우는 부작용이 발생합니다.)

### 2. 앱의 최소 지원 버전을 서버에 요청하는 `MinimumSupportedVersionService` 클래스의 `getMinimumSupportedVersion()` 메서드에서 에러 처리를 개선하였습니다.
`async` 메서드에서 `continuation`을 사용할 때, 함수의 모든 반환/실패 경로에서 `continutaion.resume`  메서드를 호출해야 합니다.
코드에서 `continuation.resume` 이 누락되는 경우가 발견되어 추가하였으며, 이때 에러를 `throw` 해야 하므로, `getMinimumSupportedVersion()` 메서드를 정의할 때 에러를 던지는 함수로 변경하였습니다.

``` swift
final class MinimumSupportedVersionService: BaseService {
    private let provider = MoyaProvider<MinimumSupportedVersionAPI>.init(plugins: [MoyaPlugin()])
    
    // 이 메서드를 에러를 throw 하는 함수로 변경하였습니다.
    func getMinimumSupportedVersion() async throws -> NetworkResult<MinimumSupportedVersionResponseDTO> {
        // `try` 키워드를 추가하였습니다.
        try await withCheckedThrowingContinuation { continuation in
            provider.request(.getMinimumSupportedVersion, completion: { [weak self] result in
                guard let self else { return }
                switch result {
                case .success(let response):
                    let networkResult: NetworkResult<MinimumSupportedVersionResponseDTO> = self.fetchNetworkResult(
                        statusCode: response.statusCode,
                        data: response.data
                    )
                    continuation.resume(returning: networkResult)
                case .failure(let error):
                    print(error.localizedDescription)
                    if case .underlying(_, let response) = error, response == nil {
                        continuation.resume(returning: .networkFail())
                    } else {
                        // 누락된 반환/에러던짐 케이스를 추가하였습니다.
                        continuation.resume(throwing: error)
                    }
                }
            })
        }
    }
}
```

### 3. 강제 업데이트 문구를 수정하였습니다.
기획에서 전달받은 문구를 `StringLiterals.swift` 파일에 이를 추가하였으며, 앱 업데이트 유도 팝업 문구에 이를 적용하였습니다.

<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### ❗️PR Point
<!-- 부족했던 점 혹은 개선하고 싶은 방향이 있다면 얘기해주세요 -->

<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->

|업데이트 필요 시 문구|앱스토어 진입 불가능 시 문구|
|:------:|:---:|
|   <img src="https://github.com/user-attachments/assets/e63f88fd-eee8-4724-b51e-1d54ad37a979" width=300>   |  <img src="https://github.com/user-attachments/assets/db175ba7-f429-408b-b06a-e132ff3fa556" width=300>   |


- Resolved: #542 
