### PR TITLE
[Chore] #550 - 자잘한 코드 개선

### DIFF
--- a/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/LogPrinter/PrintLogInDevApp.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Components/Overlay/LogPrinter/PrintLogInDevApp.swift
@@ -5,10 +5,13 @@
 //  Created by 김민성 on 2/1/25.
 //
 
-/*
- 개발용 앱에 한하여 원하는 문구를 앱 내에 띄워줄 수 있습니다.
- */
+/// 원하는 문구를 개발용 앱 내의 로그 콘솔에 띄우는 동작.
+/// - Parameter log: 개발용 앱의 콘솔에 표시할 로그 문구
+///
+/// Xcode의 콘솔에 print하는 동작도 포함합니다. (Xcode 콘솔에 띄우기 위해 추가로 print 호출할 필요 없음.)
+/// 배포용 앱에서는 print 문과 완전히 같은 동작입니다.
 func printLog(_ log: String) {
+    print(log)
     #if DevTarget
     LogPrinterManager.shared.printLog(log)
     #else

--- a/Offroad-iOS/Offroad-iOS/Network/Base/NetworkResultError.swift
+++ b/Offroad-iOS/Offroad-iOS/Network/Base/NetworkResultError.swift
@@ -16,7 +16,7 @@ enum NetworkResultError: LocalizedError {
     case httpError(statusCode: Int)
     
     /// 응답값이 정해진 DTO로 디코딩되지 않음.
-    case decodingFailed
+    case decodingFailed(any Decodable.Type)
     
     //===----------------------------------------------------------------------===//
     // 여기부터 URLError
@@ -56,8 +56,8 @@ enum NetworkResultError: LocalizedError {
             case 502: return "502(Bad Gateway)"
             default: return "코드에서 명시되지 않은 기타 HTTP 응답 상태 에러. 상태 코드: \(statusCode)"
             }
-        case .decodingFailed:
-            return "서버의 응답값(Body)을 지정한 DTO로 디코딩하는 데에 실패했습니다. 서버의 응답값 형식 또는 DTO를 확인하세요."
+        case .decodingFailed(let dtoType):
+            return "서버의 응답값(Body)을 지정한 DTO로 디코딩하는 데에 실패했습니다. DTO타입: \(dtoType). 서버의 응답값 형식 또는 DTO를 확인하세요."
         case .timeout:
             return "네트워크 타임아웃."
         case .notConnectedToInternet:

--- a/Offroad-iOS/Offroad-iOS/Network/Base/NetworkResultHandler.swift
+++ b/Offroad-iOS/Offroad-iOS/Network/Base/NetworkResultHandler.swift
@@ -29,7 +29,7 @@ struct NetworkResultHandler {
         
         // 지정된 DTO 형식으로 디코딩.
         guard let decodedDTO = try? JSONDecoder().decode(T.self, from: response.data) else {
-            throw NetworkResultError.decodingFailed
+            throw NetworkResultError.decodingFailed(T.self)
         }
         
         return decodedDTO


### PR DESCRIPTION
### 🌴 작업한 브랜치
- #550 


### ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->
자잘한 변경점들입니다.
- 개발용 Target의 로그 콘솔을 띄우는 전역 함수 printLog에서 `print()` 도 같이 출력하도록 했습니다ㅏ.
- NetworkResultError 중 decodingFailed의 에러 메시지를 출력할 때, 디코딩이 실패한 DTO 타입도 같이 출력하도록 했습니다.
<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### ❗️PR Point
<!-- 부족했던 점 혹은 개선하고 싶은 방향이 있다면 얘기해주세요 -->

<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->

|뷰|설명|
|:------:|:---:|
|        |     |


- Resolved: #550 
