### PR TITLE
[Feat] #546 - 오브의 추천소 채팅 및 추천 장소 업데이트 기능 구현

### DIFF
--- a/Offroad-iOS/Offroad-iOS.xcodeproj/project.pbxproj
+++ b/Offroad-iOS/Offroad-iOS.xcodeproj/project.pbxproj
@@ -40,7 +40,7 @@
 		4E0A6BE02DF740E600956D7F /* AdventureResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E0A6BDE2DF740E600956D7F /* AdventureResult.swift */; };
 		4E0C69692C4724A100B6453E /* PlaceMapMarker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E0C69682C4724A100B6453E /* PlaceMapMarker.swift */; };
 		4E101D112DF4529C00BE62B0 /* ORBRecommendationChatResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E101D0F2DF4529C00BE62B0 /* ORBRecommendationChatResponseDTO.swift */; };
-		4E101D142DF453CE00BE62B0 /* ORBRecommendationResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E101D122DF453CE00BE62B0 /* ORBRecommendationResponseDTO.swift */; };
+		4E101D142DF453CE00BE62B0 /* ORBRecommendationPlacesResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E101D122DF453CE00BE62B0 /* ORBRecommendationPlacesResponseDTO.swift */; };
 		4E101D172DF473A500BE62B0 /* ORBRecommendationAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E101D162DF473A500BE62B0 /* ORBRecommendationAPI.swift */; };
 		4E101D1C2DF4759B00BE62B0 /* ORBRecommendationChatRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E101D1B2DF4759B00BE62B0 /* ORBRecommendationChatRequestDTO.swift */; };
 		4E101D1E2DF475F200BE62B0 /* ORBRecommendationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E101D1D2DF475F200BE62B0 /* ORBRecommendationService.swift */; };
@@ -730,7 +730,7 @@
 		4E0A6BDE2DF740E600956D7F /* AdventureResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdventureResult.swift; sourceTree = "<group>"; };
 		4E0C69682C4724A100B6453E /* PlaceMapMarker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaceMapMarker.swift; sourceTree = "<group>"; };
 		4E101D0F2DF4529C00BE62B0 /* ORBRecommendationChatResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ORBRecommendationChatResponseDTO.swift; sourceTree = "<group>"; };
-		4E101D122DF453CE00BE62B0 /* ORBRecommendationResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ORBRecommendationResponseDTO.swift; sourceTree = "<group>"; };
+		4E101D122DF453CE00BE62B0 /* ORBRecommendationPlacesResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ORBRecommendationPlacesResponseDTO.swift; sourceTree = "<group>"; };
 		4E101D162DF473A500BE62B0 /* ORBRecommendationAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ORBRecommendationAPI.swift; sourceTree = "<group>"; };
 		4E101D1B2DF4759B00BE62B0 /* ORBRecommendationChatRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ORBRecommendationChatRequestDTO.swift; sourceTree = "<group>"; };
 		4E101D1D2DF475F200BE62B0 /* ORBRecommendationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ORBRecommendationService.swift; sourceTree = "<group>"; };
@@ -1680,7 +1680,7 @@
 			isa = PBXGroup;
 			children = (
 				4E101D0F2DF4529C00BE62B0 /* ORBRecommendationChatResponseDTO.swift */,
-				4E101D122DF453CE00BE62B0 /* ORBRecommendationResponseDTO.swift */,
+				4E101D122DF453CE00BE62B0 /* ORBRecommendationPlacesResponseDTO.swift */,
 			);
 			path = Response;
 			sourceTree = "<group>";
@@ -4246,7 +4246,7 @@
 				4E4F320E2D4718F400C3B2FF /* MyPageView.swift in Sources */,
 				4E4F320F2D4718F400C3B2FF /* CustomerInquiryView.swift in Sources */,
 				4E4F32102D4718F400C3B2FF /* CollectedTitleModel.swift in Sources */,
-				4E101D142DF453CE00BE62B0 /* ORBRecommendationResponseDTO.swift in Sources */,
+				4E101D142DF453CE00BE62B0 /* ORBRecommendationPlacesResponseDTO.swift in Sources */,
 				4E4F32112D4718F400C3B2FF /* HomeViewController.swift in Sources */,
 				D0CA20872D8018FA00FDF7F4 /* MyDiaryManager.swift in Sources */,
 				4E101D172DF473A500BE62B0 /* ORBRecommendationAPI.swift in Sources */,

--- a/Offroad-iOS/Offroad-iOS.xcodeproj/project.pbxproj
+++ b/Offroad-iOS/Offroad-iOS.xcodeproj/project.pbxproj
@@ -84,6 +84,7 @@
 		4E43C7412DFEAAD200CED213 /* CharacterChatMessageItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E43C73F2DFEAAD200CED213 /* CharacterChatMessageItem.swift */; };
 		4E43C7C02E01B08A00CED213 /* PlaceProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E43C7BF2E01B08A00CED213 /* PlaceProtocols.swift */; };
 		4E43C7C12E01B08A00CED213 /* PlaceProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E43C7BF2E01B08A00CED213 /* PlaceProtocols.swift */; };
+		4E43C8012E04542D00CED213 /* ORBRecommendationFixedPhraseResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E43C8002E04542D00CED213 /* ORBRecommendationFixedPhraseResponseDTO.swift */; };
 		4E456CC02CF4003D0011B50F /* UICollectionView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E456CBF2CF4003D0011B50F /* UICollectionView+.swift */; };
 		4E46E5F72CB997B4000A1EEE /* ORBToastManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E46E5F62CB997B4000A1EEE /* ORBToastManager.swift */; };
 		4E46E5F92CB99944000A1EEE /* ORBToastWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E46E5F82CB99944000A1EEE /* ORBToastWindow.swift */; };
@@ -767,6 +768,7 @@
 		4E43C7392DFE8F5B00CED213 /* RecommendationButtonInChatLogCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecommendationButtonInChatLogCell.swift; sourceTree = "<group>"; };
 		4E43C73F2DFEAAD200CED213 /* CharacterChatMessageItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CharacterChatMessageItem.swift; sourceTree = "<group>"; };
 		4E43C7BF2E01B08A00CED213 /* PlaceProtocols.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaceProtocols.swift; sourceTree = "<group>"; };
+		4E43C8002E04542D00CED213 /* ORBRecommendationFixedPhraseResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ORBRecommendationFixedPhraseResponseDTO.swift; sourceTree = "<group>"; };
 		4E456CBF2CF4003D0011B50F /* UICollectionView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UICollectionView+.swift"; sourceTree = "<group>"; };
 		4E46E5F62CB997B4000A1EEE /* ORBToastManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ORBToastManager.swift; sourceTree = "<group>"; };
 		4E46E5F82CB99944000A1EEE /* ORBToastWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ORBToastWindow.swift; sourceTree = "<group>"; };
@@ -1679,6 +1681,7 @@
 		4E101D1A2DF4751B00BE62B0 /* Response */ = {
 			isa = PBXGroup;
 			children = (
+				4E43C8002E04542D00CED213 /* ORBRecommendationFixedPhraseResponseDTO.swift */,
 				4E101D0F2DF4529C00BE62B0 /* ORBRecommendationChatResponseDTO.swift */,
 				4E101D122DF453CE00BE62B0 /* ORBRecommendationPlacesResponseDTO.swift */,
 			);
@@ -4148,6 +4151,7 @@
 				4E4F31C42D4718F400C3B2FF /* QuestListView.swift in Sources */,
 				4E4F31C52D4718F400C3B2FF /* PushNotificationRedirectModel.swift in Sources */,
 				4E59AFB22DB148C7000A5EAD /* ChatLogCellCharacter.swift in Sources */,
+				4E43C8012E04542D00CED213 /* ORBRecommendationFixedPhraseResponseDTO.swift in Sources */,
 				4E4F31C62D4718F400C3B2FF /* NetworkResult.swift in Sources */,
 				4E4F31C72D4718F400C3B2FF /* UIView+.swift in Sources */,
 				4E4F31C82D4718F400C3B2FF /* MarketingConsentViewController.swift in Sources */,

--- a/Offroad-iOS/Offroad-iOS.xcodeproj/project.pbxproj
+++ b/Offroad-iOS/Offroad-iOS.xcodeproj/project.pbxproj
@@ -36,6 +36,12 @@
 		4E0A404E2DC7A4F400A0680C /* ORBRecommendationChatViewPresentingTransition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E0A404D2DC7A4F400A0680C /* ORBRecommendationChatViewPresentingTransition.swift */; };
 		4E0A40502DC7A51100A0680C /* ORBRecommendationChatViewDismissingTransition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E0A404F2DC7A51100A0680C /* ORBRecommendationChatViewDismissingTransition.swift */; };
 		4E0A40522DC7A70000A0680C /* ORBRecommendationChatPresentationFloatingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E0A40512DC7A70000A0680C /* ORBRecommendationChatPresentationFloatingView.swift */; };
+		4E101D112DF4529C00BE62B0 /* ORBRecommendationChatResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E101D0F2DF4529C00BE62B0 /* ORBRecommendationChatResponseDTO.swift */; };
+		4E101D142DF453CE00BE62B0 /* ORBRecommendationResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E101D122DF453CE00BE62B0 /* ORBRecommendationResponseDTO.swift */; };
+		4E101D172DF473A500BE62B0 /* ORBRecommendationAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E101D162DF473A500BE62B0 /* ORBRecommendationAPI.swift */; };
+		4E101D1C2DF4759B00BE62B0 /* ORBRecommendationChatRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E101D1B2DF4759B00BE62B0 /* ORBRecommendationChatRequestDTO.swift */; };
+		4E101D1E2DF475F200BE62B0 /* ORBRecommendationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E101D1D2DF475F200BE62B0 /* ORBRecommendationService.swift */; };
+		4E101D212DF4847900BE62B0 /* ORBRecommendationPlaceModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E101D202DF4847900BE62B0 /* ORBRecommendationPlaceModel.swift */; };
 		4E0A6BDF2DF740E600956D7F /* AdventureResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E0A6BDE2DF740E600956D7F /* AdventureResult.swift */; };
 		4E0A6BE02DF740E600956D7F /* AdventureResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E0A6BDE2DF740E600956D7F /* AdventureResult.swift */; };
 		4E0C69692C4724A100B6453E /* PlaceMapMarker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E0C69682C4724A100B6453E /* PlaceMapMarker.swift */; };
@@ -721,6 +727,12 @@
 		4E0A40512DC7A70000A0680C /* ORBRecommendationChatPresentationFloatingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ORBRecommendationChatPresentationFloatingView.swift; sourceTree = "<group>"; };
 		4E0A6BDE2DF740E600956D7F /* AdventureResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdventureResult.swift; sourceTree = "<group>"; };
 		4E0C69682C4724A100B6453E /* PlaceMapMarker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaceMapMarker.swift; sourceTree = "<group>"; };
+		4E101D0F2DF4529C00BE62B0 /* ORBRecommendationChatResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ORBRecommendationChatResponseDTO.swift; sourceTree = "<group>"; };
+		4E101D122DF453CE00BE62B0 /* ORBRecommendationResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ORBRecommendationResponseDTO.swift; sourceTree = "<group>"; };
+		4E101D162DF473A500BE62B0 /* ORBRecommendationAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ORBRecommendationAPI.swift; sourceTree = "<group>"; };
+		4E101D1B2DF4759B00BE62B0 /* ORBRecommendationChatRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ORBRecommendationChatRequestDTO.swift; sourceTree = "<group>"; };
+		4E101D1D2DF475F200BE62B0 /* ORBRecommendationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ORBRecommendationService.swift; sourceTree = "<group>"; };
+		4E101D202DF4847900BE62B0 /* ORBRecommendationPlaceModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ORBRecommendationPlaceModel.swift; sourceTree = "<group>"; };
 		4E1CFDEE2D4E5CB70067344B /* PrintLogInDevApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrintLogInDevApp.swift; sourceTree = "<group>"; };
 		4E1E94102C39870700A7B08A /* ColorLiterals.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorLiterals.swift; sourceTree = "<group>"; };
 		4E1E94122C398C4200A7B08A /* String+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+.swift"; sourceTree = "<group>"; };
@@ -1308,6 +1320,7 @@
 				4E3A32662CE510B6007228D0 /* CharacterChat */,
 				D07D3A852D8DAC0F0030995E /* DiarySetting */,
 				D07D3AD52D9074920030995E /* Diary */,
+				4E101D0E2DF4507D00BE62B0 /* ORBRecommendation */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -1632,6 +1645,50 @@
 			path = Model;
 			sourceTree = "<group>";
 		};
+		4E101D0D2DF4507D00BE62B0 /* DTO */ = {
+			isa = PBXGroup;
+			children = (
+				4E101D192DF4751500BE62B0 /* Request */,
+				4E101D1A2DF4751B00BE62B0 /* Response */,
+			);
+			path = DTO;
+			sourceTree = "<group>";
+		};
+		4E101D0E2DF4507D00BE62B0 /* ORBRecommendation */ = {
+			isa = PBXGroup;
+			children = (
+				4E101D0D2DF4507D00BE62B0 /* DTO */,
+				4E101D162DF473A500BE62B0 /* ORBRecommendationAPI.swift */,
+				4E101D1D2DF475F200BE62B0 /* ORBRecommendationService.swift */,
+			);
+			path = ORBRecommendation;
+			sourceTree = "<group>";
+		};
+		4E101D192DF4751500BE62B0 /* Request */ = {
+			isa = PBXGroup;
+			children = (
+				4E101D1B2DF4759B00BE62B0 /* ORBRecommendationChatRequestDTO.swift */,
+			);
+			path = Request;
+			sourceTree = "<group>";
+		};
+		4E101D1A2DF4751B00BE62B0 /* Response */ = {
+			isa = PBXGroup;
+			children = (
+				4E101D0F2DF4529C00BE62B0 /* ORBRecommendationChatResponseDTO.swift */,
+				4E101D122DF453CE00BE62B0 /* ORBRecommendationResponseDTO.swift */,
+			);
+			path = Response;
+			sourceTree = "<group>";
+		};
+		4E101D1F2DF4846600BE62B0 /* model */ = {
+			isa = PBXGroup;
+			children = (
+				4E101D202DF4847900BE62B0 /* ORBRecommendationPlaceModel.swift */,
+			);
+			path = model;
+			sourceTree = "<group>";
+		};
 		4E1E94142C3AC25000A7B08A /* ViewControllers */ = {
 			isa = PBXGroup;
 			children = (
@@ -1668,6 +1725,7 @@
 		4E2DE9D12DB49C7000DCE641 /* ORBRecommendation */ = {
 			isa = PBXGroup;
 			children = (
+				4E101D1F2DF4846600BE62B0 /* model */,
 				4EEF6E8E2DC36842008C1E96 /* order */,
 				4E87847F2DC4FD0300B639EA /* chat */,
 				4E2DE9D22DB49CC000DCE641 /* main */,
@@ -3973,6 +4031,7 @@
 				4E4F317B2D4718F400C3B2FF /* AdventuresQRAuthenticationResponseDTO.swift in Sources */,
 				D07D3AE62D9106050030995E /* DiaryResponseDTO.swift in Sources */,
 				4E9759F22DA013B300F30692 /* DeveloperModeView.swift in Sources */,
+				4E101D1E2DF475F200BE62B0 /* ORBRecommendationService.swift in Sources */,
 				4EEB47DA2DAEA3150025AAA2 /* ORBRecommendationGradientStyle.swift in Sources */,
 				4E4F317C2D4718F400C3B2FF /* QuestListResponseDTO.swift in Sources */,
 				4E4F317D2D4718F400C3B2FF /* CustomIntensityBlurView.swift in Sources */,
@@ -4126,6 +4185,7 @@
 				D05B70D52D63286800A1E206 /* DiaryTimeViewController.swift in Sources */,
 				4E2A9C592DA5525900D8E6D1 /* ORBMapView.swift in Sources */,
 				4E4F31E62D4718F400C3B2FF /* NetworkMonitoringManager.swift in Sources */,
+				4E101D212DF4847900BE62B0 /* ORBRecommendationPlaceModel.swift in Sources */,
 				4E4F31E72D4718F400C3B2FF /* ShareableImageProvider.swift in Sources */,
 				4E4F31E82D4718F400C3B2FF /* CharacterAPI.swift in Sources */,
 				4E4F31E92D4718F400C3B2FF /* MyInfoManager.swift in Sources */,
@@ -4152,6 +4212,7 @@
 				4E4F31F92D4718F400C3B2FF /* AdventureService.swift in Sources */,
 				4E4F31FA2D4718F400C3B2FF /* ORBSegmentedControl.swift in Sources */,
 				4E4F31FB2D4718F400C3B2FF /* UICollectionView+.swift in Sources */,
+				4E101D112DF4529C00BE62B0 /* ORBRecommendationChatResponseDTO.swift in Sources */,
 				4E4F31FC2D4718F400C3B2FF /* BirthViewController.swift in Sources */,
 				4E4F31FD2D4718F400C3B2FF /* ORBAlertViewTextFieldWithSubMessage.swift in Sources */,
 				4E4F31FE2D4718F400C3B2FF /* LoadingView.swift in Sources */,
@@ -4169,6 +4230,7 @@
 				4E4F32082D4718F400C3B2FF /* CouponListViewController.swift in Sources */,
 				4ED6BE3D2D7B3C000020C871 /* AmplitudeManager.swift in Sources */,
 				4E4F32092D4718F400C3B2FF /* CharacterChatPostResponseDTO.swift in Sources */,
+				4E101D1C2DF4759B00BE62B0 /* ORBRecommendationChatRequestDTO.swift in Sources */,
 				4E9759E12D9F9A6C00F30692 /* QuestListCollectionView.swift in Sources */,
 				D09A196F2D70589900B07FC2 /* TimePeriod.swift in Sources */,
 				4E4F320A2D4718F400C3B2FF /* UIImage+.swift in Sources */,
@@ -4178,8 +4240,10 @@
 				4E4F320E2D4718F400C3B2FF /* MyPageView.swift in Sources */,
 				4E4F320F2D4718F400C3B2FF /* CustomerInquiryView.swift in Sources */,
 				4E4F32102D4718F400C3B2FF /* CollectedTitleModel.swift in Sources */,
+				4E101D142DF453CE00BE62B0 /* ORBRecommendationResponseDTO.swift in Sources */,
 				4E4F32112D4718F400C3B2FF /* HomeViewController.swift in Sources */,
 				D0CA20872D8018FA00FDF7F4 /* MyDiaryManager.swift in Sources */,
+				4E101D172DF473A500BE62B0 /* ORBRecommendationAPI.swift in Sources */,
 				4E4F32122D4718F400C3B2FF /* ORBAlertViewCouponRedemptionFailure.swift in Sources */,
 				4E4F32132D4718F400C3B2FF /* ChangeEmblemResponseDTO.swift in Sources */,
 				4E4F32142D4718F400C3B2FF /* PlaceMapMarker.swift in Sources */,

--- a/Offroad-iOS/Offroad-iOS.xcodeproj/project.pbxproj
+++ b/Offroad-iOS/Offroad-iOS.xcodeproj/project.pbxproj
@@ -36,15 +36,15 @@
 		4E0A404E2DC7A4F400A0680C /* ORBRecommendationChatViewPresentingTransition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E0A404D2DC7A4F400A0680C /* ORBRecommendationChatViewPresentingTransition.swift */; };
 		4E0A40502DC7A51100A0680C /* ORBRecommendationChatViewDismissingTransition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E0A404F2DC7A51100A0680C /* ORBRecommendationChatViewDismissingTransition.swift */; };
 		4E0A40522DC7A70000A0680C /* ORBRecommendationChatPresentationFloatingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E0A40512DC7A70000A0680C /* ORBRecommendationChatPresentationFloatingView.swift */; };
+		4E0A6BDF2DF740E600956D7F /* AdventureResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E0A6BDE2DF740E600956D7F /* AdventureResult.swift */; };
+		4E0A6BE02DF740E600956D7F /* AdventureResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E0A6BDE2DF740E600956D7F /* AdventureResult.swift */; };
+		4E0C69692C4724A100B6453E /* PlaceMapMarker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E0C69682C4724A100B6453E /* PlaceMapMarker.swift */; };
 		4E101D112DF4529C00BE62B0 /* ORBRecommendationChatResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E101D0F2DF4529C00BE62B0 /* ORBRecommendationChatResponseDTO.swift */; };
 		4E101D142DF453CE00BE62B0 /* ORBRecommendationResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E101D122DF453CE00BE62B0 /* ORBRecommendationResponseDTO.swift */; };
 		4E101D172DF473A500BE62B0 /* ORBRecommendationAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E101D162DF473A500BE62B0 /* ORBRecommendationAPI.swift */; };
 		4E101D1C2DF4759B00BE62B0 /* ORBRecommendationChatRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E101D1B2DF4759B00BE62B0 /* ORBRecommendationChatRequestDTO.swift */; };
 		4E101D1E2DF475F200BE62B0 /* ORBRecommendationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E101D1D2DF475F200BE62B0 /* ORBRecommendationService.swift */; };
 		4E101D212DF4847900BE62B0 /* ORBRecommendationPlaceModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E101D202DF4847900BE62B0 /* ORBRecommendationPlaceModel.swift */; };
-		4E0A6BDF2DF740E600956D7F /* AdventureResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E0A6BDE2DF740E600956D7F /* AdventureResult.swift */; };
-		4E0A6BE02DF740E600956D7F /* AdventureResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E0A6BDE2DF740E600956D7F /* AdventureResult.swift */; };
-		4E0C69692C4724A100B6453E /* PlaceMapMarker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E0C69682C4724A100B6453E /* PlaceMapMarker.swift */; };
 		4E1CFDEF2D4E5CB70067344B /* PrintLogInDevApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E1CFDEE2D4E5CB70067344B /* PrintLogInDevApp.swift */; };
 		4E1CFDF02D4E5CB70067344B /* PrintLogInDevApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E1CFDEE2D4E5CB70067344B /* PrintLogInDevApp.swift */; };
 		4E1E94112C39870700A7B08A /* ColorLiterals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E1E94102C39870700A7B08A /* ColorLiterals.swift */; };
@@ -82,6 +82,8 @@
 		4E43C73A2DFE8F5B00CED213 /* RecommendationButtonInChatLogCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E43C7392DFE8F5B00CED213 /* RecommendationButtonInChatLogCell.swift */; };
 		4E43C7402DFEAAD200CED213 /* CharacterChatMessageItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E43C73F2DFEAAD200CED213 /* CharacterChatMessageItem.swift */; };
 		4E43C7412DFEAAD200CED213 /* CharacterChatMessageItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E43C73F2DFEAAD200CED213 /* CharacterChatMessageItem.swift */; };
+		4E43C7C02E01B08A00CED213 /* PlaceProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E43C7BF2E01B08A00CED213 /* PlaceProtocols.swift */; };
+		4E43C7C12E01B08A00CED213 /* PlaceProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E43C7BF2E01B08A00CED213 /* PlaceProtocols.swift */; };
 		4E456CC02CF4003D0011B50F /* UICollectionView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E456CBF2CF4003D0011B50F /* UICollectionView+.swift */; };
 		4E46E5F72CB997B4000A1EEE /* ORBToastManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E46E5F62CB997B4000A1EEE /* ORBToastManager.swift */; };
 		4E46E5F92CB99944000A1EEE /* ORBToastWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E46E5F82CB99944000A1EEE /* ORBToastWindow.swift */; };
@@ -764,6 +766,7 @@
 		4E43C7362DFDDCA900CED213 /* ChatLogCellCharacterRecommendation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatLogCellCharacterRecommendation.swift; sourceTree = "<group>"; };
 		4E43C7392DFE8F5B00CED213 /* RecommendationButtonInChatLogCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecommendationButtonInChatLogCell.swift; sourceTree = "<group>"; };
 		4E43C73F2DFEAAD200CED213 /* CharacterChatMessageItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CharacterChatMessageItem.swift; sourceTree = "<group>"; };
+		4E43C7BF2E01B08A00CED213 /* PlaceProtocols.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaceProtocols.swift; sourceTree = "<group>"; };
 		4E456CBF2CF4003D0011B50F /* UICollectionView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UICollectionView+.swift"; sourceTree = "<group>"; };
 		4E46E5F62CB997B4000A1EEE /* ORBToastManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ORBToastManager.swift; sourceTree = "<group>"; };
 		4E46E5F82CB99944000A1EEE /* ORBToastWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ORBToastWindow.swift; sourceTree = "<group>"; };
@@ -1286,6 +1289,7 @@
 				4ECD026F2D9D722C00830534 /* ORBScrollLoadingStyle.swift */,
 				4ECD02722D9D725700830534 /* ORBCenterLoadingStyle.swift */,
 				4E9759D12D9F975600F30692 /* ORBEmptyCaseStyle.swift */,
+				4E43C7BF2E01B08A00CED213 /* PlaceProtocols.swift */,
 			);
 			path = Protocols;
 			sourceTree = "<group>";
@@ -3844,6 +3848,7 @@
 				D0E796202C4532A6005B47A5 /* ErrorResponseDTO.swift in Sources */,
 				4ECD02742D9D725700830534 /* ORBCenterLoadingStyle.swift in Sources */,
 				D0E796332C453615005B47A5 /* NicknameCheckResponseDTO.swift in Sources */,
+				4E43C7C12E01B08A00CED213 /* PlaceProtocols.swift in Sources */,
 				D0EAF21F2C3B02B700566543 /* SplashView.swift in Sources */,
 				4EFCDFE12C92BD93006DEBB6 /* ORBAlertType.swift in Sources */,
 				4E99007E2CDBCD46007EEFF7 /* ORBCharacterChatManager.swift in Sources */,
@@ -4201,6 +4206,7 @@
 				4E4F31F12D4718F400C3B2FF /* DeleteAccountResponseDTO.swift in Sources */,
 				4E4F31F22D4718F400C3B2FF /* CharacterChatLogFooter.swift in Sources */,
 				4E4F31F32D4718F400C3B2FF /* ORBAlertViewTextField.swift in Sources */,
+				4E43C7C02E01B08A00CED213 /* PlaceProtocols.swift in Sources */,
 				4E8785282DC79B2B00B639EA /* ORBRecommendationChatViewController.swift in Sources */,
 				4E4F31F42D4718F400C3B2FF /* HomeView.swift in Sources */,
 				4E4D00FA2DCB42DC002D9C6A /* ORBRecommendationChatExampleQuestion.swift in Sources */,

--- a/Offroad-iOS/Offroad-iOS/Global/Components/ORBMap/ORBMapView.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Components/ORBMap/ORBMapView.swift
@@ -335,6 +335,43 @@ extension ORBMapView {
         }
     }
     
+    /// 여러 장소의 좌표를 받아 이 장소들을 모두 비추도록 지도의 카메라를 이동하는 함수.
+    /// - Parameters:
+    ///   - placesToShow: 지도에 보여질 장소들의 좌표.
+    ///   - padding: 카메라가 변경된 후 영역과 지도 화면 간 확보할 최소 여백. pt 단위.
+    ///   - animationCurve: 지도가 움직일 때의 애니메이션 종류. NMFCameraUpdateAnimation 타입.
+    ///   - animationDuration: 애니메이션 시간. 0으로 설정할 경우, 애니메이션 없이 바로 이동. 기본값은 NAVER Map iOS SDK에서 설정하는 0.2
+    ///   - reason: 카메라 이동에 사용될 `NMFCameraUpdate` 타입의 `reason` 속성에 할당할 값. 기본값은 `NMFMapChangedByDeveloper`이며, -1에 해당. (개발자가 API를 호출해 카메라가 움직였음을 의미)
+    ///   - completion: 카메라 이동이 완료되었을 때 호출되는 콜백 블록. 애니메이션이 있으면 완전히 끝난 후에 호출됩니다. `Bool` 타입의 매개변수는 카메라 이동이 완료되기 전에 다른 카메라 이동이 호출되거나 사용자가 제스처로 지도를 조작한 경우 `true`입니다.
+    ///
+    ///  - Note: 빈 배열이 전달될 경우, 오류가 나며 앱이 꺼질 수 있으므로, 빈 배열이 전달될 시, 기본 장소 값으로 광화문 광장을 설정하였습니다.
+    ///  기본 장소 값은 추후 변경될 수 있음.
+    public func moveCamera(
+        placesToShow coordinates: [NMGLatLng],
+        padding: CGFloat = 0,
+        animationCurve: NMFCameraUpdateAnimation = .easeOut,
+        // NAVER Map iOS SDK에서 지정하는 기본값이 0.2
+        animationDuration: TimeInterval = 0.2,
+        reason: Int32 = Int32(NMFMapChangedByDeveloper),
+        completion: ((Bool) -> Void)? = nil
+    ) {
+        // 빈 배열이 전달될 경우 기본 위치(광화문 광장)으로 이동.
+        guard !coordinates.isEmpty else {
+            /// 광화문광장 (37.5716229, 126.9767879)
+            let gwanghwamunSquare = NMGLatLng(lat: 37.5716229, lng: 126.9767879)
+            moveCamera(scrollTo: gwanghwamunSquare)
+            return
+        }
+        let bounds = NMGLatLngBounds(latLngs: coordinates)
+        let cameraUpdate = NMFCameraUpdate(fit: bounds, padding: padding)
+        cameraUpdate.reason = reason
+        cameraUpdate.animation = animationCurve
+        cameraUpdate.animationDuration = animationDuration
+        mapView.moveCamera(cameraUpdate) { isCancelled in
+            completion?(isCancelled)
+        }
+    }
+    
 }
 
 //MARK: - NMFMapViewCameraDelegate

--- a/Offroad-iOS/Offroad-iOS/Global/Components/ORBMap/ORBMapView.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Components/ORBMap/ORBMapView.swift
@@ -49,7 +49,7 @@ final class ORBMapView: NMFNaverMapView {
     
     private let locationManager = CLLocationManager()
     
-    /// 툴팁이 떠 있을 때 툴팁 아래의 배경을 터치할 수 있는지 여부. 기본값은 `true`
+    /// 툴팁이 떠 있을 때 지도 배경 터치를 막을지 여부. 기본값은 `true`
     var shouldBlockBackgroundTouch: Bool = true
     
     /// 툴팁이 떠 있을 때 지도가 움직이면 툴팁이 닫힐 지 여부. 기본값은 `true`
@@ -110,6 +110,7 @@ final class ORBMapView: NMFNaverMapView {
 extension ORBMapView {
     
     private func setupStyle() {
+        clipsToBounds = true
         shadingView.isUserInteractionEnabled = false
         tooltip.isHidden = true
     }

--- a/Offroad-iOS/Offroad-iOS/Global/Components/ORBMap/ORBMapView.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Components/ORBMap/ORBMapView.swift
@@ -337,7 +337,7 @@ extension ORBMapView {
     
     /// 여러 장소의 좌표를 받아 이 장소들을 모두 비추도록 지도의 카메라를 이동하는 함수.
     /// - Parameters:
-    ///   - placesToShow: 지도에 보여질 장소들의 좌표.
+    ///   - coordinates: 지도에 보여질 장소들의 좌표.
     ///   - padding: 카메라가 변경된 후 영역과 지도 화면 간 확보할 최소 여백. pt 단위.
     ///   - animationCurve: 지도가 움직일 때의 애니메이션 종류. NMFCameraUpdateAnimation 타입.
     ///   - animationDuration: 애니메이션 시간. 0으로 설정할 경우, 애니메이션 없이 바로 이동. 기본값은 NAVER Map iOS SDK에서 설정하는 0.2

--- a/Offroad-iOS/Offroad-iOS/Global/Components/ORBMap/ORBMapView.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Components/ORBMap/ORBMapView.swift
@@ -79,7 +79,7 @@ final class ORBMapView: NMFNaverMapView {
     // MARK: - Rx Properties
     
     private var disposeBag = DisposeBag()
-    let exploreButtonTapped = PublishRelay<PlaceModel>()
+    let exploreButtonTapped = PublishRelay<any PlaceDescribable>()
     let onMapViewCameraIdle = PublishRelay<Void>()
     let tooltipWillShow = PublishRelay<Void>()
     let tooltipDidShow = PublishRelay<Void>()

--- a/Offroad-iOS/Offroad-iOS/Global/Components/ORBMap/PlaceInfoTooltip/PlaceInfoTooltip.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Components/ORBMap/PlaceInfoTooltip/PlaceInfoTooltip.swift
@@ -50,12 +50,21 @@ final class PlaceInfoTooltip: UIView {
             }()
             placeCategoryImageView.image = categoryImage
             
-            if marker?.place is PlaceModel {
+            // 툴팁 하단의 버튼에 보일 문구 설정.
+            guard let marker else {
+                exploreButton.setTitle("알 수 없음", for: .normal)
+                return
+            }
+            
+            if marker.place is PlaceModel {
                 exploreButton.setTitle("탐험하기", for: .normal)
-            } else if marker?.place is ORBRecommendationPlaceModel {
+            } else if marker.place is ORBRecommendationPlaceModel {
                 exploreButton.setTitle("지도 열기", for: .normal)
             } else {
-                exploreButton.setTitle("", for: .normal)
+                exploreButton.setTitle("알 수 없음", for: .normal)
+                assertionFailure(
+                    "잘못된 장소 모델 타입이 사용되었습니다: \(type(of:marker.place))\nPlaceModel 혹은 ORBRecommendationPlaceModel 타입만 사용 가능합니다."
+                )
             }
         }
     }

--- a/Offroad-iOS/Offroad-iOS/Global/Components/ORBMap/PlaceInfoTooltip/PlaceInfoTooltip.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Components/ORBMap/PlaceInfoTooltip/PlaceInfoTooltip.swift
@@ -49,6 +49,14 @@ final class PlaceInfoTooltip: UIView {
                 }
             }()
             placeCategoryImageView.image = categoryImage
+            
+            if marker?.place is PlaceModel {
+                exploreButton.setTitle("탐험하기", for: .normal)
+            } else if marker?.place is ORBRecommendationPlaceModel {
+                exploreButton.setTitle("지도 열기", for: .normal)
+            } else {
+                exploreButton.setTitle("", for: .normal)
+            }
         }
     }
     
@@ -186,7 +194,6 @@ extension PlaceInfoTooltip  {
         }
         
         exploreButton.do { button in
-            button.setTitle("탐험하기", for: .normal)
             button.setTitleColor(.primary(.white), for: .normal)
             button.configureBackgroundColorWhen(normal: .sub(.sub4),
                                                 highlighted: .sub(.sub480),

--- a/Offroad-iOS/Offroad-iOS/Global/Protocols/PlaceProtocols.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Protocols/PlaceProtocols.swift
@@ -1,0 +1,46 @@
+//
+//  PlaceProtocols.swift
+//  Offroad-iOS
+//
+//  Created by 김민성 on 6/17/25.
+//
+//  장소를 나타내는 데이터 모델의 인터페이스.
+
+import CoreLocation
+
+/// '장소'를 나타내는 데이터가 필수로 가져야 하는 속성들을 포함하는 타입.
+protocol BasePlaceType {
+    
+    /// 장소 이름
+    var name: String { get }
+    
+    /// 장소의 주소
+    var address: String { get }
+    
+    /// 장소의 카테고리. `ORBPlaceCategory` 타입
+    var placeCategory: ORBPlaceCategory { get }
+    
+    /// 장소의 위•경도 좌표
+    var coordinate: CLLocationCoordinate2D { get }
+    
+}
+
+/// 장소에 대해 설명하기 위한 추가적인 정보를 갖는 타입.
+///
+/// 장소 목록 셀, 툴팁 등에서 장소에 대한 정보를 표시할 때 사용
+protocol PlaceDescribable: BasePlaceType {
+    
+    /// 장소 한 줄 소개
+    var shortIntroduction: String { get }
+    
+    /// 장소 구역(시간이 머무는 마을 등)
+    var placeArea: String { get }
+    
+    /// 방문 횟수
+    var visitCount: Int { get }
+    
+    /// 카테고리 이미지의 URL
+    /// - Note: 현재는 사용하지 않음. (이미지 리소스를 바로 사용)
+    var categoryImageUrl: URL { get }
+    
+}

--- a/Offroad-iOS/Offroad-iOS/Network/Adventure/DTO/Response/AdventuresPlaceAuthenticationResponsetDTO.swift
+++ b/Offroad-iOS/Offroad-iOS/Network/Adventure/DTO/Response/AdventuresPlaceAuthenticationResponsetDTO.swift
@@ -28,7 +28,7 @@ extension AdventuresPlaceAuthenticationResultData: SVGFetchable {
     /// `AdventuresPlaceAuthenticationResultData` 타입을 `AdventureModel` 타입으로 변환
     /// - Parameter place: 탐험을 시도한 장소
     /// - Returns: 변환된 `AdventureModel` 인스턴스
-    func asAdventureResult(at place: PlaceModel) async throws -> AdventureResult {
+    func asAdventureResult(at place: some PlaceDescribable) async throws -> AdventureResult {
         let resultImage = try await fetchSVG(svgURLString: self.successCharacterImageUrl)
         let adventureResult: AdventureResult = .init(
             place: place,

--- a/Offroad-iOS/Offroad-iOS/Network/Base/NetworkService.swift
+++ b/Offroad-iOS/Offroad-iOS/Network/Base/NetworkService.swift
@@ -30,5 +30,6 @@ final class NetworkService {
     #if DevTarget
     let diarySettingService: DiarySettingServiceProtocol = DiarySettingService()
     let diaryService: DiaryServiceProtocol = DiaryService()
+    let orbRecommendationService = ORBRecommendationService()
     #endif
 }

--- a/Offroad-iOS/Offroad-iOS/Network/ORBRecommendation/DTO/Request/ORBRecommendationChatRequestDTO.swift
+++ b/Offroad-iOS/Offroad-iOS/Network/ORBRecommendation/DTO/Request/ORBRecommendationChatRequestDTO.swift
@@ -1,0 +1,10 @@
+//
+//  ORBRecommendationChatRequestDTO.swift
+//  ORB_Dev
+//
+//  Created by 김민성 on 6/7/25.
+//
+
+struct ORBREcommendationChatRequestDTO: Encodable {
+    let content: String
+}

--- a/Offroad-iOS/Offroad-iOS/Network/ORBRecommendation/DTO/Response/ORBRecommendationChatResponseDTO.swift
+++ b/Offroad-iOS/Offroad-iOS/Network/ORBRecommendation/DTO/Response/ORBRecommendationChatResponseDTO.swift
@@ -1,0 +1,16 @@
+//
+//  ORBRecommendationChatResponseDTO.swift
+//  ORB
+//
+//  Created by 김민성 on 6/7/25.
+//
+
+struct ORBRecommendationChatResponseDTO: Decodable {
+    let message: String
+    let data: ORBRecommendationChatResponseData
+}
+
+struct ORBRecommendationChatResponseData: Decodable {
+    let content: String
+    let success: Bool
+}

--- a/Offroad-iOS/Offroad-iOS/Network/ORBRecommendation/DTO/Response/ORBRecommendationFixedPhraseResponseDTO.swift
+++ b/Offroad-iOS/Offroad-iOS/Network/ORBRecommendation/DTO/Response/ORBRecommendationFixedPhraseResponseDTO.swift
@@ -1,0 +1,15 @@
+//
+//  ORBRecommendationFixedPhraseResponseDTO.swift
+//  ORB_Dev
+//
+//  Created by 김민성 on 6/19/25.
+//
+
+struct ORBRecommendationFixedPhraseResponseDTO: Decodable {
+    let message: String
+    let data: ORBRecommendationFixedPhraseResponseData
+}
+
+struct ORBRecommendationFixedPhraseResponseData: Decodable {
+    let content: String
+}

--- a/Offroad-iOS/Offroad-iOS/Network/ORBRecommendation/DTO/Response/ORBRecommendationPlacesResponseDTO.swift
+++ b/Offroad-iOS/Offroad-iOS/Network/ORBRecommendation/DTO/Response/ORBRecommendationPlacesResponseDTO.swift
@@ -1,11 +1,11 @@
 //
-//  ORBRecommendationResponseDTO.swift
+//  ORBRecommendationPlacesResponseDTO.swift
 //  Offroad-iOS
 //
 //  Created by 김민성 on 6/7/25.
 //
 
-struct ORBRecommendationResponseDTO: Decodable {
+struct ORBRecommendationPlacesResponseDTO: Decodable {
     var message: String
     var data: ORBRecommendationResponseData
 }

--- a/Offroad-iOS/Offroad-iOS/Network/ORBRecommendation/DTO/Response/ORBRecommendationResponseDTO.swift
+++ b/Offroad-iOS/Offroad-iOS/Network/ORBRecommendation/DTO/Response/ORBRecommendationResponseDTO.swift
@@ -1,0 +1,28 @@
+//
+//  ORBRecommendationResponseDTO.swift
+//  Offroad-iOS
+//
+//  Created by 김민성 on 6/7/25.
+//
+
+struct ORBRecommendationResponseDTO: Decodable {
+    var message: String
+    var data: ORBRecommendationResponseData
+}
+
+struct ORBRecommendationResponseData: Decodable {
+    var recommendataion: [ORBRecommendationPlace]
+}
+
+struct ORBRecommendationPlace: Decodable {
+    let id: Int
+    let recommendationType: String
+    let name: String
+    let address: String
+    let shortIntroduction: String
+    let placeCategory: String
+    let placeArea: String
+    let latitude: Double
+    let longitude: Double
+    let categoryImageUrl: String
+}

--- a/Offroad-iOS/Offroad-iOS/Network/ORBRecommendation/DTO/Response/ORBRecommendationResponseDTO.swift
+++ b/Offroad-iOS/Offroad-iOS/Network/ORBRecommendation/DTO/Response/ORBRecommendationResponseDTO.swift
@@ -11,7 +11,7 @@ struct ORBRecommendationResponseDTO: Decodable {
 }
 
 struct ORBRecommendationResponseData: Decodable {
-    var recommendataion: [ORBRecommendationPlace]
+    var recommendations: [ORBRecommendationPlace]
 }
 
 struct ORBRecommendationPlace: Decodable {
@@ -22,6 +22,7 @@ struct ORBRecommendationPlace: Decodable {
     let shortIntroduction: String
     let placeCategory: String
     let placeArea: String
+    let visitCount: Int?
     let latitude: Double
     let longitude: Double
     let categoryImageUrl: String

--- a/Offroad-iOS/Offroad-iOS/Network/ORBRecommendation/ORBRecommendationAPI.swift
+++ b/Offroad-iOS/Offroad-iOS/Network/ORBRecommendation/ORBRecommendationAPI.swift
@@ -1,0 +1,49 @@
+//
+//  ORBRecommendationAPI.swift
+//  Offroad-iOS
+//
+//  Created by 김민성 on 6/7/25.
+//
+
+import Foundation
+
+import Moya
+
+enum ORBRecommendationAPI: BaseTargetType {
+    case getRecommendedPlaces
+    case postRecommendationChat(content: String)
+}
+
+extension ORBRecommendationAPI {
+    var headerType: HeaderType {
+        return .accessTokenHeaderForGet
+    }
+    
+    var path: String {
+        switch self {
+        case .getRecommendedPlaces:
+            return "/place-recommendations/order"
+        case .postRecommendationChat:
+            return "/place-recommendations/order/chat"
+        }
+    }
+    
+    var method: Moya.Method {
+        switch self {
+        case .getRecommendedPlaces:
+            return .get
+        case .postRecommendationChat(let content):
+            return .post
+        }
+    }
+    
+    var task: Moya.Task {
+        switch self {
+        case .getRecommendedPlaces:
+            return .requestPlain
+        case .postRecommendationChat(let content):
+            let requestDTO = ORBREcommendationChatRequestDTO(content: content)
+            return .requestJSONEncodable(requestDTO)
+        }
+    }
+}

--- a/Offroad-iOS/Offroad-iOS/Network/ORBRecommendation/ORBRecommendationAPI.swift
+++ b/Offroad-iOS/Offroad-iOS/Network/ORBRecommendation/ORBRecommendationAPI.swift
@@ -22,7 +22,7 @@ extension ORBRecommendationAPI {
     var path: String {
         switch self {
         case .getRecommendedPlaces:
-            return "/place-recommendations/order"
+            return "/place-recommendations"
         case .postRecommendationChat:
             return "/place-recommendations/order/chat"
         }
@@ -32,7 +32,7 @@ extension ORBRecommendationAPI {
         switch self {
         case .getRecommendedPlaces:
             return .get
-        case .postRecommendationChat(let content):
+        case .postRecommendationChat:
             return .post
         }
     }

--- a/Offroad-iOS/Offroad-iOS/Network/ORBRecommendation/ORBRecommendationAPI.swift
+++ b/Offroad-iOS/Offroad-iOS/Network/ORBRecommendation/ORBRecommendationAPI.swift
@@ -10,6 +10,8 @@ import Foundation
 import Moya
 
 enum ORBRecommendationAPI: BaseTargetType {
+    /// 오브의 추천소 메인화면 상단 고정 문구 요청(`GET`)
+    case getFixedPhrase
     case getRecommendedPlaces
     case postRecommendationChat(content: String)
 }
@@ -21,6 +23,8 @@ extension ORBRecommendationAPI {
     
     var path: String {
         switch self {
+        case .getFixedPhrase:
+            return "/place-recommendations/fixed-phrase"
         case .getRecommendedPlaces:
             return "/place-recommendations"
         case .postRecommendationChat:
@@ -30,7 +34,7 @@ extension ORBRecommendationAPI {
     
     var method: Moya.Method {
         switch self {
-        case .getRecommendedPlaces:
+        case .getFixedPhrase, .getRecommendedPlaces:
             return .get
         case .postRecommendationChat:
             return .post
@@ -39,7 +43,7 @@ extension ORBRecommendationAPI {
     
     var task: Moya.Task {
         switch self {
-        case .getRecommendedPlaces:
+        case .getFixedPhrase, .getRecommendedPlaces:
             return .requestPlain
         case .postRecommendationChat(let content):
             let requestDTO = ORBREcommendationChatRequestDTO(content: content)

--- a/Offroad-iOS/Offroad-iOS/Network/ORBRecommendation/ORBRecommendationService.swift
+++ b/Offroad-iOS/Offroad-iOS/Network/ORBRecommendation/ORBRecommendationService.swift
@@ -15,6 +15,8 @@ struct ORBRecommendationService {
         plugins: [MoyaPlugin()]
     )
     
+    /// 오브의 추천 장소 목록을 비동기적으로 받아오는 함수.
+    /// - Returns: 오브의 추천 장소 목록. `[ORBRecommendationPlaceModel]` 타입.
     func getRecommendedPlaces() async throws -> [ORBRecommendationPlaceModel] {
         let api = ORBRecommendationAPI.getRecommendedPlaces
         
@@ -28,7 +30,7 @@ struct ORBRecommendationService {
                             decodingType: ORBRecommendationResponseDTO.self
                         )
                         
-                        let places = try decodedDTO.data.recommendataion.map { try ORBRecommendationPlaceModel($0) }
+                        let places = try decodedDTO.data.recommendations.map { try ORBRecommendationPlaceModel($0) }
                         continuation.resume(returning: places)
                     } catch {
                         continuation.resume(throwing: error)
@@ -41,6 +43,11 @@ struct ORBRecommendationService {
         }
     }
     
+    /// 오브의 추천소에서 채팅을 보내는 함수.
+    /// - Parameter content: 채팅을 보낼 메시지.
+    /// - Returns: 장소 추천이 성공했는지 여부와, 오브의 답장 텍스트.
+    ///
+    /// 오브의 추천소에서 채팅을 통해 주문서를 작성할 때, 채팅을 보내는 동작에 해당.
     func sendRecommendationChat(content: String) async throws -> (Bool, String) {
         let api = ORBRecommendationAPI.postRecommendationChat(content: content)
         

--- a/Offroad-iOS/Offroad-iOS/Network/ORBRecommendation/ORBRecommendationService.swift
+++ b/Offroad-iOS/Offroad-iOS/Network/ORBRecommendation/ORBRecommendationService.swift
@@ -15,6 +15,33 @@ struct ORBRecommendationService {
         plugins: [MoyaPlugin()]
     )
     
+    /// 오브의 추천소 메인 화면 상단에 띄울 고정 문구를 서버에서 비동기적으로 받아오는 함수.
+    /// - Returns: 오브의 추천소 메인 화면 상단 버튼에 띄울 고정 문구
+    func getFixedPhrase() async throws -> String {
+        let api = ORBRecommendationAPI.getFixedPhrase
+        
+        return try await withCheckedThrowingContinuation { continuation in
+            provider.request(api) { result in
+                switch result {
+                case .success(let response):
+                    do {
+                        let decodedDTO = try NetworkResultHandler().handleSuccessCase(
+                            response: response,
+                            decodingType: ORBRecommendationFixedPhraseResponseDTO.self
+                        )
+                        
+                        continuation.resume(returning: decodedDTO.data.content)
+                    } catch {
+                        continuation.resume(throwing: error)
+                    }
+                case .failure(let moyaError):
+                    let errorToThrow = NetworkResultHandler().handleFailureCase(moyaError: moyaError)
+                    continuation.resume(throwing: errorToThrow)
+                }
+            }
+        }
+    }
+    
     /// 오브의 추천 장소 목록을 비동기적으로 받아오는 함수.
     /// - Returns: 오브의 추천 장소 목록. `[ORBRecommendationPlaceModel]` 타입.
     func getRecommendedPlaces() async throws -> [ORBRecommendationPlaceModel] {

--- a/Offroad-iOS/Offroad-iOS/Network/ORBRecommendation/ORBRecommendationService.swift
+++ b/Offroad-iOS/Offroad-iOS/Network/ORBRecommendation/ORBRecommendationService.swift
@@ -27,7 +27,7 @@ struct ORBRecommendationService {
                     do {
                         let decodedDTO = try NetworkResultHandler().handleSuccessCase(
                             response: response,
-                            decodingType: ORBRecommendationResponseDTO.self
+                            decodingType: ORBRecommendationPlacesResponseDTO.self
                         )
                         
                         let places = try decodedDTO.data.recommendations.map { try ORBRecommendationPlaceModel($0) }

--- a/Offroad-iOS/Offroad-iOS/Network/ORBRecommendation/ORBRecommendationService.swift
+++ b/Offroad-iOS/Offroad-iOS/Network/ORBRecommendation/ORBRecommendationService.swift
@@ -1,0 +1,67 @@
+//
+//  ORBRecommendationService.swift
+//  ORB_Dev
+//
+//  Created by 김민성 on 6/7/25.
+//
+
+import Foundation
+
+import Moya
+
+struct ORBRecommendationService {
+    private let provider = MoyaProvider<ORBRecommendationAPI>.init(
+        session: Session(interceptor: TokenInterceptor.shared),
+        plugins: [MoyaPlugin()]
+    )
+    
+    func getRecommendedPlaces() async throws -> [ORBRecommendationPlaceModel] {
+        let api = ORBRecommendationAPI.getRecommendedPlaces
+        
+        return try await withCheckedThrowingContinuation { continuation in
+            provider.request(api) { result in
+                switch result {
+                case .success(let response):
+                    do {
+                        let decodedDTO = try NetworkResultHandler().handleSuccessCase(
+                            response: response,
+                            decodingType: ORBRecommendationResponseDTO.self
+                        )
+                        
+                        let places = try decodedDTO.data.recommendataion.map { try ORBRecommendationPlaceModel($0) }
+                        continuation.resume(returning: places)
+                    } catch {
+                        continuation.resume(throwing: error)
+                    }
+                case .failure(let moyaError):
+                    let errorToThrow = NetworkResultHandler().handleFailureCase(moyaError: moyaError)
+                    continuation.resume(throwing: errorToThrow)
+                }
+            }
+        }
+    }
+    
+    func sendRecommendationChat(content: String) async throws -> (Bool, String) {
+        let api = ORBRecommendationAPI.postRecommendationChat(content: content)
+        
+        return try await withCheckedThrowingContinuation { continuation in
+            provider.request(api) { result in
+                switch result {
+                case .success(let resposne):
+                    do {
+                        let decodedDTO = try NetworkResultHandler().handleSuccessCase(
+                            response: resposne,
+                            decodingType: ORBRecommendationChatResponseDTO.self
+                        )
+                        continuation.resume(returning: (decodedDTO.data.success, decodedDTO.data.content))
+                    } catch {
+                        continuation.resume(throwing: error)
+                    }
+                case .failure(let moyaError):
+                    let errorToThrow = NetworkResultHandler().handleFailureCase(moyaError: moyaError)
+                    continuation.resume(throwing: errorToThrow)
+                }
+            }
+        }
+    }
+}

--- a/Offroad-iOS/Offroad-iOS/Network/ORBRecommendation/ORBRecommendationService.swift
+++ b/Offroad-iOS/Offroad-iOS/Network/ORBRecommendation/ORBRecommendationService.swift
@@ -81,10 +81,10 @@ struct ORBRecommendationService {
         return try await withCheckedThrowingContinuation { continuation in
             provider.request(api) { result in
                 switch result {
-                case .success(let resposne):
+                case .success(let response):
                     do {
                         let decodedDTO = try NetworkResultHandler().handleSuccessCase(
-                            response: resposne,
+                            response: response,
                             decodingType: ORBRecommendationChatResponseDTO.self
                         )
                         continuation.resume(returning: (decodedDTO.data.success, decodedDTO.data.content))

--- a/Offroad-iOS/Offroad-iOS/Network/Place/DTO/Responce/RegisteredPlaceResponseDTO.swift
+++ b/Offroad-iOS/Offroad-iOS/Network/Place/DTO/Responce/RegisteredPlaceResponseDTO.swift
@@ -27,11 +27,5 @@ struct RegisteredPlaceInfo: Codable {
     let longitude: Double
     let visitCount: Int
     let categoryImageUrl: String
-    /*
-     실제 사용되는 API 요청 메서드에서는 응답값에 distanceFromUser가 항상 포함되지만,
-     현재 스웨거에서 확인되는 등록 장소 API 중 응답값에 distanceFromUser가 포함되지 않는 경우도 존재하기 때문에,
-     혹시 모를 충돌을 대비하고자, distanceFromUser의 타입을 옵셔널로 지정하였음.
-     추후 API의 변경에 따라 타입을 옵셔널이 아닌 Double로 지정할 수 있음.
-     */
-    let distanceFromUser: Double?
+    let distanceFromUser: Double
 }

--- a/Offroad-iOS/Offroad-iOS/Presentation/ORBRecommendation/chat/ViewControllers/ORBRecommendationChatViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/ORBRecommendation/chat/ViewControllers/ORBRecommendationChatViewController.swift
@@ -152,15 +152,15 @@ private extension ORBRecommendationChatViewController {
                 rootView.chatInputView.isSendingAllowed = true
             }
             
-            let characterReply = await getChatResponse(onSending: text)
+            let characterReply = await getChatReplyText(onSending: text)
             addReply(characterReply)
         }
     }
     
-    /// 채팅을 보낸 후 캐릭터가 답변할 내용을 비동기적으로 반환하는 함수.
+    /// 채팅을 보낸 후 캐릭터가 답변할 텍스트를 비동기적으로 반환하는 함수. 추천 로직 결과 및 추천 장소 유무에 따라 분기처리됨.
     /// - Parameter text: 사용자가 채팅을 보낸 문자열
-    /// - Returns: 캐릭터가 답변할 문자열.
-    func getChatResponse(onSending text: String) async -> String {
+    /// - Returns: 캐릭터가 답변할 텍스트 문자열.
+    func getChatReplyText(onSending text: String) async -> String {
         let networkService = NetworkService.shared.orbRecommendationService
         guard let (recommendationSuccess, answer) = try? await networkService.sendRecommendationChat(content: text) else {
             return "이런...장소 추천에 실패했어..잠시 후에 다시 시도해볼래?"

--- a/Offroad-iOS/Offroad-iOS/Presentation/ORBRecommendation/chat/ViewControllers/ORBRecommendationChatViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/ORBRecommendation/chat/ViewControllers/ORBRecommendationChatViewController.swift
@@ -5,6 +5,7 @@
 //  Created by 김민성 on 5/4/25.
 //
 
+import Combine
 import UIKit
 
 import RxSwift
@@ -13,6 +14,10 @@ import RxCocoa
 final class ORBRecommendationChatViewController: UIViewController {
     
     // MARK: - Properties
+    
+    /// 추천소 채팅 로그 뷰에서 장소 추천 채팅이 성공했을 때 이벤트를 방출하는 `PassthroughSubject`
+    // RxSwift에서 PublishRelay 역할
+    let shouldUpdatePlaces = PassthroughSubject<Void, Never>()
     
     private let rootView = ORBRecommendationChatView()
     private let firstChatText: String
@@ -127,9 +132,9 @@ private extension ORBRecommendationChatViewController {
                 let networkService = NetworkService.shared.orbRecommendationService
                 let (recommendationSuccess, answer) = try await networkService.sendRecommendationChat(content: text)
                 
-                // 서버 내부 장소 추천 로직이 성공했을 때 처리
+                // 서버 내부 장소 추천 로직이 성공했을 때 외부로 이벤트 방출
                 if recommendationSuccess {
-                    // ...외부로 이벤트 방출 필요 -> Combine 사용 시도?
+                    shouldUpdatePlaces.send()
                 }
                 
                 // 응답 메시지 채팅 화면에 반영

--- a/Offroad-iOS/Offroad-iOS/Presentation/ORBRecommendation/chat/ViewControllers/ORBRecommendationChatViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/ORBRecommendation/chat/ViewControllers/ORBRecommendationChatViewController.swift
@@ -59,7 +59,6 @@ private extension ORBRecommendationChatViewController {
             self.dismiss(animated: true)
         }.disposed(by: disposeBag)
         
-        // 채팅 UI 테스트용 - 번갈아가며 채팅 내용 입력할 수 있도록 임시로 구현
         rootView.chatInputView.onSendingText.subscribe(onNext: { [weak self] text in
             guard let self else { return }
             self.rootView.exampleQuestionListView.isHidden = true

--- a/Offroad-iOS/Offroad-iOS/Presentation/ORBRecommendation/chat/Views/ORBRecommendationChatView.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/ORBRecommendation/chat/Views/ORBRecommendationChatView.swift
@@ -23,10 +23,10 @@ final class ORBRecommendationChatView: ORBRecommendationChatBackgroundView {
     
     // MARK: - UI Properties
     
-    private(set) var xButton = UIButton()
+    let xButton = UIButton()
     private(set) var collectionView: UICollectionView! = nil
-    private(set) var exampleQuestionListView = ORBRecommendationChatExampleQuestionListView()
-    private(set) var chatInputView = ChatTextInputView()
+    let exampleQuestionListView = ORBRecommendationChatExampleQuestionListView()
+    let chatInputView = ChatTextInputView()
     private let keyboardBackgroundView = UIView()
     
     // MARK: - Life Cycle

--- a/Offroad-iOS/Offroad-iOS/Presentation/ORBRecommendation/main/ViewController/ORBRecommendationMainViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/ORBRecommendation/main/ViewController/ORBRecommendationMainViewController.swift
@@ -154,7 +154,8 @@ private extension ORBRecommendationMainViewController {
                 self.rootView.contentToolBar.isUserInteractionEnabled = true
             }
             do {
-                let recommendedPlaces = try await self.getRecommendedPlace()
+                let networkService = NetworkService.shared.orbRecommendationService
+                let recommendedPlaces = try await networkService.getRecommendedPlaces()
                 self.updateRecommendedPlaces(recommendedPlaces)
             } catch let error as NetworkResultError {
                 let message: String
@@ -167,21 +168,11 @@ private extension ORBRecommendationMainViewController {
                 
                 // 데이터 불러오기 실패 시 alert 팝업 띄우는 코드.
                 let alertController = ORBAlertController(message: message, type: .messageOnly)
-                let okAction = ORBAlertAction(title: "화인", style: .default) { _ in return }
+                let okAction = ORBAlertAction(title: "확인", style: .default) { _ in return }
                 alertController.addAction(okAction)
                 alertController.xButton.isHidden = true
                 self.present(alertController, animated: true)
             }
-        }
-    }
-    
-    func getRecommendedPlace() async throws -> [ORBRecommendationPlaceModel] {
-        let networkService = NetworkService.shared.orbRecommendationService
-        do {
-            let recommendedPlaces = try await networkService.getRecommendedPlaces()
-            return recommendedPlaces
-        } catch {
-            throw error
         }
     }
     
@@ -196,7 +187,7 @@ private extension ORBRecommendationMainViewController {
             let marker = PlaceMapMarker(place: $0)
             (marker.width, marker.height) = (26, 32)
             marker.mapView = rootView.orbMapView.mapView
-            marker.touchHandler = { [weak self] overlay in
+            marker.touchHandler = { [weak self] _ in
                 self?.rootView.orbMapView.showTooltip(marker)
                 return true
             }

--- a/Offroad-iOS/Offroad-iOS/Presentation/ORBRecommendation/main/ViewController/ORBRecommendationMainViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/ORBRecommendation/main/ViewController/ORBRecommendationMainViewController.swift
@@ -144,6 +144,12 @@ extension ORBRecommendationMainViewController {
                 }
                 self?.markers = newMarkers
                 
+                // 모든 장소가 모두 보일 곳으로 이동하기
+                let naverMapCoordinates: [NMGLatLng] = recommendedPlaces.map { place in
+                    NMGLatLng(from: place.coordinate)
+                }
+                self?.rootView.orbMapView.moveCamera(placesToShow: naverMapCoordinates, padding: 50)
+                
             } catch {
                 print(error.localizedDescription)
             }

--- a/Offroad-iOS/Offroad-iOS/Presentation/ORBRecommendation/main/ViewController/ORBRecommendationMainViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/ORBRecommendation/main/ViewController/ORBRecommendationMainViewController.swift
@@ -5,6 +5,7 @@
 //  Created by 김민성 on 4/20/25.
 //
 
+import Combine
 import UIKit
 
 import NMapsMap
@@ -17,6 +18,8 @@ final class ORBRecommendationMainViewController: UIViewController {
     
     private let rootView = ORBRecommendationMainView()
     private var disposeBag = DisposeBag()
+    // RxSwift의 DisposeBag 역할
+    private var cancellables = Set<AnyCancellable>()
     private var markers: [PlaceMapMarker] = []
     
     // MARK: - Life Cycle
@@ -51,6 +54,13 @@ final class ORBRecommendationMainViewController: UIViewController {
                 let chatViewController = ORBRecommendationChatViewController(
                     firstChatText: self.rootView.orbMessageButton.message
                 )
+                
+                // 추천소 채팅 뷰컨트롤러의 Combine 구독
+                chatViewController.shouldUpdatePlaces
+                    .sink { [weak self] in
+                        self?.updateRecommendedPlaces()
+                    }.store(in: &cancellables)
+                
                 chatViewController.view.layoutIfNeeded()
                 chatViewController.transitioningDelegate = self
                 chatViewController.modalPresentationStyle = .custom

--- a/Offroad-iOS/Offroad-iOS/Presentation/ORBRecommendation/main/ViewController/ORBRecommendationMainViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/ORBRecommendation/main/ViewController/ORBRecommendationMainViewController.swift
@@ -29,6 +29,7 @@ final class ORBRecommendationMainViewController: UIViewController {
         super.viewDidLoad()
         
         setupButtonActions()
+        updateFixedPhrase()
         updateRecommendedPlaces()
     }
     
@@ -120,7 +121,17 @@ extension ORBRecommendationMainViewController: UIViewControllerTransitioningDele
 }
 
 // 뷰의 컨텐츠 업데이트 관련
-extension ORBRecommendationMainViewController {
+private extension ORBRecommendationMainViewController {
+    
+    func updateFixedPhrase() {
+        Task { [weak self] in
+            let networkService = NetworkService.shared.orbRecommendationService
+            let fixedPhrase = try? await networkService.getFixedPhrase()
+            // 에러 종류에 상관없이 고정 문구 받아오는 데 실패한 경우 에러를 사용자에게 안내하는 대신 다음과 같이 기본값 적용.
+            self?.rootView.orbMessageButton.message =
+            fixedPhrase ?? "어라! 어디 가고 싶은 곳이 있는 표정이야! 나 추천 오브 츄링이한테 말해봐 츄츄~"
+        }
+    }
     
     func updateRecommendedPlaces() {
         Task { [weak self] in

--- a/Offroad-iOS/Offroad-iOS/Presentation/ORBRecommendation/main/Views/ORBRecommendationMainView.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/ORBRecommendation/main/Views/ORBRecommendationMainView.swift
@@ -78,6 +78,7 @@ private extension ORBRecommendationMainView {
         }
         
         orbMapView.isHidden = true
+        orbMapView.mapView.maxTilt = 0
     }
     
     func setupHierarchy() {

--- a/Offroad-iOS/Offroad-iOS/Presentation/ORBRecommendation/main/Views/ORBRecommendationMainView.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/ORBRecommendation/main/Views/ORBRecommendationMainView.swift
@@ -77,8 +77,6 @@ private extension ORBRecommendationMainView {
             stackView.distribution = .fillProportionally
         }
         
-        orbMessageButton.message = "오브의 추천소에 어서와~\n여기서는 ~~~소개소개"
-        
         orbMapView.isHidden = true
     }
     

--- a/Offroad-iOS/Offroad-iOS/Presentation/ORBRecommendation/main/Views/ORBRecommendationMainView.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/ORBRecommendation/main/Views/ORBRecommendationMainView.swift
@@ -37,7 +37,7 @@ final class ORBRecommendationMainView: UIView {
     let orbMessageButton = ORBRecommendationMessageButton()
     let orbMapView = ORBMapView()
     let recommendedContentView = ORBRecommendedContentView()
-    private let contentToolBar = ORBRecommendationMainViewToolBar()
+    let contentToolBar = ORBRecommendationMainViewToolBar()
     
     override init(frame: CGRect) {
         super.init(frame: frame)

--- a/Offroad-iOS/Offroad-iOS/Presentation/ORBRecommendation/main/Views/ORBRecommendationMainView.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/ORBRecommendation/main/Views/ORBRecommendationMainView.swift
@@ -98,7 +98,8 @@ private extension ORBRecommendationMainView {
         }
         
         titleStack.snp.makeConstraints { make in
-            make.top.equalToSuperview().inset(132.5)
+            let topInset: CGFloat = UIScreen.current.isAspectRatioTall ? 30 : 10
+            make.top.equalTo(backButton.snp.bottom).offset(topInset)
             make.leading.equalToSuperview().inset(24)
             make.trailing.lessThanOrEqualToSuperview().inset(24)
         }

--- a/Offroad-iOS/Offroad-iOS/Presentation/ORBRecommendation/main/Views/ORBRecommendationMainView.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/ORBRecommendation/main/Views/ORBRecommendationMainView.swift
@@ -35,8 +35,8 @@ final class ORBRecommendationMainView: UIView {
     private let titleImageView = UIImageView(image: .icnOrbRecommendationMainTitle)
     private lazy var titleStack = UIStackView(arrangedSubviews: [titleLabel, titleImageView])
     let orbMessageButton = ORBRecommendationMessageButton()
-    private let orbMapView = ORBMapView()
-    private let recommendedContentView = ORBRecommendedContentView()
+    let orbMapView = ORBMapView()
+    let recommendedContentView = ORBRecommendedContentView()
     private let contentToolBar = ORBRecommendationMainViewToolBar()
     
     override init(frame: CGRect) {

--- a/Offroad-iOS/Offroad-iOS/Presentation/ORBRecommendation/main/Views/ORBRecommendedContentView.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/ORBRecommendation/main/Views/ORBRecommendedContentView.swift
@@ -19,7 +19,7 @@ final class ORBRecommendedContentView: ExpandableCellCollectionView {
     private let locationManager = CLLocationManager()
     private let placeService = NetworkService.shared.placeService
     
-    var places: [PlaceModel] = []
+    var places: [ORBRecommendationPlaceModel] = []
     
     // MARK: - UI Properties
     
@@ -37,7 +37,6 @@ final class ORBRecommendedContentView: ExpandableCellCollectionView {
         setupLayout()
         locationManager.startUpdatingLocation()
         setupCollectionView()
-        getInitialPlaceData()
         panGestureRecognizer.delegate = self
     }
     
@@ -79,27 +78,6 @@ private extension ORBRecommendedContentView {
         register(PlaceListCell.self, forCellWithReuseIdentifier: PlaceListCell.className)
     }
     
-    func getInitialPlaceData() {
-        guard let currentLocation = locationManager.location else { return }
-        placeService.getRegisteredMapPlaces(
-            latitude: currentLocation.coordinate.latitude,
-            longitude: currentLocation.coordinate.longitude,
-            limit: 100) { [weak self] result in
-            switch result {
-            case .success(let data):
-                guard let data = data?.data else { return }
-                do {
-                    self?.places = try data.places.map({ try PlaceModel($0) })
-                    self?.reloadData()
-                } catch {
-                    print(error.localizedDescription)
-                }
-            default:
-                return
-            }
-        }
-    }
-    
 }
 
 // MARK: - UICollectionViewDataSource
@@ -112,7 +90,7 @@ extension ORBRecommendedContentView: UICollectionViewDataSource {
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: PlaceListCell.className, for: indexPath) as? PlaceListCell else { fatalError("PlaceListCell dequeueing failed") }
-        cell.configure(with: places[indexPath.item], isVisitCountShowing: true)
+        cell.configure(with: places[indexPath.item], isVisitCountShowing: false)
         return cell
     }
     

--- a/Offroad-iOS/Offroad-iOS/Presentation/ORBRecommendation/main/Views/ORBRecommendedContentView.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/ORBRecommendation/main/Views/ORBRecommendedContentView.swift
@@ -11,7 +11,7 @@ import UIKit
 import ExpandableCell
 import SnapKit
 
-final class ORBRecommendedContentView: ExpandableCellCollectionView {
+final class ORBRecommendedContentView: ExpandableCellCollectionView, ORBCenterLoadingStyle {
     
     // MARK: - Properties
     

--- a/Offroad-iOS/Offroad-iOS/Presentation/ORBRecommendation/model/ORBRecommendationPlaceModel.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/ORBRecommendation/model/ORBRecommendationPlaceModel.swift
@@ -14,14 +14,11 @@ enum ORBRecommendationType: String {
 }
 
 enum ORBRecommendationPlaceModelError: LocalizedError {
-    case invalidRecommendationType(wrongValue: String)
     case invalidCategoryValue(wrongValue: String)
     case invalidCategoryImageURL(wrongURL: String)
     
     var errorDescription: String? {
         switch self {
-        case .invalidRecommendationType(wrongValue: let wrongValue):
-            return "잘못된 오브의 장소 추천 타입: \(wrongValue). 오브의 장소 추천 타입은 식당, 카페 중 하나여야 합니다."
         case .invalidCategoryValue(let wrongValue):
             return "Invalid category value: \(wrongValue)"
         case .invalidCategoryImageURL(let wrongURL):
@@ -33,31 +30,30 @@ enum ORBRecommendationPlaceModelError: LocalizedError {
 struct ORBRecommendationPlaceModel {
     
     let id: Int
-    let recommendationType: ORBRecommendationType
     let name: String
     let address: String
     let shortIntroduction: String
-    let placeCategory: PlaceCategory
+    let placeCategory: ORBPlaceCategory
     let placeArea: String
+    let visitCount: Int
     let coordinate: CLLocationCoordinate2D
     let categoryImageUrl: URL
     
     init(_ dto: ORBRecommendationPlace) throws {
         self.id = dto.id
-        if let recommendationType = ORBRecommendationType(rawValue: dto.recommendationType) {
-            self.recommendationType = recommendationType
-        } else {
-            throw ORBRecommendationPlaceModelError.invalidRecommendationType(wrongValue: dto.recommendationType)
-        }
         self.name = dto.name
         self.address = dto.address
         self.shortIntroduction = dto.shortIntroduction
-        if let category = PlaceCategory(rawValue: dto.placeCategory) {
+        if let category = ORBPlaceCategory(rawValue: dto.placeCategory) {
             self.placeCategory = category
         } else {
             throw ORBRecommendationPlaceModelError.invalidCategoryValue(wrongValue: dto.placeCategory)
         }
         self.placeArea = dto.placeArea
+        // 현재 서버 응답값에 visitCount가 포함되어있지 않아서 visitCount가 nil로 들어옴.
+        // 우선 런타임 에러 막기 위해 기본값 0 할당.
+        // 서버에서 visitCount 포함하여 데이터 넘겨주면 반영할 예정
+        self.visitCount = dto.visitCount ?? 0
         self.coordinate = .init(latitude: dto.latitude, longitude: dto.longitude)
         if let imageURL = URL(string: dto.categoryImageUrl) {
             self.categoryImageUrl = imageURL

--- a/Offroad-iOS/Offroad-iOS/Presentation/ORBRecommendation/model/ORBRecommendationPlaceModel.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/ORBRecommendation/model/ORBRecommendationPlaceModel.swift
@@ -1,0 +1,69 @@
+//
+//  ORBRecommendationPlaceModel.swift
+//  ORB_Dev
+//
+//  Created by 김민성 on 6/7/25.
+//
+
+import CoreLocation
+import Foundation
+
+enum ORBRecommendationType: String {
+    case restaurant = "RESTAURANT"
+    case cafe = "CAFE"
+}
+
+enum ORBRecommendationPlaceModelError: LocalizedError {
+    case invalidRecommendationType(wrongValue: String)
+    case invalidCategoryValue(wrongValue: String)
+    case invalidCategoryImageURL(wrongURL: String)
+    
+    var errorDescription: String? {
+        switch self {
+        case .invalidRecommendationType(wrongValue: let wrongValue):
+            return "잘못된 오브의 장소 추천 타입: \(wrongValue). 오브의 장소 추천 타입은 식당, 카페 중 하나여야 합니다."
+        case .invalidCategoryValue(let wrongValue):
+            return "Invalid category value: \(wrongValue)"
+        case .invalidCategoryImageURL(let wrongURL):
+            return "Invalid category image url: \(wrongURL)"
+        }
+    }
+}
+
+struct ORBRecommendationPlaceModel {
+    
+    let id: Int
+    let recommendationType: ORBRecommendationType
+    let name: String
+    let address: String
+    let shortIntroduction: String
+    let placeCategory: PlaceCategory
+    let placeArea: String
+    let coordinate: CLLocationCoordinate2D
+    let categoryImageUrl: URL
+    
+    init(_ dto: ORBRecommendationPlace) throws {
+        self.id = dto.id
+        if let recommendationType = ORBRecommendationType(rawValue: dto.recommendationType) {
+            self.recommendationType = recommendationType
+        } else {
+            throw ORBRecommendationPlaceModelError.invalidRecommendationType(wrongValue: dto.recommendationType)
+        }
+        self.name = dto.name
+        self.address = dto.address
+        self.shortIntroduction = dto.shortIntroduction
+        if let category = PlaceCategory(rawValue: dto.placeCategory) {
+            self.placeCategory = category
+        } else {
+            throw ORBRecommendationPlaceModelError.invalidCategoryValue(wrongValue: dto.placeCategory)
+        }
+        self.placeArea = dto.placeArea
+        self.coordinate = .init(latitude: dto.latitude, longitude: dto.longitude)
+        if let imageURL = URL(string: dto.categoryImageUrl) {
+            self.categoryImageUrl = imageURL
+        } else {
+            throw PlaceModelError.invalidCategoryValue(wrongValue: dto.categoryImageUrl)
+        }
+    }
+    
+}

--- a/Offroad-iOS/Offroad-iOS/Presentation/ORBRecommendation/model/ORBRecommendationPlaceModel.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/ORBRecommendation/model/ORBRecommendationPlaceModel.swift
@@ -27,7 +27,7 @@ enum ORBRecommendationPlaceModelError: LocalizedError {
     }
 }
 
-struct ORBRecommendationPlaceModel {
+struct ORBRecommendationPlaceModel: PlaceDescribable {
     
     let id: Int
     let name: String

--- a/Offroad-iOS/Offroad-iOS/Presentation/PlaceList/Model/PlaceModel.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/PlaceList/Model/PlaceModel.swift
@@ -42,7 +42,7 @@ struct PlaceModel {
     let visitCount: Int
     let categoryImageUrl: URL
     // 장소 목록 데이터를 불러올 때 페이징 시 필요한 값.
-    let distanceFromUser: Double?
+    let distanceFromUser: Double
     
     init(_ dto: RegisteredPlaceInfo) throws {
         self.id = dto.id

--- a/Offroad-iOS/Offroad-iOS/Presentation/PlaceList/Model/PlaceModel.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/PlaceList/Model/PlaceModel.swift
@@ -30,9 +30,12 @@ enum ORBPlaceCategory: String {
     case culture = "CULTURE"
 }
 
-struct PlaceModel {
+/// 지도, 장소 목록 뷰에서 사용되는 장소 데이터
+struct PlaceModel: PlaceDescribable, Identifiable {
     
-    let id: Int
+    typealias ID = Int
+    
+    let id: ID
     let name: String
     let address: String
     let shortIntroduction: String

--- a/Offroad-iOS/Offroad-iOS/Presentation/PlaceList/Views/PlaceCollectionViewCell.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/PlaceList/Views/PlaceCollectionViewCell.swift
@@ -272,7 +272,7 @@ extension PlaceCollectionViewCell {
     
     //MARK: - Func
     
-    func configureCell(with place: PlaceModel, showingVisitingCount: Bool) {
+    func configureCell(with place: some PlaceDescribable, showingVisitingCount: Bool) {
         placeSectionLabel.text = place.placeArea
         placeNameLabel.text = place.name
         addressLabel.text = place.address

--- a/Offroad-iOS/Offroad-iOS/Presentation/PlaceList/Views/PlaceListCell.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/PlaceList/Views/PlaceListCell.swift
@@ -300,7 +300,7 @@ private extension PlaceListCell {
 
 extension PlaceListCell {
     
-    func configure(with model: PlaceModel, isVisitCountShowing: Bool) {
+    func configure(with model: some PlaceDescribable, isVisitCountShowing: Bool) {
         switch model.placeCategory {
         case .cafe:
             categoryLabel.text = "카페"

--- a/Offroad-iOS/Offroad-iOS/Presentation/QuestMap/Model/AdventureResult.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/QuestMap/Model/AdventureResult.swift
@@ -10,11 +10,19 @@ import UIKit
 /// 위치 기반 탐험 요청의 결과와 팝업에 띄울 이미지를 저장하는 타입.
 /// 완료된 퀘스트가 있을 경우 완료된 퀘스트 정보를 포함.
 struct AdventureResult {
-    let place: PlaceModel
+    let place: any PlaceDescribable
     let isValidPosition: Bool
     let isFirstVisitToday: Bool
     let completedQuests: [CompleteQuest]?
     let resultImage: UIImage
     
     var isAdventureSuccess: Bool { isValidPosition && isFirstVisitToday }
+    
+    init(place: some PlaceDescribable, isValidPosition: Bool, isFirstVisitToday: Bool, completedQuests: [CompleteQuest]?, resultImage: UIImage) {
+        self.place = place
+        self.isValidPosition = isValidPosition
+        self.isFirstVisitToday = isFirstVisitToday
+        self.completedQuests = completedQuests
+        self.resultImage = resultImage
+    }
 }

--- a/Offroad-iOS/Offroad-iOS/Presentation/QuestMap/UIComponents/PlaceMapMarker.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/QuestMap/UIComponents/PlaceMapMarker.swift
@@ -15,11 +15,11 @@ class PlaceMapMarker: NMFMarker {
     //MARK: - Properties
     
     /// 마커가 띄울 장소 정보.
-    let place: PlaceModel
+    let place: any PlaceDescribable
     
     //MARK: - Life Cycle
     
-    init(place: PlaceModel) {
+    init(place: some PlaceDescribable) {
         self.place = place
         super.init()
         

--- a/Offroad-iOS/Offroad-iOS/Presentation/QuestMap/UIComponents/PlaceMapMarker.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/QuestMap/UIComponents/PlaceMapMarker.swift
@@ -8,7 +8,6 @@
 import UIKit
 
 import NMapsMap
-import Then
 
 /// 탐험 지도에 띄울 보라색 마커.
 class PlaceMapMarker: NMFMarker {

--- a/Offroad-iOS/Offroad-iOS/Presentation/QuestMap/ViewControllers/AdventureMapViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/QuestMap/ViewControllers/AdventureMapViewController.swift
@@ -260,6 +260,9 @@ extension AdventureMapViewController {
                     case .notDetermined:
                         return
                     case .fullAccuracy:
+                        // 탐험 지도 뷰에서 사용되는 place는 구체 타입이 PlaceModel이어야 함.
+                        // 그렇지 않은 경우, 잘못된 할당.
+                        guard let place = place as? PlaceModel else { return }
                         self.viewModel.authenticateAdventurePlace(placeInfo: place)
                     case .reducedAccuracy:
                         self.viewModel.locationUnauthorizedMessage.accept(AlertMessage.locationReducedAccuracyMessage)

--- a/Offroad-iOS/Offroad-iOS/Presentation/QuestMap/ViewModel/AdventureMapViewModel.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/QuestMap/ViewModel/AdventureMapViewModel.swift
@@ -141,7 +141,7 @@ extension AdventureMapViewModel {
     /// - Parameter placeInfo: 탐험을 시도할 위치 정보.
     ///
     /// 개발용 `Target`(`ORB_Dev`)에서는 개발자 모드의 설정값 중 '탐험 시 위치 인증 무시' 값에 따라 분기처리됨.
-    func authenticateAdventurePlace<T: PlaceDescribable>(placeInfo: T) where T: Identifiable, T.ID == Int {
+    func authenticateAdventurePlace(placeInfo: PlaceModel) {
         guard let currentLocation else {
             locationUnauthorizedMessage.accept(ErrorMessages.accessingLocationDataFailure)
             return

--- a/Offroad-iOS/Offroad-iOS/Presentation/QuestMap/ViewModel/AdventureMapViewModel.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/QuestMap/ViewModel/AdventureMapViewModel.swift
@@ -141,7 +141,7 @@ extension AdventureMapViewModel {
     /// - Parameter placeInfo: 탐험을 시도할 위치 정보.
     ///
     /// 개발용 `Target`(`ORB_Dev`)에서는 개발자 모드의 설정값 중 '탐험 시 위치 인증 무시' 값에 따라 분기처리됨.
-    func authenticateAdventurePlace(placeInfo: PlaceModel) {
+    func authenticateAdventurePlace<T: PlaceDescribable>(placeInfo: T) where T: Identifiable, T.ID == Int {
         guard let currentLocation else {
             locationUnauthorizedMessage.accept(ErrorMessages.accessingLocationDataFailure)
             return


### PR DESCRIPTION
## ⚠️변경사항이 많습니다..!! 궁금한 점은 언제든 물어봐주세요!

### 🌴 작업한 브랜치
- #546

### ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->

### 오브의 추천소 서버 API 관련 파일 및 기능을 추가하였습니다.
다른 네트워크 서비스와 거의 동일한 형태입니다. 
다음 기능들을 가집니다.
- 오브의 추천소 상단 (그라데이션 버튼)문구를 받아오는 기능
- 오브의 추천 장소 목록을 조회하는 기능
- 오브의 추천소 채팅을 보내는 기능

### 장소 관련 데이터 모델들을 프로토콜로 추상화하였습니다.
- 오브의 추천소 기능을 구현하면서 '오브가 추천해준 장소' 를 나타낼 별도 데이터 모델을 정의해야 했습니다.  
  거의 비슷한 형식인데 조금씩 속성들이 달라서..
  그리고 코스퀘스트 장소를 나타낼 데이터 모델의 속성도 기존 PlaceModel과는 크게 차이가 있는 것 같아서
  #### **여러 데이터 모델들(구조체)을 추상화하는 프로토콜을 만들었습니다.**
  장소 목록 셀이나 마커에서 장소 정보를 갖거나 이용하는 경우가 있는데요, 이때 탐험 시 사용되는 장소 모델과 추천소에서 사용되는 장소 모델 타입에 대해 일일이 분기처리할 경우 불필요한 코드가 너무 많아질 것 같아서, 장소 모델 자체를 추상화하였고, 
  구체 타입이 필요 시 타입캐스팅을 통해 분기처리할 수 있도록 하였습니다. 
  ``` swift
  //  장소를 나타내는 데이터 모델의 인터페이스.
  
  import CoreLocation
  
  /// '장소'를 나타내는 데이터가 필수로 가져야 하는 속성들을 포함하는 타입.
  protocol BasePlaceType {
      
      /// 장소 이름
      var name: String { get }
      
      /// 장소의 주소
      var address: String { get }
      
      /// 장소의 카테고리. `ORBPlaceCategory` 타입
      var placeCategory: ORBPlaceCategory { get }
      
      /// 장소의 위•경도 좌표
      var coordinate: CLLocationCoordinate2D { get }
      
  }
  
  /// 장소에 대해 설명하기 위한 추가적인 정보를 갖는 타입.
  ///
  /// 장소 목록 셀, 툴팁 등에서 장소에 대한 정보를 표시할 때 사용
  protocol PlaceDescribable: BasePlaceType {
      
      /// 장소 한 줄 소개
      var shortIntroduction: String { get }
      
      /// 장소 구역(시간이 머무는 마을 등)
      var placeArea: String { get }
      
      /// 방문 횟수
      var visitCount: Int { get }
      
      /// 카테고리 이미지의 URL
      /// - Note: 현재는 사용하지 않음. (이미지 리소스를 바로 사용)
      var categoryImageUrl: URL { get }
      
  }
  ```
  그리고 장소 목록 셀의 configure 메서드에서 다음과 같이 매개변수를 받을 수 있습니다.  
  
  ``` swift
  func configure(with model: some PlaceDescribable, isVisitCountShowing: Bool) {
    // ...
  }
  ```

### `ORBMapView`에 새로운 함수를 추가하였습니다.
오브의 추천소에서 추천 장소 목록을 받으면 지도에서는 모든 장소가 보이도록 해야 합니다.
이때 여러 장소들의 좌표를 매개변수로 받아서 해당 장소들이 모두 보이도록 지도의 카메라를 이동하는 함수를 새로 구현하였습니다. 

### 홈 버튼이 있는 기기에서 오브의 추천소 UI를 개선하였습니다.
제목과 뒤로가기 버튼 사이의 간격을 좁게 설정하여, 스크롤 가능한 영역을 최대한 확보하도록 하였습니다.

<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### ❗️PR Point
<!-- 부족했던 점 혹은 개선하고 싶은 방향이 있다면 얘기해주세요 -->

- 오브의 추천소 채팅 화면에서는 채팅이 실패 시 별도 팝업이나 토스트로 사용자에게 피드백을 주는 대신, 채팅의 답변으로 주는 식으로 구현해 보았습니다. 
- 오브의 추천소 채팅이 시작하면 x 버튼을 비활성화하고, 답변이 오면 x 버튼을 활성화하도록 구현했습니다.  (답변을 기다리는 중에 나가지 못하도록)
  질문을 받는 과정에 추천 장소를 새로고침하는 것도 포함되어있어서, 채팅이 끝난 후 추천소 메인화면으로 나갔을 때, 새로고침된 장소 목록을 바로 확인할 수 있도록 하기 위함입니다. 
  (채팅의 답변을 기다리는 중에 나가면 추천소 홈 화면에서 부자연스럽게 끊기며 새로고침되기도 하고, 사용자가 어떤 피드백을 받았는지 확인하지 못한다는 단점도 있음.)

### 다음 기능들은 이 PR이 머지되고 나면 다른 브랜치에서 추가할 예정입니다. 이 브랜치에서 같이 작업하면 변경사항이 지나치게 많아질 것 같아서, 머지하자마자 바로 작업에 들어간 후 새 PR로 올릴 예정입니다.
- 채팅 시 마지막 채팅으로 스크롤되도록 UX 개선
- 추천소 메인 화면에서 엠티 케이스 뷰 및 엠티 케이스 시 '다시 물어보기' 버튼 기능 구현
- 추천소 셀 및 지도 툴팁에서 '(네이버)지도로 이동' 기능 구현

<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->

|유저 플로우|홈 버튼이 있는 화면에서의 GUI|
|:------:|:---:|
|   <video src="https://github.com/user-attachments/assets/549bfd9a-9a24-4467-bea9-027727f4ed0e" width="250">   |  <img src="https://github.com/user-attachments/assets/9197f0a9-5741-4adc-bd2c-db7cd1d751f8" width=300> |


- Resolved: #546 
