### PR TITLE
[Fix] #574 - 오브의 추천소 채팅 응답값 개선

### DIFF
--- a/Offroad-iOS/Offroad-iOS.xcodeproj/project.pbxproj
+++ b/Offroad-iOS/Offroad-iOS.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		4E0394E12C2AC059007F0517 /* NSObject+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E0394E02C2AC059007F0517 /* NSObject+.swift */; };
 		4E0394E32C2AC0D7007F0517 /* UIWindow+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E0394E22C2AC0D7007F0517 /* UIWindow+.swift */; };
 		4E0394E62C2AC16A007F0517 /* UIScreen+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E0394E52C2AC16A007F0517 /* UIScreen+.swift */; };
+		4E04FDC42E0BCC09004A53D2 /* ORBRecommendationChatReplyTexts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E04FDC32E0BCC09004A53D2 /* ORBRecommendationChatReplyTexts.swift */; };
 		4E08B9572C5DF0920082EFB8 /* PlaceListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E08B9562C5DF0920082EFB8 /* PlaceListViewController.swift */; };
 		4E08B9592C5DF0B20082EFB8 /* PlaceListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E08B9582C5DF0B20082EFB8 /* PlaceListView.swift */; };
 		4E08B95B2C5E4F860082EFB8 /* ORBSegmentedControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E08B95A2C5E4F860082EFB8 /* ORBSegmentedControl.swift */; };
@@ -718,6 +719,7 @@
 		4E0394E02C2AC059007F0517 /* NSObject+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSObject+.swift"; sourceTree = "<group>"; };
 		4E0394E22C2AC0D7007F0517 /* UIWindow+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIWindow+.swift"; sourceTree = "<group>"; };
 		4E0394E52C2AC16A007F0517 /* UIScreen+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIScreen+.swift"; sourceTree = "<group>"; };
+		4E04FDC32E0BCC09004A53D2 /* ORBRecommendationChatReplyTexts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ORBRecommendationChatReplyTexts.swift; sourceTree = "<group>"; };
 		4E08B9562C5DF0920082EFB8 /* PlaceListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaceListViewController.swift; sourceTree = "<group>"; };
 		4E08B9582C5DF0B20082EFB8 /* PlaceListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaceListView.swift; sourceTree = "<group>"; };
 		4E08B95A2C5E4F860082EFB8 /* ORBSegmentedControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ORBSegmentedControl.swift; sourceTree = "<group>"; };
@@ -1623,6 +1625,14 @@
 			path = SupportingFiles;
 			sourceTree = "<group>";
 		};
+		4E04FDC22E0BCBDE004A53D2 /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				4E04FDC32E0BCC09004A53D2 /* ORBRecommendationChatReplyTexts.swift */,
+			);
+			path = Model;
+			sourceTree = "<group>";
+		};
 		4E08B9542C5DF0780082EFB8 /* ViewControllers */ = {
 			isa = PBXGroup;
 			children = (
@@ -2011,6 +2021,7 @@
 		4E87847F2DC4FD0300B639EA /* chat */ = {
 			isa = PBXGroup;
 			children = (
+				4E04FDC22E0BCBDE004A53D2 /* Model */,
 				4E8785252DC79AFC00B639EA /* ViewControllers */,
 				4E8785242DC79AF400B639EA /* Views */,
 				4E8785262DC79B0500B639EA /* DiffableDataSource */,
@@ -4177,6 +4188,7 @@
 				4E4F31D72D4718F400C3B2FF /* CharacterMotionResponseDTO.swift in Sources */,
 				87C27F732D80008D008036FA /* CourseQuest.swift in Sources */,
 				4E4F31D82D4718F400C3B2FF /* CouponListView.swift in Sources */,
+				4E04FDC42E0BCC09004A53D2 /* ORBRecommendationChatReplyTexts.swift in Sources */,
 				4E4F31D92D4718F400C3B2FF /* AdventureMapViewController.swift in Sources */,
 				4E4F31DA2D4718F400C3B2FF /* CustomerInquiryViewController.swift in Sources */,
 				4E4F31DB2D4718F400C3B2FF /* QuestResultView.swift in Sources */,

--- a/Offroad-iOS/Offroad-iOS/Global/Literals/StringLiterals.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Literals/StringLiterals.swift
@@ -93,3 +93,14 @@ struct ORBRecommendationOrderText {
     static let question3 = "추가로 원하시는 내용이 있다면 입력해주세요."
     static let answer3Placeholder = "기분이 안 좋은데 스트레스 풀릴만한 음식 추천해줘. 애인과 함께할 분위기 좋은 식당이면 좋겠어."
 }
+
+/// 오브의 추천소의 답변 메시지. 서버에서 추천 로직 자체는 성공했으나, 추천 장소 목록이 비어있을 경우에 대한 답변
+struct ORBRecommendationChatPlacesNotFoundText {
+    static let text1 = "으앙… 딱 맞는 곳이 안 보여😣\n다른 말로 한 번 더 알려줄래? 다시 찾아볼게 츄츄!"
+    static let text2 = "괜찮은 장소를 못 찾았어😢\n지역이나 내용을 조금 바꿔보지 않을래 츄츄?"
+    static let text3 = "우움 지금은 딱 떠오르는 데가 없네\n기분이나 상황을 조금만 더 알려주라 츄츄🎶"
+    static let text4 = "미안해… 추천할 장소를 못 찾았어💦\n혹시 다른 조건으로 찾아보는건 어때 츄츄?"
+    static let text5 = "마땅한 장소를 못 찾았어 미안해애…\n지역이나 원하는 내용을 다시 정해주라 츄츄😢"
+
+    static let textList: [String] = [text1, text2, text3, text4, text5]
+}

--- a/Offroad-iOS/Offroad-iOS/Network/Base/MoyaPlugin.swift
+++ b/Offroad-iOS/Offroad-iOS/Network/Base/MoyaPlugin.swift
@@ -15,7 +15,6 @@ final class MoyaPlugin: PluginType {
     
     func willSend(_ request: RequestType, target: TargetType) {
         guard let httpRequest = request.request else {
-            print("--> ❌❌❌유효하지 않은 요청❌❌❌")
             printLog("--> ❌❌❌유효하지 않은 요청❌❌❌")
             return
         }
@@ -30,7 +29,6 @@ final class MoyaPlugin: PluginType {
             log.append("\(bodyString)\n")
         }
         log.append("=========================== END \(method) ===========================")
-        print(log)
         printLog(log)
     }
 
@@ -57,7 +55,6 @@ final class MoyaPlugin: PluginType {
             log.append("4️⃣\(reString)\n")
         }
         log.append("=========================== END HTTP ===========================")
-        print(log)
         printLog(log)
     }
 
@@ -70,7 +67,6 @@ final class MoyaPlugin: PluginType {
         log.append("<-- \(error.errorCode)\n")
         log.append("\(error.failureReason ?? error.errorDescription ?? "unknown error")\n")
         log.append("<-- END HTTP")
-        print(log)
         printLog(log)
     }
 }

--- a/Offroad-iOS/Offroad-iOS/Presentation/ORBRecommendation/chat/Model/ORBRecommendationChatReplyTexts.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/ORBRecommendation/chat/Model/ORBRecommendationChatReplyTexts.swift
@@ -1,0 +1,18 @@
+//
+//  ORBRecommendationChatReplyTexts.swift
+//  ORB_Dev
+//
+//  Created by 김민성 on 6/25/25.
+//
+
+/// 오브의 추천소에서 랜덤으로 보여질 텍스트를 생성하는 텍스트 랜던 생성기.
+///
+/// - Note: 원래는 서버의 로직이지만, 임시로 클라이언트에서 구현.
+/// 서버에서 추천 로직 자체는 성공했으나, 추천 장소 목록이 비어있을 경우에 대한 답변만을 생성.
+struct ORBRecommendationTextGenerator {
+    
+    static func getRandomText() -> String {
+        ORBRecommendationChatPlacesNotFoundText.textList.randomElement()!
+    }
+    
+}

--- a/Offroad-iOS/Offroad-iOS/Presentation/ORBRecommendation/chat/ViewControllers/ORBRecommendationChatViewController.swift
+++ b/Offroad-iOS/Offroad-iOS/Presentation/ORBRecommendation/chat/ViewControllers/ORBRecommendationChatViewController.swift
@@ -183,7 +183,7 @@ private extension ORBRecommendationChatViewController {
         // 추천 장소 목록이 비어있지는 않은가?
         guard !recommendedPlaces.isEmpty else {
             // 장소 추천 로직은 성공했으나, 추천된 장소가 하나도 없는 경우
-            return "적절한 장소를 찾지 못했어..다른 조건으로 장소를 찾아봐줄래?"
+            return ORBRecommendationTextGenerator.getRandomText()
         }
         
         // (서버 추천 로직 성공 && 추천 장소 업데이트 성공 && 추천 장소 목록 존재) 인 경우


### PR DESCRIPTION
### 🌴 작업한 브랜치
- #574 


### ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->
- 오브의 추천소 채팅에서 채팅의 결과로 서버의 추천 로직은 성공했으나,
추천 장소 목록이 없을 경우 화면에 띄울(오브의 답장 메시지) 텍스트를  변경하였습니다.
현재는 제가 임의로 적어둔 `"적절한 장소를 찾지 못했어..다른 조건으로 장소를 찾아봐줄래?"`
를 사용중인데, 
기획 파트에서 제공해 준 문구를 사용하도록 변경했습니다.
여러 문구 중 하나를 랜덤으로 생성하도록 구현하였습니다.

- 그 외에 기타로 중복되는 print문을 제거하였습니다.
<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### ❗️PR Point
<!-- 부족했던 점 혹은 개선하고 싶은 방향이 있다면 얘기해주세요 -->

<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->

|뷰|설명|
|:------:|:---:|
|        |     |


- Resolved: #574
