### PR TITLE
[Fix] #554 - 장소 목록 뷰의 각 세그먼트가 반대로 표시되는 문제 해결

### DIFF
--- a/Offroad-iOS/Offroad-iOS/Presentation/PlaceList/Views/PlaceListView.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/PlaceList/Views/PlaceListView.swift
@@ -105,7 +105,7 @@ extension PlaceListView {
             scrollView
         )
         
-        scrollView.addSubviews(viewAllPlaces, viewUnvisitedPlaces)
+        scrollView.addSubviews(viewUnvisitedPlaces, viewAllPlaces)
     }
     
     private func setupLayout() {
@@ -148,15 +148,15 @@ extension PlaceListView {
             make.bottom.equalToSuperview()
         }
         
-        viewAllPlaces.snp.makeConstraints { make in
+        viewUnvisitedPlaces.snp.makeConstraints { make in
             make.verticalEdges.equalTo(scrollView.frameLayoutGuide)
             make.leading.equalTo(scrollView.contentLayoutGuide)
             make.width.equalTo(UIScreen.currentScreenSize.width)
         }
         
-        viewUnvisitedPlaces.snp.makeConstraints { make in
+        viewAllPlaces.snp.makeConstraints { make in
             make.verticalEdges.equalTo(scrollView.frameLayoutGuide)
-            make.leading.equalTo(viewAllPlaces.snp.trailing)
+            make.leading.equalTo(viewUnvisitedPlaces.snp.trailing)
             make.trailing.equalTo(scrollView.contentLayoutGuide)
             make.width.equalTo(UIScreen.currentScreenSize.width)
         }


### PR DESCRIPTION
### 🌴 작업한 브랜치
- #554 


### ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->
장소 목록 뷰의 각 세그먼트가 반대로 표시되는 문제를 해결하였습니다.
<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### ❗️PR Point
<!-- 부족했던 점 혹은 개선하고 싶은 방향이 있다면 얘기해주세요 -->

<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->

| 문제 상황 | 수정 후 |
|:------:|:---:|
|    <img src="https://github.com/user-attachments/assets/634ee335-2408-4fc6-be20-a1900e444bf0" width=250>    |   <img src="https://github.com/user-attachments/assets/e612e6eb-532d-4192-b8c2-4229950ec049" width=250>  |


- Resolved: #이슈번호
