### PR TITLE
[Hotfix] #573 - 툴팁에서 `ORBRecommendationPlaceModel` 타입 사용 시 타겟별 분기처리 적용

### DIFF
--- a/Offroad-iOS/Offroad-iOS/Global/Components/ORBMap/PlaceInfoTooltip/PlaceInfoTooltip.swift
+++ b/Offroad-iOS/Offroad-iOS/Global/Components/ORBMap/PlaceInfoTooltip/PlaceInfoTooltip.swift
@@ -55,7 +55,7 @@ final class PlaceInfoTooltip: UIView {
                 exploreButton.setTitle("알 수 없음", for: .normal)
                 return
             }
-            
+            #if DevTarget
             if marker.place is PlaceModel {
                 exploreButton.setTitle("탐험하기", for: .normal)
             } else if marker.place is ORBRecommendationPlaceModel {
@@ -66,6 +66,16 @@ final class PlaceInfoTooltip: UIView {
                     "잘못된 장소 모델 타입이 사용되었습니다: \(type(of:marker.place))\nPlaceModel 혹은 ORBRecommendationPlaceModel 타입만 사용 가능합니다."
                 )
             }
+            #else
+            if marker.place is PlaceModel {
+                exploreButton.setTitle("탐험하기", for: .normal)
+            } else {
+                exploreButton.setTitle("알 수 없음", for: .normal)
+                assertionFailure(
+                    "잘못된 장소 모델 타입이 사용되었습니다: \(type(of:marker.place))\nPlaceModel 타입만 사용 가능합니다."
+                )
+            }
+            #endif
         }
     }
     


### PR DESCRIPTION
### 🌴 작업한 브랜치
- #573 


### ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->
추천소 기능을 구현하면서 추천 장소 데이터 타입을 나타내는 `ORBRecommendationPlaceModel` 타입을 새로 만들었었는데,
개발용 타겟에서도(툴팁에서) 이 타입에 사용되면서 빌드가 되지 않는 문제가 발생했습니다.

-> 툴팁에서 `ORBRecommendationPlaceModel` 를 사용하는 코드에 Target별 분기처리를 적용하였습니다.

<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### ❗️PR Point
<!-- 부족했던 점 혹은 개선하고 싶은 방향이 있다면 얘기해주세요 -->

<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


### 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->

|뷰|설명|
|:------:|:---:|
|        |     |


- Resolved: #573 
